### PR TITLE
feat(runtime): grain migration — IGrainMigrationParticipant + MigrateOnIdle + directed placement

### DIFF
--- a/packages/core/src/grain-migration-participant.test.ts
+++ b/packages/core/src/grain-migration-participant.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  isMigrationParticipant,
+  MigrationBag,
+  type IGrainMigrationParticipant,
+} from "@tsva/core/grain-migration-participant";
+
+describe("isMigrationParticipant", () => {
+  it("accepts an object exposing both migration hooks", () => {
+    const participant: IGrainMigrationParticipant = {
+      onDehydrate: () => undefined,
+      onRehydrate: () => undefined,
+    };
+    expect(isMigrationParticipant(participant)).toBe(true);
+  });
+
+  it("rejects objects missing a hook, and non-objects", () => {
+    expect(isMigrationParticipant({ onDehydrate: () => undefined })).toBe(false);
+    expect(isMigrationParticipant({})).toBe(false);
+    expect(isMigrationParticipant(null)).toBe(false);
+    expect(isMigrationParticipant(42)).toBe(false);
+  });
+});
+
+describe("MigrationBag", () => {
+  it("round-trips values through set/get/has and exposes its data", () => {
+    const bag = new MigrationBag();
+    expect(bag.has("count")).toBe(false);
+    bag.set("count", 7);
+    bag.set("label", "a");
+    expect(bag.has("count")).toBe(true);
+    expect(bag.get<number>("count")).toBe(7);
+    expect(bag.get<string>("label")).toBe("a");
+    expect(bag.get("missing")).toBeUndefined();
+    expect([...bag.keys].sort()).toEqual(["count", "label"]);
+    expect(bag.data).toEqual({ count: 7, label: "a" });
+  });
+
+  it("reads from a backing record supplied on the target", () => {
+    const bag = new MigrationBag({ count: 5 });
+    expect(bag.has("count")).toBe(true);
+    expect(bag.get<number>("count")).toBe(5);
+  });
+});

--- a/packages/core/src/grain-migration-participant.ts
+++ b/packages/core/src/grain-migration-participant.ts
@@ -1,0 +1,60 @@
+/** A write-only bag a participant populates during dehydration (Orleans `IDehydrationContext`). */
+export interface DehydrationContext {
+  set(key: string, value: unknown): void;
+}
+
+/** A read-only bag a participant consults during rehydration (Orleans `IRehydrationContext`). */
+export interface RehydrationContext {
+  has(key: string): boolean;
+  get<T>(key: string): T | undefined;
+  readonly keys: readonly string[];
+}
+
+/**
+ * A grain — or a state facet it owns — that carries its in-memory state across a
+ * live migration: `onDehydrate` writes it into the bag on the source silo and
+ * `onRehydrate` restores it on the target, so the activation moves without losing
+ * (possibly unflushed) state. Mirrors Orleans `IGrainMigrationParticipant`.
+ */
+export interface IGrainMigrationParticipant {
+  onDehydrate(context: DehydrationContext): void;
+  onRehydrate(context: RehydrationContext): void;
+}
+
+/** Duck-type guard: an object is a participant if it exposes both migration hooks. */
+export function isMigrationParticipant(value: unknown): value is IGrainMigrationParticipant {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as Partial<IGrainMigrationParticipant>).onDehydrate === "function" &&
+    typeof (value as Partial<IGrainMigrationParticipant>).onRehydrate === "function"
+  );
+}
+
+/**
+ * A string-keyed bag backing both migration contexts; its `data` is the
+ * serializable payload carried to the target silo.
+ */
+export class MigrationBag implements DehydrationContext, RehydrationContext {
+  constructor(private readonly bag: Record<string, unknown> = {}) {}
+
+  set(key: string, value: unknown): void {
+    this.bag[key] = value;
+  }
+
+  has(key: string): boolean {
+    return Object.prototype.hasOwnProperty.call(this.bag, key);
+  }
+
+  get<T>(key: string): T | undefined {
+    return this.bag[key] as T | undefined;
+  }
+
+  get keys(): readonly string[] {
+    return Object.keys(this.bag);
+  }
+
+  get data(): Record<string, unknown> {
+    return this.bag;
+  }
+}

--- a/packages/core/src/grain-runtime.ts
+++ b/packages/core/src/grain-runtime.ts
@@ -2,6 +2,7 @@ import type { Duration } from "./duration";
 import type { GrainInterface } from "./grain-interface";
 import type { GrainTimer } from "./grain-timer";
 import type { GrainKeyFor } from "./key-kinds";
+import type { SiloAddress } from "./silo-address";
 import type { StreamProvider } from "./stream";
 
 /**
@@ -16,4 +17,11 @@ export interface GrainRuntime {
   getStreamProvider(name?: string): StreamProvider;
   deactivateOnIdle(): void;
   delayDeactivation(by: Duration): void;
+  /**
+   * Request that this activation migrate to another silo the next time it goes
+   * idle, carrying its in-memory state (gathered from `IGrainMigrationParticipant`s)
+   * rather than being deactivated and forgotten. Pass `targetSilo` to direct the
+   * move at a specific silo; otherwise the grain's placement strategy chooses.
+   */
+  migrateOnIdle(targetSilo?: SiloAddress): void;
 }

--- a/packages/core/src/reasons.ts
+++ b/packages/core/src/reasons.ts
@@ -4,6 +4,7 @@ export type ActivationReason = "incoming-call" | "reactivation";
 export type DeactivationReasonCode =
   | "shutting-down"
   | "idle"
+  | "migrating"
   | "application-requested"
   | "runtime-requested";
 

--- a/packages/hosting/src/migration.test.ts
+++ b/packages/hosting/src/migration.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { grain, persistentState } from "@tsva/core/decorators";
+import { Grain } from "@tsva/core/grain";
+import { GrainId } from "@tsva/core/grain-id";
+import { defineGrainInterface } from "@tsva/core/grain-interface";
+import type { GrainWithStringKey } from "@tsva/core/key-kinds";
+import type { PersistentState } from "@tsva/core/persistent-state";
+import { SiloAddress } from "@tsva/core/silo-address";
+import { FakeTimeProvider } from "@tsva/core/test-support/fake-time-provider";
+import { InProcessNetwork } from "@tsva/messaging/in-process-transport";
+import { MemoryGrainStorage } from "@tsva/persistence/memory-grain-storage";
+import { createSilo } from "@tsva/hosting/silo-builder";
+
+interface BalanceState {
+  cents: number;
+}
+
+interface IAccount extends GrainWithStringKey {
+  deposit(cents: number): Promise<number>;
+  pendingDeposit(cents: number): Promise<number>;
+  getBalance(): Promise<number>;
+  scheduleMigration(target: SiloAddress): Promise<void>;
+}
+const IAccount = defineGrainInterface<IAccount>("IAccount.migration", {
+  options: { getBalance: { readOnly: true } },
+});
+
+@grain()
+class AccountGrain extends Grain implements IAccount {
+  @persistentState("balance", { defaultValue: (): BalanceState => ({ cents: 0 }) })
+  private balance!: PersistentState<BalanceState>;
+
+  async deposit(cents: number): Promise<number> {
+    this.balance.value.cents += cents;
+    await this.balance.write();
+    return this.balance.value.cents;
+  }
+
+  /** Mutate in memory WITHOUT persisting — survives only if migration carries it. */
+  async pendingDeposit(cents: number): Promise<number> {
+    this.balance.value.cents += cents;
+    return this.balance.value.cents;
+  }
+
+  async getBalance(): Promise<number> {
+    return this.balance.value.cents;
+  }
+
+  async scheduleMigration(target: SiloAddress): Promise<void> {
+    this.runtime.migrateOnIdle(target);
+  }
+}
+
+const silo = (n: number) => new SiloAddress(`silo-${n}`, `uid-${n}`, `silo-${n}:11111`);
+const accountId = new GrainId("Account", "acc-1");
+
+function buildSilo(
+  local: SiloAddress,
+  network: InProcessNetwork,
+  storage: MemoryGrainStorage,
+  time: FakeTimeProvider,
+) {
+  return createSilo({
+    clusterId: "c-migration",
+    local,
+    time,
+    collectionAgeSeconds: 30,
+    collectionIntervalSeconds: 10,
+    random: () => 0,
+  })
+    .useStaticMembership([silo(0), silo(1)])
+    .useInProcessTransport(network)
+    .useMemoryStorage(storage)
+    .registerGrain(AccountGrain, { interfaces: [IAccount] })
+    .build();
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+async function settleUntil(pred: () => boolean, max = 200): Promise<void> {
+  for (let i = 0; i < max && !pred(); i++) await flush();
+  await flush();
+}
+
+describe("persistent-state migration (hosting)", () => {
+  it("migrates a grain to another silo carrying even its unflushed persistent state", async () => {
+    const network = new InProcessNetwork();
+    const storage = new MemoryGrainStorage();
+    const time = new FakeTimeProvider();
+    const node0 = buildSilo(silo(0), network, storage, time);
+    const node1 = buildSilo(silo(1), network, storage, time);
+    await node0.start();
+    await node1.start();
+    try {
+      // random->0 places the account on silo-0. Persist 100, then add 50 in memory only.
+      expect(await node0.getGrain(IAccount, "acc-1").deposit(100)).toBe(100);
+      expect(await node0.getGrain(IAccount, "acc-1").pendingDeposit(50)).toBe(150);
+      expect(node0.isActive(accountId)).toBe(true);
+
+      await node0.getGrain(IAccount, "acc-1").scheduleMigration(silo(1));
+
+      time.advance(31_000);
+      await settleUntil(() => node1.isActive(accountId));
+
+      expect(node0.isActive(accountId)).toBe(false);
+      expect(node1.isActive(accountId)).toBe(true);
+
+      // The unflushed 150 survives: it was carried in the bag, not re-read from
+      // storage (which still holds 100). This proves rehydrate skips the read.
+      expect(await node1.getGrain(IAccount, "acc-1").getBalance()).toBe(150);
+    } finally {
+      await node0.stop();
+      await node1.stop();
+    }
+  });
+});

--- a/packages/hosting/src/silo-builder.ts
+++ b/packages/hosting/src/silo-builder.ts
@@ -352,9 +352,11 @@ export class SiloBuilder {
       // Transactional facets need no storage provider in this slice, so the
       // binder always runs; persistent/reducer facets bind only when storage is
       // configured.
-      stateBinder: async (instance, grainId) => {
+      stateBinder: async (instance, grainId, mode) => {
         if (storage !== undefined) {
-          await bindPersistentStates(instance, grainId, storage);
+          // On rehydration the migrated value is restored from the bag, so bind the
+          // persistent facet without reading storage (which would clobber it).
+          await bindPersistentStates(instance, grainId, storage, { read: mode !== "rehydrate" });
           await bindReducerStates(instance, grainId, storage);
         }
         await bindTransactionalStates(instance, grainId, transactionalStorage, (manager, txId) =>

--- a/packages/messaging/src/message.ts
+++ b/packages/messaging/src/message.ts
@@ -42,7 +42,7 @@ export interface Message {
   method: string;
 
   /** Marks a system request (e.g. a directory partition operation) vs a grain call. */
-  system?: "directory" | undefined;
+  system?: "directory" | "migration" | undefined;
 
   responseKind?: ResponseKind | undefined;
   requestContext?: RequestContext | undefined;

--- a/packages/persistence/src/persistent-state-impl.ts
+++ b/packages/persistence/src/persistent-state-impl.ts
@@ -1,4 +1,9 @@
 import type { GrainId } from "@tsva/core/grain-id";
+import type {
+  DehydrationContext,
+  IGrainMigrationParticipant,
+  RehydrationContext,
+} from "@tsva/core/grain-migration-participant";
 import type { GrainStorage, StateHolder } from "@tsva/core/grain-storage";
 import type { PersistentState } from "@tsva/core/persistent-state";
 
@@ -6,8 +11,12 @@ import type { PersistentState } from "@tsva/core/persistent-state";
  * Binds a named state to a grain identity and a storage provider. Keeps the
  * state in memory between writes (reads are served without touching the store)
  * and carries the etag for optimistic concurrency.
+ *
+ * Participates in grain migration: its in-memory value and etag travel in the
+ * migration bag so a moved activation keeps even unflushed state and skips the
+ * storage read on the target.
  */
-export class PersistentStateImpl<T> implements PersistentState<T> {
+export class PersistentStateImpl<T> implements PersistentState<T>, IGrainMigrationParticipant {
   private readonly holder: StateHolder<T>;
 
   constructor(
@@ -49,5 +58,26 @@ export class PersistentStateImpl<T> implements PersistentState<T> {
   async clear(): Promise<void> {
     await this.storage.clear(this.stateName, this.grainId, this.holder);
     this.holder.value = this.defaultValue();
+  }
+
+  private get migrationKey(): string {
+    return `persistentState:${this.stateName}`;
+  }
+
+  onDehydrate(context: DehydrationContext): void {
+    context.set(this.migrationKey, {
+      value: this.holder.value,
+      etag: this.holder.etag,
+      exists: this.holder.exists,
+    });
+  }
+
+  onRehydrate(context: RehydrationContext): void {
+    const snapshot = context.get<{ value: T; etag?: string; exists: boolean }>(this.migrationKey);
+    if (snapshot === undefined) return;
+    this.holder.value = snapshot.value;
+    this.holder.exists = snapshot.exists;
+    if (snapshot.etag !== undefined) this.holder.etag = snapshot.etag;
+    else delete this.holder.etag;
   }
 }

--- a/packages/persistence/src/persistent-state-migration.test.ts
+++ b/packages/persistence/src/persistent-state-migration.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { GrainId } from "@tsva/core/grain-id";
+import type { GrainStorage } from "@tsva/core/grain-storage";
+import { MigrationBag } from "@tsva/core/grain-migration-participant";
+import { MemoryGrainStorage } from "@tsva/persistence/memory-grain-storage";
+import { PersistentStateImpl } from "@tsva/persistence/persistent-state-impl";
+
+interface Balance {
+  cents: number;
+}
+
+const id = new GrainId("Account", "a1");
+const makeState = (storage: GrainStorage, name = "balance") =>
+  new PersistentStateImpl<Balance>(name, id, storage, () => ({ cents: 0 }));
+
+describe("PersistentState migration participation", () => {
+  it("carries in-memory value and etag through the bag, even when unflushed", async () => {
+    const storage = new MemoryGrainStorage();
+    const source = makeState(storage);
+    source.value.cents = 100;
+    await source.write(); // establishes an etag
+    source.value.cents = 250; // mutate again WITHOUT writing
+
+    const bag = new MigrationBag();
+    source.onDehydrate(bag);
+
+    // A fresh facet on the "target" bound without reading storage restores the
+    // unflushed value and the source's etag from the bag.
+    const target = makeState(storage);
+    target.onRehydrate(new MigrationBag(bag.data));
+    expect(target.value.cents).toBe(250);
+    expect(target.exists).toBe(true);
+    expect(target.etag).toBe(source.etag);
+  });
+
+  it("leaves the facet untouched when the bag has no entry for it", () => {
+    const target = makeState(new MemoryGrainStorage());
+    target.value.cents = 7;
+    target.onRehydrate(new MigrationBag());
+    expect(target.value.cents).toBe(7);
+  });
+});

--- a/packages/persistence/src/state-activator.ts
+++ b/packages/persistence/src/state-activator.ts
@@ -9,12 +9,18 @@ const emptyDefault = () => ({});
  * Inject a `PersistentState` facet into each `@persistentState` field of a grain
  * instance and read it, before `onActivate`. Wired into the catalog by the
  * hosting layer so the runtime stays free of a persistence dependency.
+ *
+ * Pass `{ read: false }` on the migration-rehydration path: the facet is bound but
+ * not read, so the migrated value restored from the bag (via `onRehydrate`) is not
+ * overwritten by stale storage.
  */
 export async function bindPersistentStates(
   instance: object,
   grainId: GrainId,
   registry: StorageRegistry,
+  opts: { read?: boolean } = {},
 ): Promise<void> {
+  const read = opts.read ?? true;
   for (const field of getPersistentFields(instance)) {
     const storage = registry.get(field.provider);
     const state = new PersistentStateImpl(
@@ -24,6 +30,6 @@ export async function bindPersistentStates(
       field.defaultValue ?? emptyDefault,
     );
     (instance as Record<string, unknown>)[field.fieldName] = state;
-    await state.read();
+    if (read) await state.read();
   }
 }

--- a/packages/runtime/src/activation.migration.test.ts
+++ b/packages/runtime/src/activation.migration.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { RejectionError } from "@tsva/core/errors";
+import { Grain } from "@tsva/core/grain";
+import { GrainId } from "@tsva/core/grain-id";
+import type {
+  DehydrationContext,
+  RehydrationContext,
+} from "@tsva/core/grain-migration-participant";
+import type { InvocationRequest } from "@tsva/core/request";
+import { SiloAddress } from "@tsva/core/silo-address";
+import { ActivationData } from "@tsva/runtime/activation";
+import { FakeTimeProvider } from "@tsva/runtime/test-support/fake-time-provider";
+
+class MigratableGrain extends Grain {
+  count = 0;
+  onDehydrate(ctx: DehydrationContext): void {
+    ctx.set("count", this.count);
+  }
+  onRehydrate(ctx: RehydrationContext): void {
+    const c = ctx.get<number>("count");
+    if (c !== undefined) this.count = c;
+  }
+  async bump(by: number): Promise<number> {
+    this.count += by;
+    return this.count;
+  }
+}
+
+const id = new GrainId("Counter", "a");
+const silo = new SiloAddress("silo-1", "uid-1", "silo-1:1");
+
+function makeActivation(count: number): { activation: ActivationData; grain: MigratableGrain } {
+  const activation = new ActivationData(id, new FakeTimeProvider(), 30_000, false, "act-1");
+  const grain = new MigratableGrain();
+  grain.setContext(activation);
+  grain.count = count;
+  activation.instance = grain;
+  activation.beginActivate("incoming-call");
+  return { activation, grain };
+}
+
+const bump = (by: number): InvocationRequest => ({
+  target: id,
+  interfaceId: 0,
+  method: "bump",
+  args: [by],
+  options: {},
+  reentrancyId: "r1",
+});
+
+describe("activation migration mechanics", () => {
+  it("records a migration request and the directed target", () => {
+    const { activation } = makeActivation(0);
+    expect(activation.wantsMigration).toBe(false);
+    activation.requestMigration(silo);
+    expect(activation.wantsMigration).toBe(true);
+    expect(activation.migrationTarget?.equals(silo)).toBe(true);
+  });
+
+  it("dehydrates in-memory state into the bag via onDehydrate", async () => {
+    const { activation } = makeActivation(5);
+    const bag = await activation.dehydrate();
+    expect(bag).toEqual({ count: 5 });
+  });
+
+  it("rejects calls after dehydration as stale, so they re-resolve to the new host", async () => {
+    const { activation } = makeActivation(5);
+    await activation.dehydrate();
+    await expect(activation.invoke(bump(1))).rejects.toMatchObject({
+      name: "RejectionError",
+      kind: "noActivation",
+    });
+    await expect(activation.invoke(bump(1))).rejects.toBeInstanceOf(RejectionError);
+  });
+
+  it("restores migrated state through applyRehydration", () => {
+    const { activation, grain } = makeActivation(0);
+    activation.rehydrationBag = { count: 9 };
+    activation.applyRehydration();
+    expect(grain.count).toBe(9);
+  });
+});

--- a/packages/runtime/src/activation.ts
+++ b/packages/runtime/src/activation.ts
@@ -1,12 +1,15 @@
 import { newActivationId, type ActivationId } from "@tsva/core/activation-id";
 import type { Duration } from "@tsva/core/duration";
-import { GrainCallError } from "@tsva/core/errors";
+import { GrainCallError, RejectionError } from "@tsva/core/errors";
 import type { Grain } from "@tsva/core/grain";
 import type { GrainContext } from "@tsva/core/grain-context";
 import type { GrainId } from "@tsva/core/grain-id";
+import { MigrationBag } from "@tsva/core/grain-migration-participant";
 import type { GrainRuntime } from "@tsva/core/grain-runtime";
 import type { GrainTimer } from "@tsva/core/grain-timer";
 import type { ActivationReason, DeactivationReason } from "@tsva/core/reasons";
+import type { SiloAddress } from "@tsva/core/silo-address";
+import { migrationParticipantsOf } from "@tsva/runtime/migration-participants";
 import { getGrainInterface } from "@tsva/core/grain-interface";
 import {
   grainIncomingFilter,
@@ -45,9 +48,16 @@ export class ActivationData implements GrainContext {
   /** Incoming grain-call filters wrapping each grain-method dispatch; set by the catalog. */
   incomingCallFilters: readonly IncomingGrainCallFilter[] = [];
 
+  /** When migrating: the directed target silo (undefined lets placement choose). */
+  migrationTarget: SiloAddress | undefined;
+  /** State captured on the source silo to restore on the target; set by the catalog. */
+  rehydrationBag: Record<string, unknown> | undefined;
+
   private lastActiveMs: number;
   private keepAliveUntilMs = 0;
   private deactivateRequested = false;
+  private migrationRequested = false;
+  private dehydrated = false;
   private readonly timers = new Set<GrainTimerImpl>();
   /** Handlers for pulling-agent stream delivery, keyed by `namespace/key`. */
   private readonly streamHandlers = new Map<string, StreamHandler<unknown>>();
@@ -92,6 +102,11 @@ export class ActivationData implements GrainContext {
         run: () => {
           if (this.state === "invalid" || this.state === "deactivating") {
             throw new GrainCallError(`activation unavailable: ${this.id.toString()}`);
+          }
+          // Dehydrated for migration: the directory now points at the new host, so
+          // reject as stale and let the caller re-resolve there.
+          if (this.dehydrated) {
+            throw new RejectionError(`activation migrated: ${this.id.toString()}`, "noActivation");
           }
           return invocationContext.run(
             {
@@ -156,6 +171,46 @@ export class ActivationData implements GrainContext {
 
   delayDeactivation(byMs: number): void {
     this.keepAliveUntilMs = Math.max(this.keepAliveUntilMs, this.time.now() + byMs);
+  }
+
+  /** Mark this activation to migrate (rather than deactivate) when next idle. */
+  requestMigration(target?: SiloAddress): void {
+    this.migrationRequested = true;
+    this.migrationTarget = target;
+  }
+
+  get wantsMigration(): boolean {
+    return this.migrationRequested;
+  }
+
+  /**
+   * Gather the activation's in-memory state into a transport-safe bag by running
+   * each migration participant's `onDehydrate` on a turn. Marks the activation
+   * dehydrated so no further calls run here — they re-resolve to the new host.
+   */
+  async dehydrate(): Promise<Record<string, unknown>> {
+    const bag = new MigrationBag();
+    await this.scheduler.schedule({
+      options: {},
+      reentrancyId: this.activationId,
+      run: () => {
+        for (const participant of migrationParticipantsOf(this.instance)) {
+          participant.onDehydrate(bag);
+        }
+        this.dehydrated = true;
+        return Promise.resolve();
+      },
+    });
+    return bag.data;
+  }
+
+  /** Restore migrated state into the (freshly bound) participants on the target. */
+  applyRehydration(): void {
+    if (this.rehydrationBag === undefined) return;
+    const ctx = new MigrationBag(this.rehydrationBag);
+    for (const participant of migrationParticipantsOf(this.instance)) {
+      participant.onRehydrate(ctx);
+    }
   }
 
   isStale(): boolean {

--- a/packages/runtime/src/catalog.ts
+++ b/packages/runtime/src/catalog.ts
@@ -24,8 +24,18 @@ export interface CatalogOptions {
   defaultCollectionAgeSeconds: number;
   /** Called after an activation has been deactivated (idle collection or shutdown). */
   onDeactivated?: (activation: ActivationData) => void;
-  /** Bind/read persistent state before `onActivate` (provided by the hosting layer). */
-  activateState?: (instance: Grain, grainId: GrainId) => Promise<void>;
+  /**
+   * Bind state before `onActivate` (provided by the hosting layer). In `"activate"`
+   * mode it reads from storage; in `"rehydrate"` mode it binds the facets without
+   * reading, so migrated state restored from the bag is not clobbered.
+   */
+  activateState?: (
+    instance: Grain,
+    grainId: GrainId,
+    mode?: "activate" | "rehydrate",
+  ) => Promise<void>;
+  /** Migrate an idle activation to another silo; resolves to whether it moved. */
+  migrate?: (activation: ActivationData) => Promise<boolean>;
   /** Resolves the reminder registry a grain's `registerReminder` delegates to. */
   reminderRegistry?: () => ReminderRegistry | undefined;
   /** Resolves the stream provider a grain's `getStreamProvider` returns. */
@@ -61,6 +71,23 @@ export class Catalog {
     return created;
   }
 
+  /**
+   * Migration path: create an activation that restores its state from `bag` (via
+   * each participant's `onRehydrate`) instead of reading storage, with the
+   * activation id the source silo chose for the move.
+   */
+  activateMigrated(
+    id: GrainId,
+    activationId: string,
+    bag: Record<string, unknown>,
+  ): ActivationData {
+    const existing = this.activations.get(id.toString());
+    if (existing !== undefined && existing.state !== "invalid") return existing;
+    const created = this.create(id, activationId, bag);
+    this.activations.set(id.toString(), created);
+    return created;
+  }
+
   get(id: GrainId): ActivationData | undefined {
     return this.activations.get(id.toString());
   }
@@ -76,7 +103,11 @@ export class Catalog {
     return n;
   }
 
-  private create(id: GrainId, activationId?: string): ActivationData {
+  private create(
+    id: GrainId,
+    activationId?: string,
+    rehydrationBag?: Record<string, unknown>,
+  ): ActivationData {
     const reg = this.options.grainTypes.get(id.type);
     if (reg === undefined) throw new GrainCallError(`no grain type registered: ${id.type}`);
     const ageSeconds =
@@ -103,17 +134,37 @@ export class Catalog {
       activation.incomingCallFilters = this.options.incomingCallFilters;
     }
     const activateState = this.options.activateState;
-    if (activateState !== undefined) {
-      activation.preActivate = () => activateState(instance, id);
+    if (rehydrationBag !== undefined) {
+      activation.rehydrationBag = rehydrationBag;
+      activation.preActivate = async () => {
+        if (activateState !== undefined) await activateState(instance, id, "rehydrate");
+        activation.applyRehydration();
+      };
+      activation.beginActivate("reactivation");
+    } else {
+      if (activateState !== undefined) {
+        activation.preActivate = () => activateState(instance, id);
+      }
+      activation.beginActivate("incoming-call");
     }
-    activation.beginActivate("incoming-call");
     return activation;
   }
 
   async collectIdle(): Promise<void> {
     for (const [key, activation] of this.activations) {
       if (activation.isStale()) {
-        await activation.deactivate({ code: "idle", description: "idle collection" });
+        // A grain that asked to migrate moves to another silo first (flipping the
+        // directory); then the local activation is deactivated either way — its
+        // address-matched directory unregister is a no-op once the entry moved.
+        const moved =
+          activation.wantsMigration && this.options.migrate !== undefined
+            ? await this.options.migrate(activation)
+            : false;
+        await activation.deactivate(
+          moved
+            ? { code: "migrating", description: "migrated to another silo" }
+            : { code: "idle", description: "idle collection" },
+        );
       }
       if (activation.state === "invalid") {
         this.activations.delete(key);

--- a/packages/runtime/src/cluster-node.ts
+++ b/packages/runtime/src/cluster-node.ts
@@ -1,6 +1,7 @@
+import { newActivationId } from "@tsva/core/activation-id";
 import { GrainCallError, RejectionError } from "@tsva/core/errors";
 import type { Grain } from "@tsva/core/grain";
-import type { GrainAddress } from "@tsva/core/grain-address";
+import { grainAddressEquals, type GrainAddress } from "@tsva/core/grain-address";
 import type { GrainId } from "@tsva/core/grain-id";
 import type { GrainInterface } from "@tsva/core/grain-interface";
 import { getGrainInterface } from "@tsva/core/grain-interface";
@@ -40,9 +41,13 @@ import { Catalog, type RegisteredGrain } from "@tsva/runtime/catalog";
 import type { ActivationData } from "@tsva/runtime/activation";
 import { DistributedDispatcher } from "@tsva/runtime/distributed-dispatcher";
 import { GrainFactory } from "@tsva/runtime/grain-factory";
+import { chooseMigrationTarget } from "@tsva/runtime/placement/choose-migration-target";
 import { placementStrategyFor } from "@tsva/runtime/placement/placement-director";
 import { RandomPlacement } from "@tsva/runtime/placement/random-placement";
-import type { PlacementStrategy } from "@tsva/runtime/placement/placement-strategy";
+import type {
+  PlacementContext,
+  PlacementStrategy,
+} from "@tsva/runtime/placement/placement-strategy";
 import { systemTimeProvider, type TimeProvider } from "@tsva/runtime/time-provider";
 import { TransactionAgent } from "@tsva/runtime/transaction-agent";
 
@@ -59,8 +64,15 @@ export interface ClusterNodeOptions {
   defaultCollectionAgeSeconds?: number;
   /** How often the idle-collection sweep runs (defaults to 60s). */
   collectionIntervalSeconds?: number;
-  /** Bind/read persistent state before `onActivate` (provided by the hosting layer). */
-  stateBinder?: (instance: Grain, grainId: GrainId) => Promise<void>;
+  /**
+   * Bind state before `onActivate` (provided by the hosting layer). `"rehydrate"`
+   * mode binds facets without reading storage so migrated state is preserved.
+   */
+  stateBinder?: (
+    instance: Grain,
+    grainId: GrainId,
+    mode?: "activate" | "rehydrate",
+  ) => Promise<void>;
   /** Resolves the reminder registry a grain's `registerReminder` delegates to. */
   reminderRegistry?: () => ReminderRegistry | undefined;
   /** Resolves the stream provider a grain's `getStreamProvider` returns. */
@@ -86,6 +98,13 @@ type DirectoryOp =
 
 function directoryOpGrainId(op: DirectoryOp): GrainId {
   return op.kind === "lookup" ? op.grainId : op.addr.grainId;
+}
+
+/** Carries a migrating activation's identity and dehydrated state to its new host. */
+interface MigrationPayload {
+  grainId: GrainId;
+  sourceAddr: GrainAddress;
+  bag: Record<string, unknown>;
 }
 
 const newChainId = () => Guid.newGuid().toString();
@@ -145,6 +164,7 @@ export class ClusterNode {
       time,
       defaultCollectionAgeSeconds: options.defaultCollectionAgeSeconds ?? 900,
       onDeactivated: (a) => this.onDeactivated(a),
+      migrate: (a) => this.migrateActivation(a),
       ...(options.stateBinder !== undefined ? { activateState: options.stateBinder } : {}),
       ...(options.reminderRegistry !== undefined
         ? { reminderRegistry: options.reminderRegistry }
@@ -324,6 +344,107 @@ export class ClusterNode {
     this.cache.invalidate(activation.id);
   }
 
+  // --- migration ---
+
+  /**
+   * Move an idle activation to another silo with its state preserved: pick the
+   * target (directed or via placement), dehydrate, and ask the target to take it
+   * over (which flips the directory by CAS). Returns whether the move succeeded;
+   * on any failure the caller falls back to plain deactivation.
+   */
+  private async migrateActivation(activation: ActivationData): Promise<boolean> {
+    try {
+      const candidates = activeSilos(this.options.membership.current());
+      const context: PlacementContext = {
+        localSilo: this.options.local,
+        activationCount: (silo) => (silo.equals(this.options.local) ? this.catalog.count() : 0),
+        random: this.options.random ?? Math.random,
+      };
+      const target = chooseMigrationTarget(
+        activation.id.type,
+        activation.migrationTarget,
+        candidates,
+        this.placementFor(activation.id.type),
+        context,
+      );
+      if (target === undefined) return false;
+      const bag = await activation.dehydrate();
+      const sourceAddr: GrainAddress = {
+        grainId: activation.id,
+        silo: this.options.local,
+        activationId: activation.activationId,
+      };
+      const accepted = await this.sendMigration(target, {
+        grainId: activation.id,
+        sourceAddr,
+        bag,
+      });
+      // The directory now points at the new host; drop our stale cache entry.
+      if (accepted) this.cache.invalidate(activation.id);
+      return accepted;
+    } catch {
+      return false;
+    }
+  }
+
+  private async sendMigration(target: SiloAddress, payload: MigrationPayload): Promise<boolean> {
+    const conn = await this.connections.get(target);
+    const correlationId = nextCorrelationId();
+    const message: Message = {
+      correlationId,
+      direction: "request",
+      system: "migration",
+      targetGrain: payload.grainId,
+      sendingSilo: this.options.local,
+      interfaceId: 0,
+      method: "",
+      body: this.serializer.serialize(payload),
+    };
+    const pending = this.correlation.register(correlationId, this.callTimeoutMs);
+    conn.send(message);
+    return this.interpretResponse(await pending) as boolean;
+  }
+
+  private async handleMigration(message: Message): Promise<void> {
+    const replyTo = message.sendingSilo;
+    if (replyTo === undefined) return;
+    try {
+      const payload = this.serializer.deserialize<MigrationPayload>(message.body);
+      const accepted = await this.acceptMigration(payload);
+      await this.reply(
+        replyTo,
+        responseTo(message, "success", this.serializer.serialize(accepted), this.options.local),
+      );
+    } catch (err) {
+      const body = this.serializer.serialize({
+        message: err instanceof Error ? err.message : String(err),
+      });
+      await this.reply(replyTo, responseTo(message, "error", body, this.options.local));
+    }
+  }
+
+  /** Take over a migrating activation here, rehydrating its state and claiming the directory entry. */
+  private async acceptMigration(payload: MigrationPayload): Promise<boolean> {
+    const activation = this.catalog.activateMigrated(
+      payload.grainId,
+      newActivationId(),
+      payload.bag,
+    );
+    const newAddr: GrainAddress = {
+      grainId: payload.grainId,
+      silo: this.options.local,
+      activationId: activation.activationId,
+    };
+    const winner = await this.directory.register(newAddr, payload.sourceAddr);
+    this.cache.put(winner);
+    if (!grainAddressEquals(winner, newAddr)) {
+      // Another silo moved or activated the grain first: discard our activation.
+      await activation.deactivate({ code: "runtime-requested", description: "migration lost CAS" });
+      return false;
+    }
+    return true;
+  }
+
   // --- transport ---
 
   private async sendRemote(silo: SiloAddress, req: InvocationRequest): Promise<unknown> {
@@ -399,6 +520,10 @@ export class ClusterNode {
     }
     if (message.system === "directory") {
       void this.handleDirectoryRequest(message);
+      return;
+    }
+    if (message.system === "migration") {
+      void this.handleMigration(message);
       return;
     }
     void this.receiveRequest(message);

--- a/packages/runtime/src/grain-runtime-impl.ts
+++ b/packages/runtime/src/grain-runtime-impl.ts
@@ -4,6 +4,7 @@ import type { GrainKey } from "@tsva/core/grain-key";
 import type { GrainRuntime } from "@tsva/core/grain-runtime";
 import type { GrainTimer } from "@tsva/core/grain-timer";
 import type { ReminderRegistry } from "@tsva/core/reminder";
+import type { SiloAddress } from "@tsva/core/silo-address";
 import { isActivationBound, type StreamProvider } from "@tsva/core/stream";
 import type { ActivationData } from "@tsva/runtime/activation";
 import { ActivationStreamProvider } from "@tsva/runtime/activation-stream-provider";
@@ -59,6 +60,10 @@ export class GrainRuntimeImpl implements GrainRuntime {
 
   deactivateOnIdle(): void {
     this.activation.requestDeactivation();
+  }
+
+  migrateOnIdle(targetSilo?: SiloAddress): void {
+    this.activation.requestMigration(targetSilo);
   }
 
   delayDeactivation(by: Duration): void {

--- a/packages/runtime/src/migration-participants.ts
+++ b/packages/runtime/src/migration-participants.ts
@@ -1,0 +1,21 @@
+import {
+  isMigrationParticipant,
+  type IGrainMigrationParticipant,
+} from "@tsva/core/grain-migration-participant";
+import { getPersistentFields } from "@tsva/core/persistent-state-metadata";
+
+/**
+ * The migration participants of a grain instance: the grain itself (when it
+ * implements the migration hooks) plus each bound persistent-state facet that
+ * does. The same set is asked to dehydrate on the source silo and rehydrate on
+ * the target, so the activation's in-memory state moves with it.
+ */
+export function migrationParticipantsOf(instance: object): IGrainMigrationParticipant[] {
+  const participants: IGrainMigrationParticipant[] = [];
+  if (isMigrationParticipant(instance)) participants.push(instance);
+  for (const field of getPersistentFields(instance)) {
+    const facet = (instance as Record<string, unknown>)[field.fieldName];
+    if (isMigrationParticipant(facet)) participants.push(facet);
+  }
+  return participants;
+}

--- a/packages/runtime/src/migration.test.ts
+++ b/packages/runtime/src/migration.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { grain } from "@tsva/core/decorators";
+import { Grain } from "@tsva/core/grain";
+import { GrainId } from "@tsva/core/grain-id";
+import { defineGrainInterface } from "@tsva/core/grain-interface";
+import type {
+  DehydrationContext,
+  IGrainMigrationParticipant,
+  RehydrationContext,
+} from "@tsva/core/grain-migration-participant";
+import type { GrainWithStringKey } from "@tsva/core/key-kinds";
+import type { MembershipService } from "@tsva/core/membership";
+import { SiloAddress } from "@tsva/core/silo-address";
+import { InProcessNetwork, InProcessTransport } from "@tsva/messaging/in-process-transport";
+import { ClusterNode } from "@tsva/runtime/cluster-node";
+import { Silo } from "@tsva/runtime/silo";
+import { StaticMembershipService } from "@tsva/runtime/static-membership";
+import { FakeTimeProvider } from "@tsva/runtime/test-support/fake-time-provider";
+
+interface IMigratingCounter extends GrainWithStringKey {
+  increment(by: number): Promise<number>;
+  get(): Promise<number>;
+  scheduleMigration(target?: SiloAddress): Promise<void>;
+}
+const IMigratingCounter = defineGrainInterface<IMigratingCounter>("IMigratingCounter.migration", {
+  options: { get: { readOnly: true } },
+});
+
+@grain()
+class MigratingCounterGrain extends Grain implements IMigratingCounter, IGrainMigrationParticipant {
+  private count = 0;
+
+  async increment(by: number): Promise<number> {
+    this.count += by;
+    return this.count;
+  }
+
+  async get(): Promise<number> {
+    return this.count;
+  }
+
+  async scheduleMigration(target?: SiloAddress): Promise<void> {
+    this.runtime.migrateOnIdle(target);
+  }
+
+  onDehydrate(ctx: DehydrationContext): void {
+    ctx.set("count", this.count);
+  }
+
+  onRehydrate(ctx: RehydrationContext): void {
+    const c = ctx.get<number>("count");
+    if (c !== undefined) this.count = c;
+  }
+}
+
+const CLUSTER = "c-migration";
+const silo = (n: number) => new SiloAddress(`silo-${n}`, `uid-${n}`, `silo-${n}:11111`);
+const grainId = new GrainId("MigratingCounter", "x");
+
+class MembershipView implements MembershipService {
+  constructor(
+    private readonly shared: StaticMembershipService,
+    private readonly local: SiloAddress,
+  ) {}
+  current() {
+    return this.shared.current();
+  }
+  updates() {
+    return this.shared.updates();
+  }
+  localSilo() {
+    return this.local;
+  }
+}
+
+function buildCluster(count: number, time: FakeTimeProvider) {
+  const network = new InProcessNetwork();
+  const addresses = Array.from({ length: count }, (_, i) => silo(i));
+  const membership = new StaticMembershipService(addresses[0]!, addresses);
+  const nodes = addresses.map((local) => {
+    const node = new ClusterNode({
+      local,
+      clusterId: CLUSTER,
+      membership: new MembershipView(membership, local),
+      transport: new InProcessTransport(network, CLUSTER),
+      time,
+      defaultCollectionAgeSeconds: 30,
+      collectionIntervalSeconds: 10,
+      random: () => 0, // deterministic placement -> first candidate (silo-0)
+    });
+    node.registerGrain(MigratingCounterGrain, { interfaces: [IMigratingCounter] });
+    return node;
+  });
+  return {
+    nodes,
+    hostsOf: () => nodes.filter((n) => n.isActive(grainId)),
+    start: async () => {
+      for (const n of nodes) await n.start();
+    },
+    stop: async () => {
+      for (const n of nodes) await n.stop();
+    },
+  };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+async function settleUntil(pred: () => boolean, max = 200): Promise<void> {
+  for (let i = 0; i < max && !pred(); i++) await flush();
+  await flush();
+}
+
+describe("grain migration (multi-silo)", () => {
+  it("migrates an idle activation to a directed silo, preserving its state", async () => {
+    const time = new FakeTimeProvider();
+    const cluster = buildCluster(3, time);
+    await cluster.start();
+    try {
+      // random->0 places the grain on silo-0; mutate its in-memory state there.
+      expect(await cluster.nodes[1]!.getGrain(IMigratingCounter, "x").increment(5)).toBe(5);
+      expect(cluster.hostsOf()).toEqual([cluster.nodes[0]]);
+
+      // Ask it to migrate to silo-1 once idle.
+      await cluster.nodes[1]!.getGrain(IMigratingCounter, "x").scheduleMigration(silo(1));
+
+      // The collector sweep past the collection age migrates rather than collects.
+      time.advance(31_000);
+      await settleUntil(() => cluster.nodes[1]!.isActive(grainId));
+
+      expect(cluster.nodes[0]!.isActive(grainId)).toBe(false);
+      expect(cluster.hostsOf()).toEqual([cluster.nodes[1]]);
+
+      // State survived the move: the new host reports the accumulated count.
+      expect(await cluster.nodes[2]!.getGrain(IMigratingCounter, "x").get()).toBe(5);
+    } finally {
+      await cluster.stop();
+    }
+  });
+
+  it("migrates to a strategy-chosen silo (other than the current host) when undirected", async () => {
+    const time = new FakeTimeProvider();
+    const cluster = buildCluster(3, time);
+    await cluster.start();
+    try {
+      await cluster.nodes[1]!.getGrain(IMigratingCounter, "x").increment(8);
+      expect(cluster.hostsOf()).toEqual([cluster.nodes[0]]);
+
+      // No target: placement picks among the *other* silos (random->0 => silo-1).
+      await cluster.nodes[1]!.getGrain(IMigratingCounter, "x").scheduleMigration();
+
+      time.advance(31_000);
+      await settleUntil(
+        () => !cluster.nodes[0]!.isActive(grainId) && cluster.hostsOf().length === 1,
+      );
+
+      const hosts = cluster.hostsOf();
+      expect(hosts).toHaveLength(1);
+      expect(hosts[0]).not.toBe(cluster.nodes[0]);
+      expect(await hosts[0]!.getGrain(IMigratingCounter, "x").get()).toBe(8);
+    } finally {
+      await cluster.stop();
+    }
+  });
+
+  it("falls back to plain idle deactivation on a single silo (nowhere to migrate)", async () => {
+    const time = new FakeTimeProvider();
+    const host = new Silo({ time, defaultCollectionAgeSeconds: 30, collectionIntervalSeconds: 10 });
+    host.registerGrain(MigratingCounterGrain, { interfaces: [IMigratingCounter] });
+    host.start();
+    try {
+      const counter = host.getGrain(IMigratingCounter, "y");
+      await counter.increment(3);
+      await counter.scheduleMigration();
+      const id = new GrainId("MigratingCounter", "y");
+      expect(host.isActive(id)).toBe(true);
+
+      time.advance(31_000);
+      await flush();
+
+      // No migrate hook on a single silo: it simply deactivates and reactivates fresh.
+      expect(host.isActive(id)).toBe(false);
+      expect(await counter.get()).toBe(0);
+    } finally {
+      await host.stop();
+    }
+  });
+});

--- a/packages/runtime/src/placement/choose-migration-target.test.ts
+++ b/packages/runtime/src/placement/choose-migration-target.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { SiloAddress } from "@tsva/core/silo-address";
+import { chooseMigrationTarget } from "@tsva/runtime/placement/choose-migration-target";
+import type { PlacementContext } from "@tsva/runtime/placement/placement-strategy";
+import { RandomPlacement } from "@tsva/runtime/placement/random-placement";
+
+const silo = (n: number) => new SiloAddress(`silo-${n}`, `uid-${n}`, `silo-${n}:1`);
+const candidates = [silo(0), silo(1), silo(2)];
+const strategy = new RandomPlacement();
+// random -> 0 picks the first of the "others" list (which excludes the local silo).
+const ctx = (local: SiloAddress): PlacementContext => ({ localSilo: local, random: () => 0 });
+
+describe("chooseMigrationTarget", () => {
+  it("honours a directed target that is a live, non-local candidate", () => {
+    const target = chooseMigrationTarget("Counter", silo(2), candidates, strategy, ctx(silo(0)));
+    expect(target?.ringKey).toBe("silo-2");
+  });
+
+  it("falls back to the strategy (over other silos) when the directed target is dead", () => {
+    const target = chooseMigrationTarget("Counter", silo(9), candidates, strategy, ctx(silo(0)));
+    expect(target?.ringKey).toBe("silo-1"); // others = [silo-1, silo-2], random->0 picks silo-1
+  });
+
+  it("never returns the local silo (it is excluded from the strategy candidates)", () => {
+    const target = chooseMigrationTarget("Counter", undefined, candidates, strategy, ctx(silo(0)));
+    expect(target?.ringKey).toBe("silo-1");
+    expect(target?.equals(silo(0))).toBe(false);
+  });
+
+  it("ignores a directed target that is the local silo and uses the strategy", () => {
+    const target = chooseMigrationTarget("Counter", silo(0), candidates, strategy, ctx(silo(0)));
+    expect(target?.ringKey).toBe("silo-1");
+  });
+
+  it("returns undefined when the local silo is the only candidate", () => {
+    expect(
+      chooseMigrationTarget("Counter", undefined, [silo(0)], strategy, ctx(silo(0))),
+    ).toBeUndefined();
+    expect(
+      chooseMigrationTarget("Counter", silo(1), [silo(0)], strategy, ctx(silo(0))),
+    ).toBeUndefined();
+  });
+});

--- a/packages/runtime/src/placement/choose-migration-target.ts
+++ b/packages/runtime/src/placement/choose-migration-target.ts
@@ -1,0 +1,32 @@
+import type { GrainType } from "@tsva/core/grain-type";
+import type { SiloAddress } from "@tsva/core/silo-address";
+import type {
+  PlacementContext,
+  PlacementStrategy,
+} from "@tsva/runtime/placement/placement-strategy";
+
+/**
+ * Pick where a migrating activation should go. If a `directed` silo is named and
+ * it is a live candidate other than the local silo, honour it (directed
+ * placement). Otherwise let the grain's placement strategy choose among the other
+ * live silos. Returns `undefined` when there is nowhere to move to (the local
+ * silo is the only candidate), so the caller falls back to plain deactivation.
+ */
+export function chooseMigrationTarget(
+  grainType: GrainType,
+  directed: SiloAddress | undefined,
+  candidates: readonly SiloAddress[],
+  strategy: PlacementStrategy,
+  context: PlacementContext,
+): SiloAddress | undefined {
+  if (
+    directed !== undefined &&
+    !directed.equals(context.localSilo) &&
+    candidates.some((c) => c.equals(directed))
+  ) {
+    return directed;
+  }
+  const others = candidates.filter((c) => !c.equals(context.localSilo));
+  if (others.length === 0) return undefined;
+  return strategy.choose(grainType, others, context);
+}

--- a/todo.md
+++ b/todo.md
@@ -239,7 +239,18 @@ order, starting with transactions.
         runs innermost (after silo-wide filters, before the method); `defineGrain` installs
         symbol-keyed behaviour members so functional grains can declare it too. Hosting e2e: class +
         functional self-filter, ordering relative to a silo filter.
-- [ ] Grain migration / activation rebalancer (Orleans 10 core runtime).
+- [~] Grain migration / activation rebalancer (Orleans 10 core runtime).
+  - [x] Slice 1 — live migration on idle: `IGrainMigrationParticipant` (`onDehydrate`/`onRehydrate`)
+        in core; `runtime.migrateOnIdle(targetSilo?)`; the idle-collection sweep moves a migrating
+        activation to another silo (directed via `chooseMigrationTarget`, else placement strategy over
+        other silos) instead of deactivating it. The source dehydrates on a turn and rejects further
+        calls as stale; the target rehydrates and claims the directory entry via CAS
+        (`register(newAddr, sourceAddr)`); `@persistentState` facets auto-participate (value+etag move
+        in the bag, target skips the storage read). Unit (participant guard/bag, directed target
+        choice, dehydrate/reject-after) + multi-silo e2e (directed + strategy-chosen, single-silo
+        fallback) + hosting e2e (unflushed persistent state preserved across the move).
+  - [ ] Activation rebalancer (`IActivationRebalancer`) — proactively rebalance activations across
+        silos (Orleans 10 `Orleans.Runtime/Placement/Rebalancing/*`).
 - [ ] Grain-interface versioning — multiple interface versions live at once for heterogeneous rolling
       upgrades, with version-aware placement (Orleans' versioning).
 - [ ] Implicit stream subscriptions — bind a grain type to a namespace and auto-subscribe by key, no


### PR DESCRIPTION
Live-migrate an idle activation to another silo with its in-memory state
preserved, instead of collecting it. A grain calls runtime.migrateOnIdle(target?)
to request the move; the idle-collection sweep then dehydrates the activation on a
turn, sends it to the chosen silo (directed target, else the placement strategy
over the other silos), and the target rehydrates and claims the directory entry
via compare-and-set (register(newAddr, sourceAddr)). The source rejects further
calls as stale so they re-resolve to the new host. @persistentState facets
auto-participate, carrying value+etag in the migration bag so even unflushed state
survives and the target skips the storage read. Single silos with nowhere to move
fall back to plain idle deactivation.

https://claude.ai/code/session_01AGfyxekptiYb4uoczWwZ5a