### PR TITLE
Implement grain-interface versioning with version-aware placement

### DIFF
--- a/EPICS.md
+++ b/EPICS.md
@@ -46,8 +46,8 @@ decisions.
       (`IGrainMigrationParticipant`, `MigrateOnIdle`, directed placement).
 - [ ] **Activation rebalancer** — proactively move activations across silos to balance load
       (`IActivationRebalancer`).
-- [ ] **Grain-interface versioning** — multiple interface versions coexist for heterogeneous rolling
-      upgrades, with version-aware placement.
+- [x] **Grain-interface versioning** — multiple interface versions coexist for heterogeneous rolling
+      upgrades, with version-aware placement ([ADR 0014](docs/adr/0014-grain-interface-versioning.md)).
 - [ ] **Implicit stream subscriptions** — bind a grain type to a namespace and auto-subscribe by key.
 - [ ] **Directory range handoff** — versioned, lossless directory handoff on membership change
       (replacing the phase-2 drop-and-rebuild).

--- a/docs/10-kubernetes-hosting.md
+++ b/docs/10-kubernetes-hosting.md
@@ -196,10 +196,11 @@ reminder/stream ownership can rebalance without losing availability.
 - **Scale in.** Removing pods triggers graceful drain per pod; their grains reactivate elsewhere and
   their owned ranges reassign.
 - **Rolling update.** The StatefulSet replaces pods one at a time (`OrderedReady`). Each replaced
-  pod drains gracefully first. Until grain-interface versioning ships (planned parity work, see the
-  [roadmap](13-roadmap-and-phases.md)), a uniform image is assumed — no incompatible interface
-  versions — so a rolling update is just a sequence of drain-and-rejoin events the cluster already
-  handles.
+  pod drains gracefully first. With a uniform image a rolling update is just a sequence of
+  drain-and-rejoin events the cluster already handles. For a **heterogeneous** update, where new pods
+  declare a higher interface version, **grain-interface versioning** ([ADR 0014](adr/0014-grain-interface-versioning.md))
+  makes placement version-aware: a new activation is steered onto a silo whose implemented version is
+  compatible with the caller's, so v1 and v2 pods can coexist during the roll.
 
 ## Local development
 

--- a/docs/13-roadmap-and-phases.md
+++ b/docs/13-roadmap-and-phases.md
@@ -32,7 +32,7 @@ Grain call filters and cross-cutting observability (request context, OpenTelemet
 structured logs) ship too, on the grain-call-filter seam, as does implicit stream subscription.
 
 **Remaining for parity (Orleans 10):** grain migration and the activation rebalancer (the v10
-core-runtime block), grain-interface versioning, lossless directory range handoff, and placement
+core-runtime block), lossless directory range handoff, and placement
 filters. The Orleans-10 additions of durable journaling (`DurableGrain`) and durable jobs need an
 ADR each (journaling overlaps the existing reducer/persistent-state model).
 
@@ -149,7 +149,12 @@ verified.
 - **Activation rebalancer** — proactively moves activations across silos to balance load
   (`IActivationRebalancer`, `Orleans.Runtime/Placement/Rebalancing/*`; Orleans 10).
 - **Grain-interface versioning** — multiple interface versions live at once for heterogeneous rolling
-  upgrades, with version-aware placement (Orleans' versioning).
+  upgrades, with version-aware placement (Orleans' versioning). **Shipped**
+  ([ADR 0014](adr/0014-grain-interface-versioning.md)): an interface carries a `version`; each silo
+  advertises a grain manifest exchanged lazily across the cluster; placement pre-filters candidates by
+  a compatibility director (`backwardCompatible` / `strict`) and version selector (`latest` / `all` /
+  `minimum`), configured via `createSilo().useVersioning(...)`, with best-effort fallback when no silo
+  is compatible. Inert in a v1-only cluster.
 - **Implicit stream subscriptions** — bind a grain type to a namespace and auto-subscribe by key,
   with no explicit `subscribe` call (Orleans' `[ImplicitStreamSubscription]`). **Shipped** —
   `@implicitStreamSubscription(namespace)` / `defineGrain`'s `implicitSubscriptions`; the grain

--- a/docs/adr/0014-grain-interface-versioning.md
+++ b/docs/adr/0014-grain-interface-versioning.md
@@ -1,0 +1,83 @@
+# ADR 0014 — Grain-interface versioning (version-aware placement)
+
+- Status: Accepted — implemented (interface version, manifest exchange, version-aware placement)
+- Context docs: [02 — The actor model](../02-actor-model.md),
+  [04 — Messaging and serialization](../04-messaging-and-serialization.md),
+  [06 — Grain directory and placement](../06-grain-directory-and-placement.md),
+  [10 — Kubernetes hosting](../10-kubernetes-hosting.md),
+  [13 — Roadmap](../13-roadmap-and-phases.md)
+
+> Orleans references: `Orleans.Serialization/Versioning/*` (interface versioning),
+> `GrainVersionManifest` / `IClusterManifestProvider` (cluster manifest),
+> `Orleans.Runtime/Versions/Compatibility/*` (`CompatibilityDirector`,
+> `BackwardCompatible` / `StrictVersionCompatible`),
+> `Orleans.Runtime/Versions/Selector/*` (`VersionSelectorStrategy`).
+
+## Context
+
+Until now the cluster assumed a **uniform image** ([10](../10-kubernetes-hosting.md)): a rolling
+update is just a sequence of drain-and-rejoin events because no two silos could host incompatible
+interface versions. Orleans-10 parity ([13](../13-roadmap-and-phases.md)) needs **heterogeneous
+rolling upgrades** — v1 and v2 silos serving the same interface at once — with **version-aware
+placement** so a new activation lands on a silo whose implemented version is compatible with the
+caller's.
+
+## Decision
+
+- **Version on the interface.** `GrainInterface<T>` carries a `version` (default `1`), declared at
+  `defineGrainInterface(name, { version })`. The interface **id stays name-derived**
+  (`stableHash32(name)`), so versions of one interface share an id — the Orleans model. The caller's
+  compiled version rides the wire as `InvocationRequest.interfaceVersion` → `Message.interfaceVersion`
+  → back to `InvocationRequest`; absent ⇒ `1`.
+- **Per-silo grain manifest.** Each silo derives a manifest (`interfaceId → implemented version`, with
+  grain type) from its registered interfaces. Peers fetch a silo's manifest **lazily** over a new
+  `system: "manifest"` RPC — the same transport/correlation path as the `system: "directory"` RPC —
+  cache it, and drop the cache on any membership change. No gossip/push protocol.
+- **Version-aware placement.** A pre-filter in `DistributedDispatcher.placeAndInvoke` prunes the
+  candidate silos to those a `CompatibilityDirector` accepts, then narrows them with a
+  `VersionSelectorStrategy`, before the existing `PlacementStrategy` runs. Directors:
+  `backwardCompatible` (default — implemented ≥ requested) and `strict` (exact match). Selectors:
+  `latest` (default), `all`, `minimum`. Configured on the host builder via
+  `createSilo(...).useVersioning({ compatibility, selector })`.
+- **Best-effort fallback.** When no active silo is compatible, placement falls back to the full
+  candidate set rather than failing — placement never rejects on version grounds.
+- **Inert by default.** The filter (and the manifest RPC) runs only when versioning is *active*: a
+  registered interface declares a version > 1, or the host called `useVersioning`. A v1-only cluster
+  with no policy runs exactly the pre-existing code path — no manifest messages, identical placement.
+
+## Consequences
+
+- A new activation for a versioned interface is steered to a compatible silo, enabling a heterogeneous
+  rolling upgrade without a flag-day.
+- Version selection is **orthogonal to placement**: every existing `PlacementStrategy` is untouched;
+  the version filter is the same seam the roadmap's future "placement filters" item will reuse.
+- The manifest is exchanged lazily and cached, so the steady-state hot path is unchanged once peers'
+  manifests are known; membership changes re-fetch on demand.
+
+## Scope boundary
+
+- **Existing activations are not re-homed.** Version-aware selection applies at *placement* (when a
+  grain has no activation). An activation already pinned to an older silo keeps serving there until it
+  idles out; relocating a live activation onto a compatible silo is **grain migration**, a separate
+  roadmap item. A v2-only method against such a grain surfaces the existing
+  `GrainCallError "has no method …"` — consistent with the best-effort policy.
+- **Reference rehydration stays version-agnostic** (it resolves by id to build a proxy; the proxy
+  carries its own `version`).
+- **Payload/field versioning is out of scope** — this is *interface*-version placement, not
+  serializer schema evolution (that is the separate serializer-codec concern in
+  [04](../04-messaging-and-serialization.md)).
+
+## Alternatives considered
+
+- **Version in the id hash.** Rejected — it would give each version a distinct id and break the shared
+  routing/rehydration the Orleans model depends on.
+- **Carry manifests on the membership snapshot.** Rejected — membership is Kubernetes-derived
+  (EndpointSlices) and carries no per-silo metadata; a separate manifest exchange is the faithful
+  analogue of Orleans' `IClusterManifestProvider`.
+- **Push/gossip the manifest.** Deferred — lazy pull with caching is the minimal slice; a
+  push-on-join refresh can replace it later without changing the placement contract.
+- **Filter inside each `PlacementStrategy`.** Rejected — it would duplicate the logic across
+  strategies and couple version selection to placement; a single pre-filter keeps both concerns
+  separate.
+- **Reject when no compatible silo exists.** Rejected per product decision in favour of best-effort
+  placement (place anywhere) so a call never fails purely on version grounds.

--- a/packages/core/src/grain-interface.test.ts
+++ b/packages/core/src/grain-interface.test.ts
@@ -26,4 +26,16 @@ describe("defineGrainInterface", () => {
     expect(ICounter.options.get?.readOnly).toBe(true);
     expect(ICounter.options.increment).toBeUndefined();
   });
+
+  it("defaults to version 1 and carries an explicit version", () => {
+    expect(defineGrainInterface("IVersioned.default").version).toBe(1);
+    expect(defineGrainInterface("IVersioned.explicit", { version: 3 }).version).toBe(3);
+  });
+
+  it("keeps the id stable across versions of one interface (id is name-derived)", () => {
+    const v1 = defineGrainInterface("IVersioned.same", { version: 1 });
+    const v2 = defineGrainInterface("IVersioned.same", { version: 2 });
+    expect(v1.id).toBe(v2.id);
+    expect(v1.version).not.toBe(v2.version);
+  });
 });

--- a/packages/core/src/grain-interface.ts
+++ b/packages/core/src/grain-interface.ts
@@ -14,6 +14,13 @@ import type { InvokeMethodOptions } from "./invoke-options";
 export interface GrainInterface<T> {
   readonly id: number;
   readonly name: string;
+  /**
+   * Interface version (defaults to 1). The `id` is name-derived and stable
+   * across versions — two versions of one interface share an id — so a caller's
+   * version travels separately on the wire for version-aware placement
+   * ([ADR 0014](../../docs/adr/0014-grain-interface-versioning.md)).
+   */
+  readonly version: number;
   readonly options: Readonly<Record<string, InvokeMethodOptions>>;
   /** Phantom marker so a `GrainInterface<T>` carries its interface type. */
   readonly __t?: T;
@@ -22,6 +29,8 @@ export interface GrainInterface<T> {
 export interface GrainInterfaceDefinition<T> {
   /** Per-method invocation flags; only the non-default methods need an entry. */
   options?: Partial<Record<keyof T & string, InvokeMethodOptions>>;
+  /** Interface version for rolling upgrades (defaults to 1). */
+  version?: number;
 }
 
 // Process-wide registry so a receiving silo can resolve an interfaceId back to
@@ -35,6 +44,7 @@ export function defineGrainInterface<T>(
   const result: GrainInterface<T> = {
     id: stableHash32(name),
     name,
+    version: def.version ?? 1,
     options: { ...(def.options ?? {}) } as Record<string, InvokeMethodOptions>,
   };
   registry.set(result.id, result as GrainInterface<unknown>);

--- a/packages/core/src/grain-manifest.ts
+++ b/packages/core/src/grain-manifest.ts
@@ -1,0 +1,27 @@
+import type { GrainType } from "./grain-type";
+import type { SiloAddress } from "./silo-address";
+
+/**
+ * The interface versions a silo's registered grain implementations support — the
+ * unit a silo advertises to peers so placement can be version-aware (Orleans'
+ * `GrainVersionManifest` / `IClusterManifestProvider`). See
+ * [ADR 0014](../../docs/adr/0014-grain-interface-versioning.md).
+ */
+export interface InterfaceVersionEntry {
+  /** Name-derived interface id (stable across versions of one interface). */
+  interfaceId: number;
+  /** The version this silo implements for that interface. */
+  version: number;
+  /** The grain type that hosts the interface here. */
+  grainType: GrainType;
+}
+
+export interface SiloManifest {
+  silo: SiloAddress;
+  entries: readonly InterfaceVersionEntry[];
+}
+
+/** The interface version a silo implements, or `undefined` if it hosts none. */
+export function supportedVersion(manifest: SiloManifest, interfaceId: number): number | undefined {
+  return manifest.entries.find((e) => e.interfaceId === interfaceId)?.version;
+}

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -11,6 +11,8 @@ export interface InvocationRequest {
   target: GrainId;
   /** Interface id — routes `getGrain` to the hosting type and rehydrates refs. */
   interfaceId: number;
+  /** Caller's compiled interface version for version-aware placement (absent ⇒ 1). */
+  interfaceVersion?: number;
   /** The method name; the receiving activation dispatches the message by name. */
   method: string;
   args: unknown[];

--- a/packages/core/src/version-compatibility.test.ts
+++ b/packages/core/src/version-compatibility.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  backwardCompatible,
+  compatibilityDirector,
+  strict,
+} from "@tsva/core/version-compatibility";
+
+describe("backwardCompatible director", () => {
+  it("accepts an implementation newer than or equal to the request", () => {
+    expect(backwardCompatible(1, 1)).toBe(true);
+    expect(backwardCompatible(1, 2)).toBe(true);
+  });
+
+  it("rejects an implementation older than the request", () => {
+    expect(backwardCompatible(2, 1)).toBe(false);
+  });
+});
+
+describe("strict director", () => {
+  it("accepts only the exact requested version", () => {
+    expect(strict(2, 2)).toBe(true);
+    expect(strict(2, 1)).toBe(false);
+    expect(strict(1, 2)).toBe(false);
+  });
+});
+
+describe("compatibilityDirector", () => {
+  it("maps kinds to directors, defaulting to backward-compatible", () => {
+    expect(compatibilityDirector("backwardCompatible")).toBe(backwardCompatible);
+    expect(compatibilityDirector("strict")).toBe(strict);
+  });
+});

--- a/packages/core/src/version-compatibility.ts
+++ b/packages/core/src/version-compatibility.ts
@@ -1,0 +1,20 @@
+/**
+ * Decides whether a silo that *implements* a given interface version can serve a
+ * caller that *requested* another — Orleans' `CompatibilityDirector`. Used to
+ * prune placement candidates during a heterogeneous rolling upgrade (see
+ * [ADR 0014](../../docs/adr/0014-grain-interface-versioning.md)).
+ */
+export type CompatibilityDirector = (requested: number, implemented: number) => boolean;
+
+export type CompatibilityKind = "backwardCompatible" | "strict";
+
+/** Default: a newer (or equal) implementation can serve an older request. */
+export const backwardCompatible: CompatibilityDirector = (requested, implemented) =>
+  implemented >= requested;
+
+/** Exact-match only: the implementation must be the requested version. */
+export const strict: CompatibilityDirector = (requested, implemented) => implemented === requested;
+
+export function compatibilityDirector(kind: CompatibilityKind): CompatibilityDirector {
+  return kind === "strict" ? strict : backwardCompatible;
+}

--- a/packages/core/src/version-selector.test.ts
+++ b/packages/core/src/version-selector.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { all, latest, minimum, versionSelector } from "@tsva/core/version-selector";
+
+describe("version selectors", () => {
+  it("latest picks the highest compatible version", () => {
+    expect(latest(1, [1, 2, 3])).toEqual([3]);
+  });
+
+  it("minimum picks the lowest compatible version", () => {
+    expect(minimum(1, [1, 2, 3])).toEqual([1]);
+  });
+
+  it("all returns every compatible version", () => {
+    expect(all(1, [1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it("returns empty when nothing is compatible", () => {
+    expect(latest(1, [])).toEqual([]);
+    expect(minimum(1, [])).toEqual([]);
+    expect(all(1, [])).toEqual([]);
+  });
+});
+
+describe("versionSelector", () => {
+  it("maps kinds to selectors, defaulting to latest", () => {
+    expect(versionSelector("latest")).toBe(latest);
+    expect(versionSelector("minimum")).toBe(minimum);
+    expect(versionSelector("all")).toBe(all);
+  });
+});

--- a/packages/core/src/version-selector.ts
+++ b/packages/core/src/version-selector.ts
@@ -1,0 +1,36 @@
+/**
+ * Given the versions a cluster currently hosts that are *compatible* with a
+ * request, chooses which of them placement may target — Orleans'
+ * `VersionSelectorStrategy`. The director ([version-compatibility](./version-compatibility.ts))
+ * decides compatibility; the selector narrows the surviving versions (see
+ * [ADR 0014](../../docs/adr/0014-grain-interface-versioning.md)).
+ */
+export type VersionSelectorStrategy = (
+  requested: number,
+  compatible: readonly number[],
+) => readonly number[];
+
+export type VersionSelectorKind = "latest" | "all" | "minimum";
+
+/** Default: target only the highest compatible version on offer. */
+export const latest: VersionSelectorStrategy = (_requested, compatible) =>
+  compatible.length === 0 ? [] : [Math.max(...compatible)];
+
+/** Target any compatible version (widest candidate set). */
+export const all: VersionSelectorStrategy = (_requested, compatible) => compatible;
+
+/** Target only the lowest compatible version (drains older silos last). */
+export const minimum: VersionSelectorStrategy = (_requested, compatible) =>
+  compatible.length === 0 ? [] : [Math.min(...compatible)];
+
+export function versionSelector(kind: VersionSelectorKind): VersionSelectorStrategy {
+  switch (kind) {
+    case "all":
+      return all;
+    case "minimum":
+      return minimum;
+    case "latest":
+    default:
+      return latest;
+  }
+}

--- a/packages/hosting/src/silo-builder.ts
+++ b/packages/hosting/src/silo-builder.ts
@@ -6,6 +6,8 @@ import type {
 import type { GrainInterface } from "@tsva/core/grain-interface";
 import type { MembershipService } from "@tsva/core/membership";
 import type { SiloAddress } from "@tsva/core/silo-address";
+import type { CompatibilityKind } from "@tsva/core/version-compatibility";
+import type { VersionSelectorKind } from "@tsva/core/version-selector";
 import {
   KubernetesMembership,
   type EndpointWatch,
@@ -78,6 +80,9 @@ export class SiloBuilder {
   private readonly outgoingCallFilters: OutgoingGrainCallFilter[] = [];
   private metricsEnabled = false;
   private readonly registrations: Registration[] = [];
+  private versioning:
+    | { compatibility?: CompatibilityKind; selector?: VersionSelectorKind }
+    | undefined;
   private readonly starters: Array<() => Promise<void>> = [];
   private readonly closers: Array<() => Promise<void>> = [];
   private readonly pullingStreams: RedisPullingStreamProvider[] = [];
@@ -210,6 +215,20 @@ export class SiloBuilder {
    */
   useLogging(logger: Logger): this {
     this.incomingCallFilters.push(loggingFilter(logger));
+    return this;
+  }
+
+  /**
+   * Enable grain-interface versioning (ADR 0014): version-aware placement steers
+   * a new activation onto a silo whose implemented interface version is
+   * compatible with the caller's. `compatibility` defaults to `"backwardCompatible"`
+   * (a newer silo can serve an older caller); `selector` defaults to `"latest"`.
+   * When no silo is compatible, placement falls back to the full candidate set.
+   */
+  useVersioning(
+    options: { compatibility?: CompatibilityKind; selector?: VersionSelectorKind } = {},
+  ): this {
+    this.versioning = options;
     return this;
   }
 
@@ -368,6 +387,14 @@ export class SiloBuilder {
         ? { collectionIntervalSeconds: this.config.collectionIntervalSeconds }
         : {}),
       ...(this.config.random !== undefined ? { random: this.config.random } : {}),
+      // Calling useVersioning() enables versioning with resolved defaults, so the
+      // node activates version-aware placement even when no policy is overridden.
+      ...(this.versioning !== undefined
+        ? {
+            versionCompatibility: this.versioning.compatibility ?? "backwardCompatible",
+            versionSelector: this.versioning.selector ?? "latest",
+          }
+        : {}),
       ...(this.incomingCallFilters.length > 0
         ? { incomingCallFilters: this.incomingCallFilters }
         : {}),

--- a/packages/messaging/src/message.ts
+++ b/packages/messaging/src/message.ts
@@ -39,10 +39,12 @@ export interface Message {
   sendingSilo?: SiloAddress | undefined;
 
   interfaceId: number;
+  /** Caller's interface version for version-aware placement (absent ⇒ 1). */
+  interfaceVersion?: number | undefined;
   method: string;
 
-  /** Marks a system request (e.g. a directory partition operation) vs a grain call. */
-  system?: "directory" | "migration" | undefined;
+  /** Marks a system request (directory, migration, or manifest operation) vs a grain call. */
+  system?: "directory" | "migration" | "manifest" | undefined;
 
   responseKind?: ResponseKind | undefined;
   requestContext?: RequestContext | undefined;
@@ -74,6 +76,9 @@ export function responseTo(
     targetGrain: request.targetGrain,
     sendingSilo,
     interfaceId: request.interfaceId,
+    ...(request.interfaceVersion !== undefined
+      ? { interfaceVersion: request.interfaceVersion }
+      : {}),
     method: request.method,
     responseKind,
     body,

--- a/packages/runtime/src/cluster-node.ts
+++ b/packages/runtime/src/cluster-node.ts
@@ -2,11 +2,22 @@ import { newActivationId } from "@tsva/core/activation-id";
 import { GrainCallError, RejectionError } from "@tsva/core/errors";
 import type { Grain } from "@tsva/core/grain";
 import { grainAddressEquals, type GrainAddress } from "@tsva/core/grain-address";
-import type { GrainId } from "@tsva/core/grain-id";
+import { GrainId } from "@tsva/core/grain-id";
 import type { GrainInterface } from "@tsva/core/grain-interface";
 import { getGrainInterface } from "@tsva/core/grain-interface";
+import type { InterfaceVersionEntry, SiloManifest } from "@tsva/core/grain-manifest";
 import { getGrainMetadata } from "@tsva/core/grain-metadata";
 import type { GrainType } from "@tsva/core/grain-type";
+import {
+  compatibilityDirector,
+  type CompatibilityDirector,
+  type CompatibilityKind,
+} from "@tsva/core/version-compatibility";
+import {
+  versionSelector,
+  type VersionSelectorKind,
+  type VersionSelectorStrategy,
+} from "@tsva/core/version-selector";
 import type { GrainKeyFor } from "@tsva/core/key-kinds";
 import { activeSilos, type MembershipService } from "@tsva/core/membership";
 import type {
@@ -48,6 +59,7 @@ import type {
   PlacementContext,
   PlacementStrategy,
 } from "@tsva/runtime/placement/placement-strategy";
+import { filterByVersion } from "@tsva/runtime/placement/version-placement-filter";
 import { systemTimeProvider, type TimeProvider } from "@tsva/runtime/time-provider";
 import { TransactionAgent } from "@tsva/runtime/transaction-agent";
 
@@ -83,6 +95,14 @@ export interface ClusterNodeOptions {
   outgoingCallFilters?: readonly OutgoingGrainCallFilter[];
   /** Injectable RNG for deterministic placement in tests. */
   random?: () => number;
+  /**
+   * Grain-interface versioning policy (ADR 0014). Setting either field enables
+   * version-aware placement on this silo; otherwise versioning activates only
+   * when a registered interface declares a version > 1. Defaults:
+   * backward-compatible director + latest-version selector.
+   */
+  versionCompatibility?: CompatibilityKind;
+  versionSelector?: VersionSelectorKind;
 }
 
 interface RejectionPayload {
@@ -122,6 +142,15 @@ export class ClusterNode {
   private readonly interfaceToGrainType = new Map<number, GrainType>();
   /** Stream namespace → grain types implicitly subscribed to it (auto-subscribe by key). */
   private readonly implicitSubscriptions = new Map<string, GrainType[]>();
+  /** Interface versions this silo implements (ADR 0014): interfaceId -> hosted version. */
+  private readonly localVersions = new Map<number, { version: number; grainType: GrainType }>();
+  private maxLocalVersion = 1;
+  /** Peer manifests, fetched lazily and cleared on any membership change. */
+  private readonly manifestCache = new Map<string, SiloManifest>();
+  private readonly manifestInflight = new Map<string, Promise<SiloManifest>>();
+  private readonly versionPolicyConfigured: boolean;
+  private readonly director: CompatibilityDirector;
+  private readonly selector: VersionSelectorStrategy;
   private readonly cache = new LocationCache();
   private readonly correlation = new CorrelationTable();
   private readonly connections: ConnectionManager;
@@ -148,6 +177,10 @@ export class ClusterNode {
   constructor(private readonly options: ClusterNodeOptions) {
     const time = options.time ?? systemTimeProvider;
     this.callTimeoutMs = options.callTimeoutMs ?? 30_000;
+    this.versionPolicyConfigured =
+      options.versionCompatibility !== undefined || options.versionSelector !== undefined;
+    this.director = compatibilityDirector(options.versionCompatibility ?? "backwardCompatible");
+    this.selector = versionSelector(options.versionSelector ?? "latest");
     this.ring = this.buildRing();
     this.connections = new ConnectionManager(options.transport, options.local, options.clusterId);
     this.factory = new GrainFactory((interfaceId) => this.resolveGrainType(interfaceId));
@@ -188,6 +221,7 @@ export class ClusterNode {
         activationCount: (silo) => (silo.equals(this.options.local) ? this.catalog.count() : 0),
         random: this.options.random ?? Math.random,
       }),
+      versionFilter: (req, candidates) => this.applyVersionFilter(req, candidates),
     });
     this.factory.setDispatcher(this.dispatcher);
     const transactionAgent = new TransactionAgent(time);
@@ -212,6 +246,11 @@ export class ClusterNode {
     this.grainTypes.set(metadata.grainType, { ctor, metadata });
     for (const iface of registration.interfaces) {
       this.interfaceToGrainType.set(iface.id, metadata.grainType);
+      const existing = this.localVersions.get(iface.id);
+      if (existing === undefined || iface.version > existing.version) {
+        this.localVersions.set(iface.id, { version: iface.version, grainType: metadata.grainType });
+      }
+      if (iface.version > this.maxLocalVersion) this.maxLocalVersion = iface.version;
     }
     for (const namespace of metadata.implicitSubscriptions) {
       const types = this.implicitSubscriptions.get(namespace) ?? [];
@@ -232,6 +271,16 @@ export class ClusterNode {
 
   isActive(id: GrainId): boolean {
     return this.catalog.isActive(id);
+  }
+
+  /** This silo's grain manifest: the interface versions it implements (ADR 0014). */
+  manifest(): SiloManifest {
+    return { silo: this.options.local, entries: this.localManifestEntries() };
+  }
+
+  /** The version this silo implements for an interface, or `undefined` if none. */
+  localImplementedVersion(interfaceId: number): number | undefined {
+    return this.localVersions.get(interfaceId)?.version;
   }
 
   /** The hash ranges this silo owns on the current ring (drives reminder ownership). */
@@ -331,6 +380,10 @@ export class ClusterNode {
         void this.connections.drop(member);
       }
     }
+    // Peer manifests may have shifted with the view (a silo upgraded/left);
+    // drop them all and re-fetch lazily on the next version-aware placement.
+    this.manifestCache.clear();
+    this.manifestInflight.clear();
     this.ring = this.buildRing();
   }
 
@@ -341,6 +394,58 @@ export class ClusterNode {
   private placementFor(grainType: GrainType): PlacementStrategy {
     const reg = this.grainTypes.get(grainType);
     return reg ? placementStrategyFor(reg.metadata) : randomPlacement;
+  }
+
+  /** True once this silo declares a version > 1 or a versioning policy is set. */
+  private versioningActive(): boolean {
+    return this.versionPolicyConfigured || this.maxLocalVersion > 1;
+  }
+
+  /**
+   * Version-aware placement pre-filter (ADR 0014). Inert (returns the candidates
+   * unchanged, with no manifest round-trips) unless versioning is active.
+   */
+  private applyVersionFilter(
+    req: InvocationRequest,
+    candidates: readonly SiloAddress[],
+  ): Promise<readonly SiloAddress[]> {
+    if (!this.versioningActive()) return Promise.resolve(candidates);
+    return filterByVersion(req.interfaceId, req.interfaceVersion ?? 1, candidates, {
+      director: this.director,
+      selector: this.selector,
+      getManifest: (silo) => this.getManifest(silo),
+    });
+  }
+
+  private localManifestEntries(): InterfaceVersionEntry[] {
+    return [...this.localVersions.entries()].map(([interfaceId, v]) => ({
+      interfaceId,
+      version: v.version,
+      grainType: v.grainType,
+    }));
+  }
+
+  /** A peer's manifest: served locally, else fetched once over the transport and cached. */
+  private getManifest(silo: SiloAddress): Promise<SiloManifest> {
+    if (silo.equals(this.options.local)) return Promise.resolve(this.manifest());
+    const key = silo.toString();
+    const cached = this.manifestCache.get(key);
+    if (cached !== undefined) return Promise.resolve(cached);
+    const inflight = this.manifestInflight.get(key);
+    if (inflight !== undefined) return inflight;
+    const pending = this.sendManifest(silo).then(
+      (manifest) => {
+        this.manifestCache.set(key, manifest);
+        this.manifestInflight.delete(key);
+        return manifest;
+      },
+      (err: unknown) => {
+        this.manifestInflight.delete(key);
+        throw err;
+      },
+    );
+    this.manifestInflight.set(key, pending);
+    return pending;
   }
 
   private resolveGrainType(interfaceId: number): GrainType {
@@ -480,6 +585,7 @@ export class ClusterNode {
       sendingSilo: this.options.local,
       sendingGrain: req.sender,
       interfaceId: req.interfaceId,
+      ...(req.interfaceVersion !== undefined ? { interfaceVersion: req.interfaceVersion } : {}),
       method: req.method,
       requestContext: {
         reentrancyId: req.reentrancyId,
@@ -549,6 +655,10 @@ export class ClusterNode {
       void this.handleMigration(message);
       return;
     }
+    if (message.system === "manifest") {
+      void this.handleManifestRequest(message);
+      return;
+    }
     void this.receiveRequest(message);
   }
 
@@ -595,6 +705,40 @@ export class ClusterNode {
             });
       await this.reply(replyTo, responseTo(message, kind, body, this.options.local));
     }
+  }
+
+  /** Fetch a peer's manifest as a `system: "manifest"` request (mirrors directory RPC). */
+  private async sendManifest(owner: SiloAddress): Promise<SiloManifest> {
+    const conn = await this.connections.get(owner);
+    const correlationId = nextCorrelationId();
+    const message: Message = {
+      correlationId,
+      direction: "request",
+      system: "manifest",
+      targetGrain: new GrainId("manifest", owner.ringKey),
+      sendingSilo: this.options.local,
+      interfaceId: 0,
+      method: "",
+      body: this.serializer.serialize(null),
+    };
+    const pending = this.correlation.register(correlationId, this.callTimeoutMs);
+    conn.send(message);
+    const entries = this.interpretResponse(await pending) as InterfaceVersionEntry[];
+    return { silo: owner, entries };
+  }
+
+  private async handleManifestRequest(message: Message): Promise<void> {
+    const replyTo = message.sendingSilo;
+    if (replyTo === undefined) return;
+    await this.reply(
+      replyTo,
+      responseTo(
+        message,
+        "success",
+        this.serializer.serialize(this.localManifestEntries()),
+        this.options.local,
+      ),
+    );
   }
 
   private applyDirectoryOp(op: DirectoryOp): GrainAddress | undefined {
@@ -665,6 +809,9 @@ export class ClusterNode {
     return {
       target: message.targetGrain,
       interfaceId: message.interfaceId,
+      ...(message.interfaceVersion !== undefined
+        ? { interfaceVersion: message.interfaceVersion }
+        : {}),
       method: message.method,
       args: this.serializer.deserialize<unknown[]>(message.body),
       options: iface?.options[message.method] ?? {},

--- a/packages/runtime/src/distributed-dispatcher.ts
+++ b/packages/runtime/src/distributed-dispatcher.ts
@@ -28,6 +28,16 @@ export interface DistributedDispatcherDeps {
   placementFor: (grainType: GrainType) => PlacementStrategy;
   /** Extra placement context (activation counts, RNG); `localSilo` is filled in. */
   placementContext: () => Omit<PlacementContext, "localSilo">;
+  /**
+   * Optional version-aware pre-filter (grain-interface versioning). Wired only
+   * when versioning is active; returns the compatible subset of `candidates`
+   * (possibly empty). When absent, placement uses the full candidate set as
+   * before.
+   */
+  versionFilter?: (
+    req: InvocationRequest,
+    candidates: readonly SiloAddress[],
+  ) => Promise<readonly SiloAddress[]>;
 }
 
 /**
@@ -88,8 +98,15 @@ export class DistributedDispatcher implements Dispatcher {
     return act.invoke(req);
   }
 
-  private placeAndInvoke(req: InvocationRequest): Promise<unknown> {
-    const candidates = this.deps.activeSilos();
+  private async placeAndInvoke(req: InvocationRequest): Promise<unknown> {
+    const active = this.deps.activeSilos();
+    // Version-aware placement: prefer compatible silos, but fall back to the full
+    // set when none qualify (best-effort — placement never fails on version).
+    let candidates: readonly SiloAddress[] = active;
+    if (this.deps.versionFilter !== undefined) {
+      const compatible = await this.deps.versionFilter(req, active);
+      if (compatible.length > 0) candidates = compatible;
+    }
     const strategy = this.deps.placementFor(req.target.type);
     const targetSilo = strategy.choose(req.target.type, candidates, {
       localSilo: this.deps.local,

--- a/packages/runtime/src/grain-factory.ts
+++ b/packages/runtime/src/grain-factory.ts
@@ -79,6 +79,7 @@ export class GrainFactory {
               const req: InvocationRequest = {
                 target,
                 interfaceId: def.id,
+                interfaceVersion: def.version,
                 method: prop,
                 args: callArgs,
                 options,

--- a/packages/runtime/src/placement/version-placement-filter.test.ts
+++ b/packages/runtime/src/placement/version-placement-filter.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { SiloManifest } from "@tsva/core/grain-manifest";
+import { backwardCompatible, strict } from "@tsva/core/version-compatibility";
+import { all, latest, minimum } from "@tsva/core/version-selector";
+import { SiloAddress } from "@tsva/core/silo-address";
+import { filterByVersion } from "@tsva/runtime/placement/version-placement-filter";
+
+const IFACE = 42;
+const silo = (n: number) => new SiloAddress(`silo-${n}`, `uid-${n}`, `silo-${n}:1`);
+
+/** Build a `getManifest` resolver from a silo-index -> implemented-version map. */
+function manifests(versions: Record<number, number | undefined>) {
+  return (s: SiloAddress): Promise<SiloManifest> => {
+    const n = Number(s.podName.split("-")[1]);
+    const version = versions[n];
+    const entries = version === undefined ? [] : [{ interfaceId: IFACE, version, grainType: "C" }];
+    return Promise.resolve({ silo: s, entries });
+  };
+}
+
+const keys = (silos: readonly SiloAddress[]) => silos.map((s) => s.podName);
+
+describe("filterByVersion", () => {
+  const candidates = [silo(0), silo(1), silo(2)];
+
+  it("keeps backward-compatible silos and selects the latest version", async () => {
+    // silo-0=v1, silo-1=v2, silo-2=v2; a v2 request keeps the v2 silos.
+    const result = await filterByVersion(IFACE, 2, candidates, {
+      director: backwardCompatible,
+      selector: latest,
+      getManifest: manifests({ 0: 1, 1: 2, 2: 2 }),
+    });
+    expect(keys(result)).toEqual(["silo-1", "silo-2"]);
+  });
+
+  it("a v1 request reaches a newer silo under backward compatibility", async () => {
+    const result = await filterByVersion(IFACE, 1, [silo(1)], {
+      director: backwardCompatible,
+      selector: latest,
+      getManifest: manifests({ 1: 2 }),
+    });
+    expect(keys(result)).toEqual(["silo-1"]);
+  });
+
+  it("strict compatibility keeps only the exact version", async () => {
+    const result = await filterByVersion(IFACE, 2, candidates, {
+      director: strict,
+      selector: all,
+      getManifest: manifests({ 0: 1, 1: 2, 2: 3 }),
+    });
+    expect(keys(result)).toEqual(["silo-1"]);
+  });
+
+  it("minimum selector narrows to the lowest compatible version", async () => {
+    const result = await filterByVersion(IFACE, 1, candidates, {
+      director: backwardCompatible,
+      selector: minimum,
+      getManifest: manifests({ 0: 1, 1: 2, 2: 1 }),
+    });
+    expect(keys(result)).toEqual(["silo-0", "silo-2"]);
+  });
+
+  it("returns empty when no silo is compatible (caller falls back)", async () => {
+    const result = await filterByVersion(IFACE, 3, candidates, {
+      director: backwardCompatible,
+      selector: latest,
+      getManifest: manifests({ 0: 1, 1: 2, 2: undefined }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("excludes silos that do not host the interface at all", async () => {
+    const result = await filterByVersion(IFACE, 1, candidates, {
+      director: backwardCompatible,
+      selector: all,
+      getManifest: manifests({ 0: undefined, 1: 1, 2: undefined }),
+    });
+    expect(keys(result)).toEqual(["silo-1"]);
+  });
+});

--- a/packages/runtime/src/placement/version-placement-filter.ts
+++ b/packages/runtime/src/placement/version-placement-filter.ts
@@ -1,0 +1,44 @@
+import { supportedVersion, type SiloManifest } from "@tsva/core/grain-manifest";
+import type { CompatibilityDirector } from "@tsva/core/version-compatibility";
+import type { SiloAddress } from "@tsva/core/silo-address";
+import type { VersionSelectorStrategy } from "@tsva/core/version-selector";
+
+export interface VersionFilterDeps {
+  director: CompatibilityDirector;
+  selector: VersionSelectorStrategy;
+  /** Resolves a silo's advertised manifest (local synchronously, peers cached). */
+  getManifest: (silo: SiloAddress) => Promise<SiloManifest>;
+}
+
+/**
+ * Prune placement candidates to the silos that can serve a request for
+ * `interfaceId` at `requested` version: keep silos whose implemented version the
+ * compatibility director accepts, then narrow to the versions the selector picks
+ * (Orleans' version-aware placement). Returns `[]` when none qualify — the caller
+ * decides whether to fall back to the full candidate set.
+ */
+export async function filterByVersion(
+  interfaceId: number,
+  requested: number,
+  candidates: readonly SiloAddress[],
+  deps: VersionFilterDeps,
+): Promise<readonly SiloAddress[]> {
+  const manifests = await Promise.all(candidates.map((silo) => deps.getManifest(silo)));
+
+  const hosting: Array<{ silo: SiloAddress; version: number }> = [];
+  for (let i = 0; i < candidates.length; i++) {
+    const version = supportedVersion(manifests[i]!, interfaceId);
+    if (version !== undefined && deps.director(requested, version)) {
+      hosting.push({ silo: candidates[i]!, version });
+    }
+  }
+  if (hosting.length === 0) return [];
+
+  const selected = new Set(
+    deps.selector(
+      requested,
+      hosting.map((h) => h.version),
+    ),
+  );
+  return hosting.filter((h) => selected.has(h.version)).map((h) => h.silo);
+}

--- a/packages/runtime/src/versioning.cluster.test.ts
+++ b/packages/runtime/src/versioning.cluster.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import { grain } from "@tsva/core/decorators";
+import { Grain } from "@tsva/core/grain";
+import { GrainId } from "@tsva/core/grain-id";
+import { defineGrainInterface } from "@tsva/core/grain-interface";
+import type { GrainWithStringKey } from "@tsva/core/key-kinds";
+import type { MembershipService } from "@tsva/core/membership";
+import { SiloAddress } from "@tsva/core/silo-address";
+import type { CompatibilityKind } from "@tsva/core/version-compatibility";
+import type { VersionSelectorKind } from "@tsva/core/version-selector";
+import { InProcessNetwork, InProcessTransport } from "@tsva/messaging/in-process-transport";
+import type { Message } from "@tsva/messaging/message";
+import { ClusterNode } from "@tsva/runtime/cluster-node";
+import { StaticMembershipService } from "@tsva/runtime/static-membership";
+
+interface ICounter extends GrainWithStringKey {
+  increment(by: number): Promise<number>;
+}
+// All versions share one name → one id; only the version differs.
+const NAME = "ICounter.versioning";
+const ICounterAt = (version: number) => defineGrainInterface<ICounter>(NAME, { version });
+
+@grain()
+class CounterGrain extends Grain implements ICounter {
+  private count = 0;
+  async increment(by: number): Promise<number> {
+    this.count += by;
+    return this.count;
+  }
+}
+
+const CLUSTER = "cv";
+const silo = (n: number) => new SiloAddress(`silo-${n}`, `uid-${n}`, `silo-${n}:11111`);
+const COUNTER = (key: string) => new GrainId("Counter", key);
+
+/** Reports each node's own localSilo() while sharing one membership view. */
+class MembershipView implements MembershipService {
+  constructor(
+    private readonly shared: StaticMembershipService,
+    private readonly local: SiloAddress,
+  ) {}
+  current() {
+    return this.shared.current();
+  }
+  updates() {
+    return this.shared.updates();
+  }
+  localSilo() {
+    return this.local;
+  }
+}
+
+/** In-process network that counts manifest-exchange requests it carries. */
+class SpyNetwork extends InProcessNetwork {
+  manifestRequests = 0;
+  override deliver(to: SiloAddress, message: Message, from: SiloAddress): void {
+    if (message.system === "manifest") this.manifestRequests++;
+    super.deliver(to, message, from);
+  }
+}
+
+interface ClusterOptions {
+  /** Hosted interface version per silo; `undefined` means the silo hosts none. */
+  versions: ReadonlyArray<number | undefined>;
+  compatibility?: CompatibilityKind;
+  selector?: VersionSelectorKind;
+  random?: () => number;
+}
+
+function buildCluster(opts: ClusterOptions) {
+  const network = new SpyNetwork();
+  const addresses = opts.versions.map((_, i) => silo(i));
+  const membership = new StaticMembershipService(addresses[0]!, addresses);
+
+  const nodes = addresses.map((local, i) => {
+    const node = new ClusterNode({
+      local,
+      clusterId: CLUSTER,
+      membership: new MembershipView(membership, local),
+      transport: new InProcessTransport(network, CLUSTER),
+      random: opts.random ?? (() => 0),
+      ...(opts.compatibility !== undefined ? { versionCompatibility: opts.compatibility } : {}),
+      ...(opts.selector !== undefined ? { versionSelector: opts.selector } : {}),
+    });
+    const v = opts.versions[i];
+    if (v !== undefined) node.registerGrain(CounterGrain, { interfaces: [ICounterAt(v)] });
+    return node;
+  });
+
+  return {
+    nodes,
+    network,
+    membership,
+    hostsOf: (id: GrainId) => nodes.filter((n) => n.isActive(id)),
+    start: async () => {
+      for (const n of nodes) await n.start();
+    },
+    stop: async () => {
+      for (const n of nodes) await n.stop();
+    },
+  };
+}
+
+describe("grain-interface versioning — version-aware placement", () => {
+  it("places a v2 caller's activation only on a v2-capable silo", async () => {
+    const cluster = buildCluster({ versions: [1, 2], compatibility: "backwardCompatible" });
+    await cluster.start();
+    try {
+      // The v2 caller is silo-1; only silo-1 implements v2.
+      const result = await cluster.nodes[1]!.getGrain(ICounterAt(2), "k").increment(1);
+      expect(result).toBe(1);
+      expect(cluster.hostsOf(COUNTER("k"))).toEqual([cluster.nodes[1]]);
+    } finally {
+      await cluster.stop();
+    }
+  });
+
+  it("lets a v1 caller use a v2 silo (backward compatibility)", async () => {
+    const cluster = buildCluster({ versions: [2], compatibility: "backwardCompatible" });
+    await cluster.start();
+    try {
+      const result = await cluster.nodes[0]!.getGrain(ICounterAt(1), "k").increment(4);
+      expect(result).toBe(4);
+      expect(cluster.hostsOf(COUNTER("k"))).toEqual([cluster.nodes[0]]);
+    } finally {
+      await cluster.stop();
+    }
+  });
+
+  it("strict mode places only on the exact version when one exists", async () => {
+    const cluster = buildCluster({ versions: [1, 2], compatibility: "strict" });
+    await cluster.start();
+    try {
+      await cluster.nodes[1]!.getGrain(ICounterAt(2), "k").increment(1);
+      expect(cluster.hostsOf(COUNTER("k"))).toEqual([cluster.nodes[1]]);
+    } finally {
+      await cluster.stop();
+    }
+  });
+
+  it("strict mode falls back to any silo (best-effort) when none is compatible", async () => {
+    // Only a v1 silo is alive; a v2 caller has no strict match → place anyway.
+    const cluster = buildCluster({ versions: [1], compatibility: "strict" });
+    await cluster.start();
+    try {
+      const result = await cluster.nodes[0]!.getGrain(ICounterAt(2), "k").increment(2);
+      expect(result).toBe(2);
+      expect(cluster.hostsOf(COUNTER("k"))).toEqual([cluster.nodes[0]]);
+    } finally {
+      await cluster.stop();
+    }
+  });
+
+  it("the latest selector steers placement to the newest silo", async () => {
+    const cluster = buildCluster({ versions: [1, 2, 3], selector: "latest", random: () => 0 });
+    await cluster.start();
+    try {
+      await cluster.nodes[0]!.getGrain(ICounterAt(1), "k").increment(1);
+      expect(cluster.hostsOf(COUNTER("k"))).toEqual([cluster.nodes[2]]); // v3 silo
+    } finally {
+      await cluster.stop();
+    }
+  });
+
+  it("the minimum selector steers placement to the oldest silo", async () => {
+    const cluster = buildCluster({ versions: [1, 2, 3], selector: "minimum", random: () => 0 });
+    await cluster.start();
+    try {
+      await cluster.nodes[0]!.getGrain(ICounterAt(1), "k").increment(1);
+      expect(cluster.hostsOf(COUNTER("k"))).toEqual([cluster.nodes[0]]); // v1 silo
+    } finally {
+      await cluster.stop();
+    }
+  });
+
+  it("the all selector keeps every compatible silo as a candidate", async () => {
+    // random -> index 1 of the three compatible candidates, reachable only if all are kept.
+    const cluster = buildCluster({ versions: [1, 2, 3], selector: "all", random: () => 0.5 });
+    await cluster.start();
+    try {
+      await cluster.nodes[0]!.getGrain(ICounterAt(1), "k").increment(1);
+      expect(cluster.hostsOf(COUNTER("k"))).toEqual([cluster.nodes[1]]); // v2 silo (middle)
+    } finally {
+      await cluster.stop();
+    }
+  });
+
+  it("is inert in a v1-only cluster with no policy: no manifest exchange, routing unchanged", async () => {
+    const cluster = buildCluster({ versions: [1, 1, 1] });
+    await cluster.start();
+    try {
+      // random -> silo-0 places the grain there; a call from silo-1 routes to it.
+      const result = await cluster.nodes[1]!.getGrain(ICounterAt(1), "shared").increment(5);
+      expect(result).toBe(5);
+      expect(cluster.hostsOf(COUNTER("shared"))).toEqual([cluster.nodes[0]]);
+      expect(cluster.network.manifestRequests).toBe(0);
+    } finally {
+      await cluster.stop();
+    }
+  });
+});

--- a/todo.md
+++ b/todo.md
@@ -251,8 +251,19 @@ order, starting with transactions.
         fallback) + hosting e2e (unflushed persistent state preserved across the move).
   - [ ] Activation rebalancer (`IActivationRebalancer`) — proactively rebalance activations across
         silos (Orleans 10 `Orleans.Runtime/Placement/Rebalancing/*`).
-- [ ] Grain-interface versioning — multiple interface versions live at once for heterogeneous rolling
-      upgrades, with version-aware placement (Orleans' versioning).
+- [x] Grain-interface versioning — multiple interface versions live at once for heterogeneous rolling
+      upgrades, with version-aware placement (Orleans' versioning). [ADR 0014](docs/adr/0014-grain-interface-versioning.md).
+  - [x] `GrainInterface.version` (default 1; id stays name-derived) via `defineGrainInterface(name, { version })`;
+        `interfaceVersion` threaded `InvocationRequest`→`Message`→back (absent ⇒ 1).
+  - [x] Policy abstractions in core: `CompatibilityDirector` (`backwardCompatible`/`strict`),
+        `VersionSelectorStrategy` (`latest`/`all`/`minimum`), `SiloManifest`/`InterfaceVersionEntry`.
+  - [x] Per-silo manifest from registered interfaces; lazy cross-silo `system: "manifest"` RPC
+        (mirrors directory RPC), cached, cleared on membership change.
+  - [x] Version-aware placement pre-filter in `DistributedDispatcher.placeAndInvoke` (best-effort
+        fallback to all candidates when none compatible); inert unless versioning is active.
+  - [x] Host surface `createSilo().useVersioning({ compatibility, selector })`.
+  - [x] Tests: director/selector units, `filterByVersion` unit, multi-silo `versioning.cluster.test.ts`
+        (v2→v2 silo, v1→v2 silo, strict + best-effort fallback, selectors, inert v1-only cluster).
 - [x] Implicit stream subscriptions — bind a grain type to a namespace and auto-subscribe by key, no
       explicit `subscribe` call (Orleans' `[ImplicitStreamSubscription]`). A grain type declares
       namespaces via `@implicitStreamSubscription(ns)` (class) or `defineGrain`'s


### PR DESCRIPTION
## Summary

Implements grain-interface versioning (ADR 0014) to enable heterogeneous rolling upgrades where multiple versions of the same interface can coexist in a cluster. New activations are steered to silos with compatible interface versions via a version-aware placement pre-filter.

## Key Changes

- **Interface versioning:** `GrainInterface` now carries a `version` field (default 1), declared via `defineGrainInterface(name, { version })`. The interface id remains name-derived and stable across versions, so versions of one interface share an id.

- **Silo manifests:** Each silo derives and advertises a manifest (`interfaceId → implemented version`) from its registered grain implementations. Peers fetch manifests lazily over a new `system: "manifest"` RPC, cache them, and drop the cache on membership changes.

- **Version-aware placement:** A pre-filter in `DistributedDispatcher.placeAndInvoke` prunes candidate silos to those a `CompatibilityDirector` accepts, then narrows them with a `VersionSelectorStrategy`, before the existing `PlacementStrategy` runs:
  - **Directors:** `backwardCompatible` (default — implemented ≥ requested) and `strict` (exact match)
  - **Selectors:** `latest` (default), `all`, `minimum`
  - Configured via `SiloBuilder.useVersioning({ compatibility, selector })`

- **Best-effort fallback:** When no active silo is compatible, placement falls back to the full candidate set rather than failing — placement never rejects on version grounds.

- **Inert by default:** The version filter and manifest RPC run only when versioning is active: a registered interface declares version > 1, or the host called `useVersioning()`. A v1-only cluster with no policy runs the pre-existing code path unchanged.

- **Wire protocol:** `InvocationRequest` and `Message` now carry an optional `interfaceVersion` field (absent ⇒ 1) to communicate the caller's compiled version.

## Implementation Details

- Version filtering is orthogonal to placement: every existing `PlacementStrategy` is untouched; the version filter is a seam for future "placement filters."
- Manifest caching is lazy and per-peer, so the steady-state hot path is unchanged once peers' manifests are known.
- Existing activations are not re-homed; version-aware selection applies only at placement (new activations). This is consistent with the best-effort policy and leaves grain migration as a separate roadmap item.
- Comprehensive test coverage includes unit tests for directors/selectors, integration tests for version-aware placement in a multi-silo cluster, and a test verifying the feature is inert in v1-only clusters.

## Related Work

- Closes the grain-interface versioning item in the Orleans-10 parity roadmap (see `docs/13-roadmap-and-phases.md`).
- Updates `todo.md` to mark versioning complete and clarifies remaining parity work.

https://claude.ai/code/session_0167y7WjWhYeZG5eVrx2JYmn