### PR TITLE
Implement implicit stream subscriptions (Orleans parity)

### DIFF
--- a/docs/09-event-streams.md
+++ b/docs/09-event-streams.md
@@ -153,10 +153,45 @@ flowchart TB
   because that stream maps to a single physical queue.
 - **Rewind.** A consumer can subscribe from an earlier `SequenceToken` if the backing store still
   retains those entries (Redis Stream trimming policy governs retention).
-- **Implicit subscriptions (later phase).** Orleans' `[ImplicitStreamSubscription(namespace)]` binds
-  a grain type to a stream namespace so the grain is auto-subscribed by key, with no explicit
-  `subscribe` call. This is noted in the [roadmap](13-roadmap-and-phases.md) as a parity follow-on to
-  explicit subscriptions.
+
+## Implicit subscriptions
+
+A grain type can be **implicitly subscribed** to a stream namespace, so a grain is auto-subscribed by
+key with no explicit `subscribe` call — Orleans' `[ImplicitStreamSubscription(namespace)]`. A grain
+of that type with key `K` receives every event published to the stream `(namespace, K)`; the pulling
+agent reactivates it on demand to deliver, exactly as for an explicit subscription.
+
+```ts
+// Class form:
+@grain()
+@implicitStreamSubscription("chat")
+class ArchiveGrain extends Grain implements IArchive {
+  // The runtime calls this the first time an event for one of this grain's
+  // implicit streams arrives (mirroring Orleans' IStreamSubscriptionObserver);
+  // return the handler that should receive that stream's events.
+  [STREAM_SUBSCRIPTION_OBSERVER](namespace: string, key: string): StreamHandler<Message> {
+    return { onNext: async (msg) => { /* archive msg for room `key` */ } };
+  }
+}
+
+// Functional form:
+const ArchiveGrain = defineGrain<IArchive>(
+  "Archive",
+  () => ({
+    [STREAM_SUBSCRIPTION_OBSERVER]: (namespace, key): StreamHandler<Message> => ({
+      onNext: async (msg) => { /* ... */ },
+    }),
+  }),
+  { implicitSubscriptions: ["chat"] },
+);
+```
+
+The grain never calls `subscribe`/`getSubscriptions`: the runtime knows the subscriber from the
+declaration. When an agent pulls an event for stream `(ns, K)`, it fans out to the registry's
+explicit subscribers **and** to every grain type implicitly subscribed to `ns`, addressing each at
+key `K` (deduplicated, so a grain that is both gets one delivery). Implicit subscriptions are a
+pulling-agent feature (the Redis provider); the in-memory provider is for explicit-subscription
+dev/tests only. Subscribers are addressed by string key, matching how a producer names the stream.
 
 ## Providers
 

--- a/docs/11-public-api-and-examples.md
+++ b/docs/11-public-api-and-examples.md
@@ -149,7 +149,11 @@ The snippets above are the target surface. The shipped surface differs in a few 
   `@persistentState(name, { defaultValue })` decorator it wraps — and injected before `onActivate`;
   the `getStorage` accessor on `GrainRuntime` is not implemented (the hook/decorator is the supported
   path). `registerTimer`, `registerReminder` / `unregisterReminder` and `getStreamProvider` (which
-  delivers each `onNext` as a turn) are all wired.
+  delivers each `onNext` as a turn) are all wired. A grain type can also be **implicitly subscribed**
+  to a stream namespace — `@implicitStreamSubscription(ns)` (class) or `defineGrain`'s
+  `implicitSubscriptions` (functional) — so a grain is auto-subscribed by key with no `subscribe`
+  call; it exposes its handler under the `STREAM_SUBSCRIPTION_OBSERVER` symbol (Redis streams only;
+  see [09](09-event-streams.md)).
 - Transport is `useInProcessTransport(network)` or `useWebSocketTransport()`; membership is
   `useStaticMembership([...])`, `useKubernetesMembership(watch)`, or `useMembership(service)` to
   share one view across several in-process silos.

--- a/docs/13-roadmap-and-phases.md
+++ b/docs/13-roadmap-and-phases.md
@@ -29,8 +29,8 @@ cross-silo participants, and in-doubt recovery. Authoring is **functional by def
 — over the retained class substrate.
 
 **Remaining for parity (Orleans 10):** grain migration and the activation rebalancer (the v10
-core-runtime block), grain-interface versioning, implicit stream subscriptions, lossless directory
-range handoff, grain call filters, and placement filters. The Orleans-10 additions of durable
+core-runtime block), grain-interface versioning, lossless directory
+range handoff, and placement filters. The Orleans-10 additions of durable
 journaling (`DurableGrain`) and durable jobs need an ADR each (journaling overlaps the existing
 reducer/persistent-state model). Cross-cutting observability (OpenTelemetry traces/metrics, structured
 logs) remains to be wired throughout, on the grain-call-filter seam.
@@ -151,7 +151,10 @@ verified.
 - **Grain-interface versioning** — multiple interface versions live at once for heterogeneous rolling
   upgrades, with version-aware placement (Orleans' versioning).
 - **Implicit stream subscriptions** — bind a grain type to a namespace and auto-subscribe by key,
-  with no explicit `subscribe` call (Orleans' `[ImplicitStreamSubscription]`).
+  with no explicit `subscribe` call (Orleans' `[ImplicitStreamSubscription]`). **Shipped** —
+  `@implicitStreamSubscription(namespace)` / `defineGrain`'s `implicitSubscriptions`; the grain
+  exposes a handler under `STREAM_SUBSCRIPTION_OBSERVER` and the pulling agent fans each event out to
+  implicit subscribers (by key) alongside explicit ones (see [09](09-event-streams.md)).
 - **Directory range handoff** — replace the phase-2 drop-and-rebuild with a versioned, lossless
   handoff on membership change (per [06](06-grain-directory-and-placement.md)).
 - **Grain call filters** — incoming/outgoing interception around grain calls for cross-cutting

--- a/packages/core/src/decorators.ts
+++ b/packages/core/src/decorators.ts
@@ -1,5 +1,6 @@
 import {
   defaultGrainType,
+  markImplicitSubscription,
   markReentrant,
   setGrainOptions,
   type GrainConstructor,
@@ -30,6 +31,21 @@ export function grain(options: GrainOptions = {}) {
 export function reentrant() {
   return function <T extends GrainConstructor>(value: T, _context: ClassDecoratorContext): T {
     markReentrant(value);
+    return value;
+  };
+}
+
+/**
+ * Implicitly subscribes this grain type to a stream namespace (Orleans'
+ * `[ImplicitStreamSubscription]`). A grain of this type with key `K` is
+ * auto-subscribed to the stream `(namespace, K)` — events delivered to that
+ * stream reactivate the grain and reach the handler it exposes under
+ * `STREAM_SUBSCRIPTION_OBSERVER`, with no explicit `subscribe` call. Repeatable
+ * to subscribe to several namespaces.
+ */
+export function implicitStreamSubscription(namespace: string) {
+  return function <T extends GrainConstructor>(value: T, _context: ClassDecoratorContext): T {
+    markImplicitSubscription(value, namespace);
     return value;
   };
 }

--- a/packages/core/src/define-grain.ts
+++ b/packages/core/src/define-grain.ts
@@ -3,6 +3,7 @@ import type { GrainContext } from "./grain-context";
 import type { SelfFilteringGrain } from "./grain-call-filter";
 import type { GrainInterface } from "./grain-interface";
 import {
+  markImplicitSubscription,
   markReentrant,
   setGrainOptions,
   type GrainConstructor,
@@ -43,6 +44,13 @@ export type GrainBehaviour<T> = T & Partial<GrainLifecycle> & Partial<SelfFilter
 export interface DefineGrainOptions extends Omit<GrainOptions, "name"> {
   /** Mark every method reentrant (the functional equivalent of `@reentrant()`). */
   reentrant?: boolean;
+  /**
+   * Stream namespaces to implicitly subscribe to (the functional equivalent of
+   * `@implicitStreamSubscription`). A grain with key `K` is auto-subscribed to
+   * the stream `(namespace, K)`; return a `STREAM_SUBSCRIPTION_OBSERVER` member
+   * from the factory to receive its events.
+   */
+  implicitSubscriptions?: readonly string[];
 }
 
 // The grain instance is carried on the setup behind a private symbol so the
@@ -111,9 +119,12 @@ export function defineGrain<T extends object>(
     }
   }
 
-  const { reentrant, ...grainOptions } = options;
+  const { reentrant, implicitSubscriptions, ...grainOptions } = options;
   setGrainOptions(FunctionalGrain as GrainConstructor, name, { ...grainOptions, name });
   if (reentrant === true) markReentrant(FunctionalGrain as GrainConstructor);
+  for (const namespace of implicitSubscriptions ?? []) {
+    markImplicitSubscription(FunctionalGrain as GrainConstructor, namespace);
+  }
   return FunctionalGrain;
 }
 

--- a/packages/core/src/grain-metadata.ts
+++ b/packages/core/src/grain-metadata.ts
@@ -12,17 +12,24 @@ export interface GrainMetadata {
   grainType: GrainType;
   options: GrainOptions;
   reentrant: boolean;
+  /**
+   * Stream namespaces this grain type is implicitly subscribed to (Orleans'
+   * `[ImplicitStreamSubscription]`). A grain of this type with key `K` is
+   * auto-subscribed to the stream `(namespace, K)`, with no explicit `subscribe`.
+   */
+  implicitSubscriptions: readonly string[];
 }
 
 export type GrainConstructor = abstract new (...args: never[]) => object;
 
-// Decorator order is irrelevant: options and the reentrant flag are tracked
-// separately and composed on read.
+// Decorator order is irrelevant: options, the reentrant flag and implicit
+// stream subscriptions are tracked separately and composed on read.
 const optionsRegistry = new WeakMap<
   GrainConstructor,
   { grainType: GrainType; options: GrainOptions }
 >();
 const reentrantRegistry = new WeakSet<GrainConstructor>();
+const implicitSubscriptionRegistry = new WeakMap<GrainConstructor, Set<string>>();
 
 export function setGrainOptions(
   ctor: GrainConstructor,
@@ -36,13 +43,25 @@ export function markReentrant(ctor: GrainConstructor): void {
   reentrantRegistry.add(ctor);
 }
 
+/** Record that this grain type is implicitly subscribed to a stream namespace. */
+export function markImplicitSubscription(ctor: GrainConstructor, namespace: string): void {
+  let namespaces = implicitSubscriptionRegistry.get(ctor);
+  if (namespaces === undefined) {
+    namespaces = new Set();
+    implicitSubscriptionRegistry.set(ctor, namespaces);
+  }
+  namespaces.add(namespace);
+}
+
 export function getGrainMetadata(ctor: GrainConstructor): GrainMetadata | undefined {
   const entry = optionsRegistry.get(ctor);
   if (entry === undefined) return undefined;
+  const implicit = implicitSubscriptionRegistry.get(ctor);
   return {
     grainType: entry.grainType,
     options: entry.options,
     reentrant: reentrantRegistry.has(ctor),
+    implicitSubscriptions: implicit === undefined ? [] : [...implicit],
   };
 }
 

--- a/packages/core/src/implicit-subscription.test.ts
+++ b/packages/core/src/implicit-subscription.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { grain, implicitStreamSubscription } from "@tsva/core/decorators";
+import { defineGrain } from "@tsva/core/define-grain";
+import { Grain } from "@tsva/core/grain";
+import { getGrainMetadata } from "@tsva/core/grain-metadata";
+import {
+  implicitStreamObserver,
+  STREAM_SUBSCRIPTION_OBSERVER,
+  type StreamHandler,
+} from "@tsva/core/stream";
+
+describe("implicit stream subscriptions — declaration", () => {
+  it("records the namespace on a class grain via the decorator", () => {
+    @grain()
+    @implicitStreamSubscription("chat")
+    class WatcherGrain extends Grain {}
+
+    expect(getGrainMetadata(WatcherGrain)?.implicitSubscriptions).toEqual(["chat"]);
+  });
+
+  it("supports several namespaces, regardless of decorator order", () => {
+    @implicitStreamSubscription("telemetry")
+    @grain()
+    @implicitStreamSubscription("chat")
+    class MultiGrain extends Grain {}
+
+    expect([...(getGrainMetadata(MultiGrain)?.implicitSubscriptions ?? [])].sort()).toEqual([
+      "chat",
+      "telemetry",
+    ]);
+  });
+
+  it("defaults to no implicit subscriptions", () => {
+    @grain()
+    class PlainGrain extends Grain {}
+
+    expect(getGrainMetadata(PlainGrain)?.implicitSubscriptions).toEqual([]);
+  });
+
+  it("records namespaces on a functional grain via defineGrain options", () => {
+    const Watcher = defineGrain("FnWatcher", () => ({}), { implicitSubscriptions: ["room"] });
+    expect(getGrainMetadata(Watcher)?.implicitSubscriptions).toEqual(["room"]);
+  });
+});
+
+describe("implicit stream subscriptions — observer", () => {
+  it("binds the grain's STREAM_SUBSCRIPTION_OBSERVER member to the instance", async () => {
+    const seen: string[] = [];
+
+    @grain()
+    @implicitStreamSubscription("chat")
+    class WatcherGrain extends Grain {
+      tag = "watcher";
+      [STREAM_SUBSCRIPTION_OBSERVER](namespace: string, key: string): StreamHandler<unknown> {
+        return {
+          onNext: async (event) => {
+            // Reading `this` proves the observer is bound to the instance.
+            seen.push(`${this.tag}:${namespace}/${key}:${String(event)}`);
+          },
+        };
+      }
+    }
+
+    const instance = new WatcherGrain();
+    const observe = implicitStreamObserver(instance);
+    expect(observe).toBeDefined();
+    await observe!("chat", "general").onNext("hi", undefined as never);
+    expect(seen).toEqual(["watcher:chat/general:hi"]);
+  });
+
+  it("returns undefined when the grain declares no observer", () => {
+    @grain()
+    class PlainGrain extends Grain {}
+    expect(implicitStreamObserver(new PlainGrain())).toBeUndefined();
+  });
+});

--- a/packages/core/src/stream.ts
+++ b/packages/core/src/stream.ts
@@ -58,6 +58,38 @@ export interface StreamProvider {
 }
 
 /**
+ * A grain implicitly subscribed to one or more stream namespaces (declared with
+ * `@implicitStreamSubscription` / `defineGrain`'s `implicitSubscriptions`)
+ * exposes, under this symbol, the handler that receives a matching stream's
+ * events. The runtime calls it lazily the first time an event for a given stream
+ * arrives — mirroring Orleans' `IStreamSubscriptionObserver.OnSubscribed`, the
+ * grain never calls `subscribe()`. The symbol key keeps it from colliding with
+ * the grain's own (string-named) methods. Orleans' `StreamId` is namespace+key
+ * (the provider is implied by context), so that is what the observer is given.
+ */
+export const STREAM_SUBSCRIPTION_OBSERVER = Symbol.for("tsva.streamSubscriptionObserver");
+
+/** A grain that observes its implicitly-subscribed streams. */
+export interface ImplicitStreamSubscriber {
+  [STREAM_SUBSCRIPTION_OBSERVER](namespace: string, key: string): StreamHandler<unknown>;
+}
+
+/** The grain's implicit-stream observer, bound to it, or `undefined` if it declares none. */
+export function implicitStreamObserver(
+  instance: object,
+): ((namespace: string, key: string) => StreamHandler<unknown>) | undefined {
+  const fn = (instance as Record<symbol, unknown>)[STREAM_SUBSCRIPTION_OBSERVER];
+  return typeof fn === "function"
+    ? (namespace, key) =>
+        (fn as ImplicitStreamSubscriber[typeof STREAM_SUBSCRIPTION_OBSERVER]).call(
+          instance,
+          namespace,
+          key,
+        )
+    : undefined;
+}
+
+/**
  * System extension a pulling agent invokes (through the dispatcher) to hand an
  * event to a subscriber grain's single activation. The runtime intercepts it and
  * runs the activation's registered handler as a turn — the grain never declares

--- a/packages/hosting/src/redis-pulling-streams.test.ts
+++ b/packages/hosting/src/redis-pulling-streams.test.ts
@@ -1,12 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, describe, expect, it } from "vitest";
 import { createClient } from "redis";
-import { grain } from "@tsva/core/decorators";
+import { grain, implicitStreamSubscription } from "@tsva/core/decorators";
 import { Grain } from "@tsva/core/grain";
 import { defineGrainInterface } from "@tsva/core/grain-interface";
 import type { GrainWithStringKey } from "@tsva/core/key-kinds";
 import { SiloAddress } from "@tsva/core/silo-address";
-import type { StreamHandler } from "@tsva/core/stream";
+import { STREAM_SUBSCRIPTION_OBSERVER, type StreamHandler } from "@tsva/core/stream";
 import { InProcessNetwork } from "@tsva/messaging/in-process-transport";
 import { createSilo } from "@tsva/hosting/silo-builder";
 import type { SiloHost } from "@tsva/hosting/silo-host";
@@ -90,6 +90,29 @@ class ChatUserGrain extends Grain implements IChatUser {
   }
 }
 
+// An implicitly-subscribed grain: no `subscribe`/`join` call. A `Watcher` with
+// key K is auto-subscribed to the stream ("chat", K) and records what it sees in
+// a module sink (the grain may be collected between deliveries).
+const watched: Record<string, string[]> = {};
+
+interface IWatcher extends GrainWithStringKey {
+  seen(): Promise<string[]>;
+}
+const IWatcher = defineGrainInterface<IWatcher>("IWatcher.pull", {
+  options: { seen: { readOnly: true } },
+});
+
+@grain()
+@implicitStreamSubscription("chat")
+class WatcherGrain extends Grain implements IWatcher {
+  async seen(): Promise<string[]> {
+    return [...(watched[String(this.id.key)] ?? [])];
+  }
+  [STREAM_SUBSCRIPTION_OBSERVER](_namespace: string, key: string): StreamHandler<string> {
+    return { onNext: async (text) => void (watched[key] ??= []).push(text) };
+  }
+}
+
 const local = new SiloAddress("silo-0", "uid-0", "silo-0:11111");
 
 function buildSilo(): SiloHost {
@@ -99,6 +122,7 @@ function buildSilo(): SiloHost {
     .addRedisStreams("default", { url: REDIS_URL, keyPrefix })
     .registerGrain(ChatRoomGrain, { interfaces: [IChatRoom] })
     .registerGrain(ChatUserGrain, { interfaces: [IChatUser] })
+    .registerGrain(WatcherGrain, { interfaces: [IWatcher] })
     .build();
 }
 
@@ -122,6 +146,24 @@ describe.skipIf(admin === undefined)("Redis pulling-agent streams end-to-end", (
       expect(await silo.getGrain(IChatUser, "alice").history()).toEqual(["hello", "world"]);
       expect(await silo.getGrain(IChatUser, "bob").history()).toEqual(["hello", "world"]);
       expect(await silo.getGrain(IChatUser, "carol").history()).toEqual([]);
+    } finally {
+      await silo.stop();
+    }
+  });
+
+  it("auto-delivers to an implicitly-subscribed grain by key, with no subscribe call", async () => {
+    const silo = buildSilo();
+    await silo.start();
+    try {
+      // No join/subscribe: the Watcher's key matches the room's stream key, so it
+      // is implicitly subscribed to ("chat", "watched"). A Watcher on a different
+      // key sees nothing (subscription is by key).
+      await silo.getGrain(IChatRoom, "watched").say("ping");
+      await silo.getGrain(IChatRoom, "watched").say("pong");
+
+      await waitFor(async () => (await silo.getGrain(IWatcher, "watched").seen()).length === 2);
+      expect(await silo.getGrain(IWatcher, "watched").seen()).toEqual(["ping", "pong"]);
+      expect(await silo.getGrain(IWatcher, "other").seen()).toEqual([]);
     } finally {
       await silo.stop();
     }

--- a/packages/hosting/src/silo-builder.ts
+++ b/packages/hosting/src/silo-builder.ts
@@ -392,6 +392,7 @@ export class SiloBuilder {
       provider.setDeliver((grainId, streamKey, event, token) =>
         node.deliverStreamEvent(grainId, streamKey, event, token),
       );
+      provider.setImplicitSubscribers((namespace) => node.implicitGrainTypes(namespace));
       onOwnershipChange.push(async (ranges) => provider.refreshOwnership(ranges));
     }
 

--- a/packages/runtime/src/activation.ts
+++ b/packages/runtime/src/activation.ts
@@ -15,7 +15,12 @@ import {
   type IncomingGrainCallFilter,
 } from "@tsva/core/grain-call-filter";
 import type { InvocationRequest } from "@tsva/core/request";
-import { SequenceToken, StreamConsumerInterface, type StreamHandler } from "@tsva/core/stream";
+import {
+  implicitStreamObserver,
+  SequenceToken,
+  StreamConsumerInterface,
+  type StreamHandler,
+} from "@tsva/core/stream";
 import type { TransactionParticipant } from "@tsva/core/transaction-info";
 import { TransactionResourceInterface } from "@tsva/core/transaction-resource";
 import { getTransactionalFields } from "@tsva/core/transactional-state-metadata";
@@ -109,6 +114,27 @@ export class ActivationData implements GrainContext {
       .finally(() => this.touch());
   }
 
+  /**
+   * The handler for a delivered stream event, keyed by `namespace/key`. Falls
+   * back to the grain's implicit-subscription observer (and caches its result)
+   * when no handler was registered via `subscribe` — so an implicitly subscribed
+   * grain (Orleans' `[ImplicitStreamSubscription]`) receives events without ever
+   * calling `subscribe`. The fan-out only routes a stream to a grain that is an
+   * explicit or declared-implicit subscriber, so an absent observer means drop.
+   */
+  private streamHandlerFor(streamKey: string): StreamHandler<unknown> | undefined {
+    const existing = this.streamHandlers.get(streamKey);
+    if (existing !== undefined) return existing;
+    const observe = implicitStreamObserver(this.instance);
+    if (observe === undefined) return undefined;
+    const slash = streamKey.indexOf("/");
+    const namespace = slash < 0 ? streamKey : streamKey.slice(0, slash);
+    const key = slash < 0 ? "" : streamKey.slice(slash + 1);
+    const handler = observe(namespace, key);
+    this.streamHandlers.set(streamKey, handler);
+    return handler;
+  }
+
   /** Bind a pulling-agent stream handler so a delivered `StreamConsumer` turn reaches it. */
   setStreamHandler(streamKey: string, handler: StreamHandler<unknown>): void {
     this.streamHandlers.set(streamKey, handler);
@@ -176,7 +202,7 @@ export class ActivationData implements GrainContext {
     // handler the grain registered when it subscribed. Already on a turn here.
     if (req.interfaceId === StreamConsumerInterface.id) {
       const [streamKey, event, token] = req.args as [string, unknown, number];
-      const handler = this.streamHandlers.get(streamKey);
+      const handler = this.streamHandlerFor(streamKey);
       if (handler !== undefined) await handler.onNext(event, new SequenceToken(token));
       return undefined;
     }

--- a/packages/runtime/src/cluster-node.ts
+++ b/packages/runtime/src/cluster-node.ts
@@ -101,6 +101,8 @@ export class ClusterNode {
 
   private readonly grainTypes = new Map<GrainType, RegisteredGrain>();
   private readonly interfaceToGrainType = new Map<number, GrainType>();
+  /** Stream namespace → grain types implicitly subscribed to it (auto-subscribe by key). */
+  private readonly implicitSubscriptions = new Map<string, GrainType[]>();
   private readonly cache = new LocationCache();
   private readonly correlation = new CorrelationTable();
   private readonly connections: ConnectionManager;
@@ -191,7 +193,17 @@ export class ClusterNode {
     for (const iface of registration.interfaces) {
       this.interfaceToGrainType.set(iface.id, metadata.grainType);
     }
+    for (const namespace of metadata.implicitSubscriptions) {
+      const types = this.implicitSubscriptions.get(namespace) ?? [];
+      if (!types.includes(metadata.grainType)) types.push(metadata.grainType);
+      this.implicitSubscriptions.set(namespace, types);
+    }
     return this;
+  }
+
+  /** Grain types implicitly subscribed to a stream namespace (drives stream fan-out). */
+  implicitGrainTypes(namespace: string): readonly GrainType[] {
+    return this.implicitSubscriptions.get(namespace) ?? [];
   }
 
   getGrain<T>(def: GrainInterface<T>, key: GrainKeyFor<T>): T {

--- a/packages/runtime/src/implicit-stream-delivery.test.ts
+++ b/packages/runtime/src/implicit-stream-delivery.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { grain, implicitStreamSubscription } from "@tsva/core/decorators";
+import { defineGrain } from "@tsva/core/define-grain";
+import { Grain } from "@tsva/core/grain";
+import { GrainId } from "@tsva/core/grain-id";
+import { defineGrainInterface } from "@tsva/core/grain-interface";
+import type { GrainWithStringKey } from "@tsva/core/key-kinds";
+import { SiloAddress } from "@tsva/core/silo-address";
+import { STREAM_SUBSCRIPTION_OBSERVER, type StreamHandler } from "@tsva/core/stream";
+import { InProcessNetwork, InProcessTransport } from "@tsva/messaging/in-process-transport";
+import { ClusterNode } from "@tsva/runtime/cluster-node";
+import { StaticMembershipService } from "@tsva/runtime/static-membership";
+
+// Module sink so observed events survive across activations (keyed by grain key).
+let observed: Array<{ key: string; namespace: string; event: unknown }> = [];
+
+interface IWatcher extends GrainWithStringKey {
+  marker(): Promise<string>;
+}
+const IWatcher = defineGrainInterface<IWatcher>("IWatcher.implicit");
+
+@grain()
+@implicitStreamSubscription("chat")
+class WatcherGrain extends Grain implements IWatcher {
+  async marker(): Promise<string> {
+    return "watcher";
+  }
+  [STREAM_SUBSCRIPTION_OBSERVER](namespace: string, _key: string): StreamHandler<unknown> {
+    return {
+      onNext: async (event) => {
+        observed.push({ key: String(this.id.key), namespace, event });
+      },
+    };
+  }
+}
+
+interface IPlain extends GrainWithStringKey {
+  marker(): Promise<string>;
+}
+const IPlain = defineGrainInterface<IPlain>("IPlain.implicit");
+
+// Implicitly subscribed but declares no observer — the event must be dropped.
+@grain()
+@implicitStreamSubscription("noop")
+class PlainGrain extends Grain implements IPlain {
+  async marker(): Promise<string> {
+    return "plain";
+  }
+}
+
+const local = new SiloAddress("silo-0", "uid-0", "silo-0:11111");
+
+function buildNode(): ClusterNode {
+  const network = new InProcessNetwork();
+  const node = new ClusterNode({
+    local,
+    clusterId: "c1",
+    membership: new StaticMembershipService(local, [local]),
+    transport: new InProcessTransport(network, "c1"),
+  });
+  node.registerGrain(WatcherGrain, { interfaces: [IWatcher] });
+  node.registerGrain(PlainGrain, { interfaces: [IPlain] });
+  return node;
+}
+
+describe("implicit stream subscriptions — delivery through the dispatcher", () => {
+  it("exposes the registered namespace → grain types", () => {
+    const node = buildNode();
+    expect(node.implicitGrainTypes("chat")).toEqual(["Watcher"]);
+    expect(node.implicitGrainTypes("nope")).toEqual([]);
+  });
+
+  it("delivers a stream event to the matching-key grain with no explicit subscribe", async () => {
+    observed = [];
+    const node = buildNode();
+    await node.start();
+    try {
+      // The fan-out would address (Watcher, "general") for stream chat/general.
+      const watcher = new GrainId("Watcher", "general");
+      await node.deliverStreamEvent(watcher, "chat/general", "hello", 1);
+      await node.deliverStreamEvent(watcher, "chat/general", "world", 2);
+
+      expect(observed).toEqual([
+        { key: "general", namespace: "chat", event: "hello" },
+        { key: "general", namespace: "chat", event: "world" },
+      ]);
+      // Distinct stream keys reach distinct grain activations.
+      await node.deliverStreamEvent(new GrainId("Watcher", "random"), "chat/random", "hi", 1);
+      expect(observed.at(-1)).toEqual({ key: "random", namespace: "chat", event: "hi" });
+    } finally {
+      await node.stop();
+    }
+  });
+
+  it("drops an event for an implicit subscriber that declares no observer", async () => {
+    const node = buildNode();
+    await node.start();
+    try {
+      await expect(
+        node.deliverStreamEvent(new GrainId("Plain", "x"), "noop/x", "ignored", 1),
+      ).resolves.toBeUndefined();
+    } finally {
+      await node.stop();
+    }
+  });
+});
+
+// Functional grains declare the same way (defineGrain options + observer member).
+const FnWatcher = defineGrain<IWatcher>(
+  "FnWatcher",
+  (ctx) => ({
+    marker: async () => "fn-watcher",
+    [STREAM_SUBSCRIPTION_OBSERVER]: (namespace: string, _key: string): StreamHandler<unknown> => ({
+      onNext: async (event) => {
+        observed.push({ key: String(ctx.id.key), namespace, event });
+      },
+    }),
+  }),
+  { implicitSubscriptions: ["room"] },
+);
+const IFnWatcher = defineGrainInterface<IWatcher>("IFnWatcher.implicit");
+
+describe("implicit stream subscriptions — functional grain", () => {
+  it("auto-subscribes a functional grain by key", async () => {
+    observed = [];
+    const network = new InProcessNetwork();
+    const node = new ClusterNode({
+      local,
+      clusterId: "c1",
+      membership: new StaticMembershipService(local, [local]),
+      transport: new InProcessTransport(network, "c1"),
+    });
+    node.registerGrain(FnWatcher, { interfaces: [IFnWatcher] });
+    expect(node.implicitGrainTypes("room")).toEqual(["FnWatcher"]);
+    await node.start();
+    try {
+      await node.deliverStreamEvent(new GrainId("FnWatcher", "lobby"), "room/lobby", "joined", 1);
+      expect(observed).toEqual([{ key: "lobby", namespace: "room", event: "joined" }]);
+    } finally {
+      await node.stop();
+    }
+  });
+});

--- a/packages/runtime/src/placement/placement.test.ts
+++ b/packages/runtime/src/placement/placement.test.ts
@@ -14,6 +14,7 @@ const meta = (options: Partial<GrainMetadata["options"]> = {}): GrainMetadata =>
   grainType: "Counter",
   options,
   reentrant: false,
+  implicitSubscriptions: [],
 });
 
 describe("RandomPlacement", () => {

--- a/packages/streams/src/implicit-subscriptions.test.ts
+++ b/packages/streams/src/implicit-subscriptions.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import type { GrainType } from "@tsva/core/grain-type";
+import { implicitSubscriberIds } from "@tsva/streams/implicit-subscriptions";
+
+describe("implicitSubscriberIds", () => {
+  const table: Record<string, GrainType[]> = {
+    chat: ["ChatArchive", "Moderator"],
+    telemetry: ["Aggregator"],
+  };
+  const typesFor = (ns: string): GrainType[] => table[ns] ?? [];
+
+  it("synthesizes one grain id per implicitly-subscribed type, keyed by the stream key", () => {
+    const ids = implicitSubscriberIds("chat/general", typesFor);
+    expect(ids.map((g) => g.toString())).toEqual(["ChatArchive/general", "Moderator/general"]);
+  });
+
+  it("returns none when no type is subscribed to the namespace", () => {
+    expect(implicitSubscriberIds("unknown/x", typesFor)).toEqual([]);
+  });
+
+  it("keeps the full key when it contains slashes", () => {
+    const ids = implicitSubscriberIds("telemetry/region/eu/dev-1", typesFor);
+    expect(ids.map((g) => g.toString())).toEqual(["Aggregator/region/eu/dev-1"]);
+  });
+
+  it("ignores a malformed stream key without a namespace separator", () => {
+    expect(implicitSubscriberIds("nokey", typesFor)).toEqual([]);
+  });
+});

--- a/packages/streams/src/implicit-subscriptions.ts
+++ b/packages/streams/src/implicit-subscriptions.ts
@@ -1,0 +1,25 @@
+import { GrainId } from "@tsva/core/grain-id";
+import type { GrainType } from "@tsva/core/grain-type";
+
+/**
+ * Resolve a stream's implicit subscribers (Orleans' `[ImplicitStreamSubscription]`).
+ * A stream key is `namespace/key`; `typesFor` returns the grain types implicitly
+ * subscribed to the namespace. Each such type with the stream's key is a
+ * subscriber, so the synthesized `GrainId` is `(type, key)` — the grain whose
+ * primary key matches the stream is auto-subscribed (a pulling agent delivers to
+ * it without any explicit `subscribe`).
+ *
+ * The key is taken as a string: stream keys are string-encoded on the wire, and
+ * implicit subscribers are addressed by that key (matching how a producer names
+ * the stream). Integer/Guid-keyed implicit subscribers are out of scope.
+ */
+export function implicitSubscriberIds(
+  streamKey: string,
+  typesFor: (namespace: string) => Iterable<GrainType>,
+): GrainId[] {
+  const slash = streamKey.indexOf("/");
+  if (slash < 0) return [];
+  const namespace = streamKey.slice(0, slash);
+  const key = streamKey.slice(slash + 1);
+  return [...typesFor(namespace)].map((type) => new GrainId(type, key));
+}

--- a/packages/streams/src/redis-pulling-stream-provider.ts
+++ b/packages/streams/src/redis-pulling-stream-provider.ts
@@ -1,6 +1,7 @@
 import type { createClient } from "redis";
 import type { GrainId } from "@tsva/core/grain-id";
 import { keyToString, type GrainKey } from "@tsva/core/grain-key";
+import type { GrainType } from "@tsva/core/grain-type";
 import { stableHash32 } from "@tsva/core/hash";
 import type {
   ActivationBoundStreamProvider,
@@ -12,6 +13,7 @@ import type {
   StreamSubscriptionHandle,
   SubscribeOptions,
 } from "@tsva/core/stream";
+import { implicitSubscriberIds } from "@tsva/streams/implicit-subscriptions";
 import { QueuePullingAgent } from "@tsva/streams/queue-pulling-agent";
 import { ownedQueueIndices, type HashRange } from "@tsva/streams/queue-ownership";
 import { RedisStreamQueue } from "@tsva/streams/redis-stream-queue";
@@ -52,6 +54,7 @@ export class RedisPullingStreamProvider implements ActivationBoundStreamProvider
   private readonly queues: RedisStreamQueue[];
   private readonly agents = new Map<number, QueuePullingAgent>();
   private deliver: StreamDeliver = async () => undefined;
+  private implicitTypesFor: (namespace: string) => Iterable<GrainType> = () => [];
 
   constructor(
     client: RedisClient,
@@ -76,6 +79,15 @@ export class RedisPullingStreamProvider implements ActivationBoundStreamProvider
   /** Wire how a pulled event reaches a subscriber's activation (the cluster node). */
   setDeliver(deliver: StreamDeliver): void {
     this.deliver = deliver;
+  }
+
+  /**
+   * Wire the implicit-subscription table (`namespace → grain types`). An agent
+   * fans each event out to these grain types' matching-key activations as well as
+   * to the registry's explicit subscribers (Orleans' `[ImplicitStreamSubscription]`).
+   */
+  setImplicitSubscribers(typesFor: (namespace: string) => Iterable<GrainType>): void {
+    this.implicitTypesFor = typesFor;
   }
 
   /**
@@ -124,7 +136,16 @@ export class RedisPullingStreamProvider implements ActivationBoundStreamProvider
   }
 
   private async fanOut(streamKey: string, event: unknown, token: number): Promise<void> {
-    for (const subscriber of await this.registry.subscribers(streamKey)) {
+    // Explicit subscribers (from the durable registry) plus implicit ones (grain
+    // types bound to the stream's namespace), deduplicated so a grain that is both
+    // gets the event once.
+    const explicit = await this.registry.subscribers(streamKey);
+    const implicit = implicitSubscriberIds(streamKey, this.implicitTypesFor);
+    const seen = new Set<string>();
+    for (const subscriber of [...explicit, ...implicit]) {
+      const id = subscriber.toString();
+      if (seen.has(id)) continue;
+      seen.add(id);
       await this.deliver(subscriber, streamKey, event, token);
     }
   }

--- a/todo.md
+++ b/todo.md
@@ -242,8 +242,16 @@ order, starting with transactions.
 - [ ] Grain migration / activation rebalancer (Orleans 10 core runtime).
 - [ ] Grain-interface versioning — multiple interface versions live at once for heterogeneous rolling
       upgrades, with version-aware placement (Orleans' versioning).
-- [ ] Implicit stream subscriptions — bind a grain type to a namespace and auto-subscribe by key, no
-      explicit `subscribe` call (Orleans' `[ImplicitStreamSubscription]`).
+- [x] Implicit stream subscriptions — bind a grain type to a namespace and auto-subscribe by key, no
+      explicit `subscribe` call (Orleans' `[ImplicitStreamSubscription]`). A grain type declares
+      namespaces via `@implicitStreamSubscription(ns)` (class) or `defineGrain`'s
+      `implicitSubscriptions` (functional); a grain with key `K` is auto-subscribed to `(ns, K)` and
+      exposes its handler under the `STREAM_SUBSCRIPTION_OBSERVER` symbol (lazily resolved on first
+      delivery, mirroring Orleans' `IStreamSubscriptionObserver`). The pulling agent's fan-out adds
+      implicit subscribers (the `ClusterNode`'s namespace→grain-type map, synthesizing `(type, K)`
+      grain ids) alongside the registry's explicit subscribers, deduplicated; in-memory provider
+      stays explicit-only. Tests: metadata/observer unit, pure `implicitSubscriberIds`, dispatcher
+      delivery (class + functional, no-observer drop), and a Redis pulling-agent e2e (skip-if-down).
 - [ ] Directory range handoff — replace the phase-2 drop-and-rebuild with a versioned, lossless
       handoff on membership change (per [docs/06](docs/06-grain-directory-and-placement.md)).
 - [~] Observability (cross-cutting) — OpenTelemetry traces propagated via request context, metrics


### PR DESCRIPTION
Adds support for implicit stream subscriptions, allowing grain types to be auto-subscribed to stream namespaces by key without explicit `subscribe()` calls — matching Orleans' `[ImplicitStreamSubscription]` attribute.

## Summary

A grain type can now declare implicit subscriptions to stream namespaces via `@implicitStreamSubscription(namespace)` (class form) or `implicitSubscriptions` option in `defineGrain` (functional form). A grain with key `K` is automatically subscribed to stream `(namespace, K)`. When the pulling agent delivers an event, it fans out to both explicit subscribers and implicit subscribers at the matching key, with no explicit subscription required.

## Key Changes

- **Core declarations:** Added `@implicitStreamSubscription` decorator and `implicitSubscriptions` option to `defineGrain`; grain metadata now tracks declared namespaces
- **Observer pattern:** Introduced `STREAM_SUBSCRIPTION_OBSERVER` symbol and `implicitStreamObserver()` helper; grains expose their handler under this symbol (lazily resolved on first delivery, mirroring Orleans' `IStreamSubscriptionObserver`)
- **Activation delivery:** Modified `ActivationData.streamHandlerFor()` to fall back to the grain's implicit observer when no explicit handler is registered
- **Fan-out resolution:** Added `implicitSubscriberIds()` utility to synthesize grain IDs for implicit subscribers; wired into `RedisPullingStreamProvider.fanOut()` to deliver to both explicit and implicit subscribers
- **Runtime registry:** `ClusterNode` now maintains a namespace → grain types map; exposed via `implicitGrainTypes()` and `deliverStreamEvent()` for testing
- **Provider integration:** `RedisPullingStreamProvider.setImplicitSubscribers()` receives the registry callback to resolve implicit subscribers during fan-out

## Implementation Details

- Implicit subscriptions are a **pulling-agent feature** (Redis provider); the in-memory provider is for explicit-subscription dev/tests only
- Subscribers are addressed by **string key**, matching how producers name streams
- The observer is **bound to the grain instance**, so `this` context is preserved
- Grains that declare no observer have events **silently dropped** (no error)
- A grain that is both an explicit and implicit subscriber receives **one delivery** (deduplicated)
- Functional and class grains are supported equally

## Tests

- Core declaration and observer binding tests in `packages/core/src/implicit-subscription.test.ts`
- Runtime delivery and fan-out tests in `packages/runtime/src/implicit-stream-delivery.test.ts`
- End-to-end Redis pulling-agent test in `packages/hosting/src/redis-pulling-streams.test.ts`
- Utility function tests in `packages/streams/src/implicit-subscriptions.test.ts`

Closes the implicit stream subscriptions item in the roadmap.

https://claude.ai/code/session_01K6UPKSo7LyR7pBGtrbiyA1