### PR TITLE
Add placement filters and metadata-aware placement strategies

### DIFF
--- a/docs/06-grain-directory-and-placement.md
+++ b/docs/06-grain-directory-and-placement.md
@@ -150,12 +150,40 @@ Built-in strategies, each mapping onto an Orleans strategy class:
 - **Stateless-worker** — Orleans `StatelessWorkerPlacement`. Not directory-registered; each silo
   keeps its own local pool of interchangeable activations for a stateless grain type, scaling out
   CPU-bound work. Calls always resolve locally.
+- **Silo-role** — Orleans `SiloRoleBasedPlacement`. Place only on silos advertising a given role
+  (`@grain({ placement: "siloRole", role: "worker" })`); random among the matches. Roles come from
+  the silo's advertised metadata (below).
+- **Resource-optimized** — Orleans `ResourceOptimizedPlacement`. Place on the least-loaded silo by
+  activation count. The local silo's load is read from its catalog; a peer's comes from membership
+  (there is no cross-silo load gossip yet, so a peer's reported load is its membership metadata or
+  zero). Ties prefer the local silo.
 
 The directory owner itself is chosen by hashing the `GrainId` onto the ring — Orleans' equivalent is
-`HashBasedPlacement`. Orleans ships further strategies we have not ported (`SiloRoleBasedPlacement`,
-`ResourceOptimizedPlacement`) and a **placement-filter** layer (`PlacementFilterStrategy`) that
-prunes candidate silos by metadata before the strategy runs; both are parity items on the
-[roadmap](13-roadmap-and-phases.md), not yet implemented.
+`HashBasedPlacement`.
+
+### Placement filters
+
+A **placement-filter** layer (Orleans `PlacementFilterStrategy`) prunes the candidate silos *before*
+the strategy chooses among them. Filters are metadata-driven and compose — the output of one is the
+input to the next:
+
+```ts
+interface PlacementFilter {
+  filter(grainType: GrainType, candidates: SiloAddress[], context: PlacementContext): SiloAddress[];
+}
+```
+
+The shipped filter is `MetadataMatchFilter` (Orleans `PreferredMatchSiloMetadataPlacementFilter`),
+which keeps only silos whose advertised metadata defines every required key/value pair. A grain
+declares filters as serializable descriptors:
+`@grain({ placementFilters: [{ kind: "metadataMatch", match: { role: "worker" } }] })`. If filtering
+leaves no candidate, placement fails with a `noCandidates` rejection. Filters are inert for stateless
+workers (which always resolve locally and are never directory-registered).
+
+**Silo metadata** rides the membership snapshot (`SiloMember.metadata`, a string→string bag). A silo
+advertises its own via config (`metadata` on the silo builder / `ClusterNode`); under static
+membership a resolver supplies each silo's. Deriving silo metadata from Kubernetes pod labels is a
+follow-up ([roadmap](13-roadmap-and-phases.md)).
 
 A grain type selects its strategy via a decorator option, e.g. `@grain({ placement: "preferLocal" })`
 or `@grain({ stateless: true })`. A per-call **placement hint** in the request context can pin an

--- a/docs/13-roadmap-and-phases.md
+++ b/docs/13-roadmap-and-phases.md
@@ -168,10 +168,12 @@ verified.
   observability work below plugs into. **Shipped** — incoming and outgoing filters (silo-wide, via
   `addIncomingCallFilter` / `addOutgoingCallFilter`) and per-grain filters (a grain filters its own
   calls via the `INCOMING_CALL_FILTER` symbol).
-- **Placement filters** — prune the candidate silo set by metadata before a placement strategy runs
-  (Orleans' `PlacementFilterStrategy`); pairs with the additional placement strategies
-  (`SiloRoleBasedPlacement`, `ResourceOptimizedPlacement`) noted in
-  [06](06-grain-directory-and-placement.md).
+- **Placement filters** — **Shipped**. A `PlacementFilter` layer (Orleans' `PlacementFilterStrategy`)
+  prunes the candidate silo set by metadata before a placement strategy runs (`MetadataMatchFilter`),
+  alongside the `SiloRoleBasedPlacement` and `ResourceOptimizedPlacement` strategies; silo metadata
+  rides the membership snapshot (see [06](06-grain-directory-and-placement.md)). Follow-ups: derive
+  silo metadata from Kubernetes pod labels, and report remote silo load via membership gossip (today
+  a peer's resource stats are zero/metadata-only).
 - **Broadcast channels** — lightweight in-cluster pub/sub without the pulling-agent machinery
   (`Orleans.BroadcastChannel/*`, `IBroadcastChannelProvider`; Orleans 10).
 - **Durable journaling (`DurableGrain`)** — needs an ADR: Orleans 10's `Orleans.Journaling`

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -11,7 +11,8 @@ export type RejectionKind =
   | "unknownTarget"
   | "overloaded"
   | "deserialization"
-  | "noActivation";
+  | "noActivation"
+  | "noCandidates";
 
 /** A runtime-level refusal the caller can inspect to decide whether to retry. */
 export class RejectionError extends Error {

--- a/packages/core/src/grain-metadata.ts
+++ b/packages/core/src/grain-metadata.ts
@@ -1,9 +1,23 @@
 import type { GrainType } from "./grain-type";
 
+/**
+ * A serializable description of a placement filter declared on a grain. Kept inert
+ * here so `@tsva/core` need not depend on runtime placement classes; the runtime
+ * resolves it to a `PlacementFilter` instance.
+ */
+export type PlacementFilterDescriptor = {
+  kind: "metadataMatch";
+  match: Readonly<Record<string, string>>;
+};
+
 export interface GrainOptions {
   /** Override the grain type name (defaults to the class name without "Grain"). */
   name?: string;
-  placement?: "random" | "preferLocal" | "activationCount";
+  placement?: "random" | "preferLocal" | "activationCount" | "siloRole" | "resourceOptimized";
+  /** The silo role required by `placement: "siloRole"`. */
+  role?: string;
+  /** Filters that prune candidate silos by metadata before the placement strategy runs. */
+  placementFilters?: readonly PlacementFilterDescriptor[];
   stateless?: boolean;
   collectionAgeSeconds?: number;
 }

--- a/packages/core/src/membership.ts
+++ b/packages/core/src/membership.ts
@@ -5,6 +5,8 @@ export type SiloStatus = "joining" | "active" | "draining" | "dead";
 export interface SiloMember {
   address: SiloAddress;
   status: SiloStatus;
+  /** Static metadata the silo advertises (e.g. `{ role: "worker" }`), for metadata-aware placement. */
+  metadata?: Readonly<Record<string, string>>;
 }
 
 /** A versioned snapshot of the live silo set; `version` is the view number. */

--- a/packages/hosting/src/silo-builder.ts
+++ b/packages/hosting/src/silo-builder.ts
@@ -60,6 +60,8 @@ export interface SiloConfig {
   random?: () => number;
   /** How often each silo re-reads its reminder ranges from the table (defaults to 60s). */
   reminderRefreshSeconds?: number;
+  /** Static metadata this silo advertises (e.g. `{ role: "worker" }`), for metadata-aware placement. */
+  metadata?: Readonly<Record<string, string>>;
 }
 
 interface Registration {
@@ -294,8 +296,11 @@ export class SiloBuilder {
     );
   }
 
-  useStaticMembership(silos: readonly SiloAddress[]): this {
-    this.membership = new StaticMembershipService(this.config.local, silos);
+  useStaticMembership(
+    silos: readonly SiloAddress[],
+    metadata?: (silo: SiloAddress) => Readonly<Record<string, string>> | undefined,
+  ): this {
+    this.membership = new StaticMembershipService(this.config.local, silos, metadata);
     return this;
   }
 
@@ -317,6 +322,9 @@ export class SiloBuilder {
    * drain.
    */
   useKubernetesMembership(watch: EndpointWatch, options?: KubernetesMembershipOptions): this {
+    // TODO: populate SiloMember.metadata from pod labels so role/metadata-aware
+    // placement works under Kubernetes membership (deferred; static membership
+    // carries metadata today).
     this.membership = new KubernetesMembership(this.config.local, watch, options);
     const lifecycle = watch as Partial<{ start(): Promise<void>; stop(): void }>;
     if (typeof lifecycle.start === "function") {
@@ -395,6 +403,7 @@ export class SiloBuilder {
             versionSelector: this.versioning.selector ?? "latest",
           }
         : {}),
+      ...(this.config.metadata !== undefined ? { metadata: this.config.metadata } : {}),
       ...(this.incomingCallFilters.length > 0
         ? { incomingCallFilters: this.incomingCallFilters }
         : {}),

--- a/packages/runtime/src/cluster-node.ts
+++ b/packages/runtime/src/cluster-node.ts
@@ -53,7 +53,11 @@ import type { ActivationData } from "@tsva/runtime/activation";
 import { DistributedDispatcher } from "@tsva/runtime/distributed-dispatcher";
 import { GrainFactory } from "@tsva/runtime/grain-factory";
 import { chooseMigrationTarget } from "@tsva/runtime/placement/choose-migration-target";
-import { placementStrategyFor } from "@tsva/runtime/placement/placement-director";
+import {
+  placementFiltersFor,
+  placementStrategyFor,
+} from "@tsva/runtime/placement/placement-director";
+import type { PlacementFilter } from "@tsva/runtime/placement/placement-filter";
 import { RandomPlacement } from "@tsva/runtime/placement/random-placement";
 import type {
   PlacementContext,
@@ -103,6 +107,8 @@ export interface ClusterNodeOptions {
    */
   versionCompatibility?: CompatibilityKind;
   versionSelector?: VersionSelectorKind;
+  /** Static metadata the local silo advertises (e.g. `{ role: "worker" }`), for metadata-aware placement. */
+  metadata?: Readonly<Record<string, string>>;
 }
 
 interface RejectionPayload {
@@ -217,10 +223,8 @@ export class ClusterNode {
       remote: { send: (silo, req) => this.sendRemote(silo, req) },
       activeSilos: () => activeSilos(this.options.membership.current()),
       placementFor: (grainType) => this.placementFor(grainType),
-      placementContext: () => ({
-        activationCount: (silo) => (silo.equals(this.options.local) ? this.catalog.count() : 0),
-        random: this.options.random ?? Math.random,
-      }),
+      filtersFor: (grainType) => this.filtersFor(grainType),
+      placementContext: () => this.placementContext(),
       versionFilter: (req, candidates) => this.applyVersionFilter(req, candidates),
     });
     this.factory.setDispatcher(this.dispatcher);
@@ -446,6 +450,31 @@ export class ClusterNode {
     );
     this.manifestInflight.set(key, pending);
     return pending;
+  }
+
+  private filtersFor(grainType: GrainType): readonly PlacementFilter[] {
+    const reg = this.grainTypes.get(grainType);
+    return reg ? placementFiltersFor(reg.metadata) : [];
+  }
+
+  /**
+   * Placement context for the current view: activation counts, advertised silo
+   * metadata, and resource stats. The local silo's metadata and load are known
+   * directly; a peer's come from its membership entry (`resourceStats` is left
+   * undefined unless membership carries it — there is no cross-silo load gossip yet).
+   */
+  private placementContext(): Omit<PlacementContext, "localSilo"> {
+    const snapshot = this.options.membership.current();
+    const byKey = new Map(snapshot.silos.map((m) => [m.address.ringKey, m]));
+    const localMeta = this.options.metadata;
+    const isLocal = (silo: SiloAddress) => silo.equals(this.options.local);
+    return {
+      activationCount: (silo) => (isLocal(silo) ? this.catalog.count() : 0),
+      siloMetadata: (silo) => (isLocal(silo) ? localMeta : byKey.get(silo.ringKey)?.metadata),
+      resourceStats: (silo) =>
+        isLocal(silo) ? { activationCount: this.catalog.count() } : undefined,
+      random: this.options.random ?? Math.random,
+    };
   }
 
   private resolveGrainType(interfaceId: number): GrainType {

--- a/packages/runtime/src/cluster.placement.test.ts
+++ b/packages/runtime/src/cluster.placement.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { grain } from "@tsva/core/decorators";
+import { Grain } from "@tsva/core/grain";
+import { GrainId } from "@tsva/core/grain-id";
+import { defineGrainInterface } from "@tsva/core/grain-interface";
+import type { GrainWithStringKey } from "@tsva/core/key-kinds";
+import type { MembershipService } from "@tsva/core/membership";
+import { SiloAddress } from "@tsva/core/silo-address";
+import { InProcessNetwork, InProcessTransport } from "@tsva/messaging/in-process-transport";
+import { ClusterNode } from "@tsva/runtime/cluster-node";
+import { StaticMembershipService } from "@tsva/runtime/static-membership";
+
+interface IPing extends GrainWithStringKey {
+  ping(): Promise<string>;
+}
+
+// Placed only on silos advertising role "worker".
+const IWorker = defineGrainInterface<IPing>("IWorker.placement");
+@grain({ placement: "siloRole", role: "worker" })
+class WorkerGrain extends Grain implements IPing {
+  async ping(): Promise<string> {
+    return "pong";
+  }
+}
+
+// Default placement, but a metadata filter prunes to worker silos first.
+const IFiltered = defineGrainInterface<IPing>("IFiltered.placement");
+@grain({ placementFilters: [{ kind: "metadataMatch", match: { role: "worker" } }] })
+class FilteredGrain extends Grain implements IPing {
+  async ping(): Promise<string> {
+    return "pong";
+  }
+}
+
+// Lands on the least-loaded silo by activation count.
+const IBalanced = defineGrainInterface<IPing>("IBalanced.placement");
+@grain({ placement: "resourceOptimized" })
+class BalancedGrain extends Grain implements IPing {
+  async ping(): Promise<string> {
+    return "pong";
+  }
+}
+
+// preferLocal, used to seed activations on a chosen silo.
+const ISeed = defineGrainInterface<IPing>("ISeed.placement");
+@grain({ placement: "preferLocal" })
+class SeedGrain extends Grain implements IPing {
+  async ping(): Promise<string> {
+    return "pong";
+  }
+}
+
+const CLUSTER = "cp";
+const silo = (n: number) => new SiloAddress(`silo-${n}`, `uid-${n}`, `silo-${n}:11111`);
+
+class MembershipView implements MembershipService {
+  constructor(
+    private readonly shared: StaticMembershipService,
+    private readonly local: SiloAddress,
+  ) {}
+  current() {
+    return this.shared.current();
+  }
+  updates() {
+    return this.shared.updates();
+  }
+  localSilo() {
+    return this.local;
+  }
+}
+
+// silo-0 is the gateway; silo-1 and silo-2 are workers.
+const roleOf = (i: number): string => (i === 0 ? "gateway" : "worker");
+
+function buildCluster(count: number) {
+  const network = new InProcessNetwork();
+  const addresses = Array.from({ length: count }, (_, i) => silo(i));
+  const metadataFor = (s: SiloAddress) => {
+    const i = addresses.findIndex((a) => a.equals(s));
+    return i >= 0 ? { role: roleOf(i) } : undefined;
+  };
+  const membership = new StaticMembershipService(addresses[0]!, addresses, metadataFor);
+
+  const nodes = addresses.map((local, i) => {
+    const node = new ClusterNode({
+      local,
+      clusterId: CLUSTER,
+      membership: new MembershipView(membership, local),
+      transport: new InProcessTransport(network, CLUSTER),
+      random: () => 0, // deterministic: pick the first candidate
+      metadata: { role: roleOf(i) },
+    });
+    node.registerGrain(WorkerGrain, { interfaces: [IWorker] });
+    node.registerGrain(FilteredGrain, { interfaces: [IFiltered] });
+    node.registerGrain(BalancedGrain, { interfaces: [IBalanced] });
+    node.registerGrain(SeedGrain, { interfaces: [ISeed] });
+    return node;
+  });
+
+  return {
+    nodes,
+    hostsOf: (grainId: GrainId) => nodes.filter((n) => n.isActive(grainId)),
+    start: async () => {
+      for (const n of nodes) await n.start();
+    },
+    stop: async () => {
+      for (const n of nodes) await n.stop();
+    },
+  };
+}
+
+describe("metadata-aware placement across a cluster", () => {
+  it("places a siloRole grain only on a worker silo, regardless of caller", async () => {
+    const cluster = buildCluster(3);
+    await cluster.start();
+    try {
+      // Call from the gateway (silo-0); it must still land on a worker.
+      const r = await cluster.nodes[0]!.getGrain(IWorker, "w").ping();
+      expect(r).toBe("pong");
+      const hosts = cluster.hostsOf(new GrainId("Worker", "w"));
+      expect(hosts).toHaveLength(1);
+      expect(hosts[0]).toBe(cluster.nodes[1]); // random->0 over [silo-1, silo-2] => silo-1
+    } finally {
+      await cluster.stop();
+    }
+  });
+
+  it("prunes to worker silos via a metadata filter before placing", async () => {
+    const cluster = buildCluster(3);
+    await cluster.start();
+    try {
+      await cluster.nodes[0]!.getGrain(IFiltered, "f").ping();
+      const hosts = cluster.hostsOf(new GrainId("Filtered", "f"));
+      expect(hosts).toHaveLength(1);
+      // The gateway (silo-0) was filtered out; placement landed on a worker.
+      expect(hosts[0]).not.toBe(cluster.nodes[0]);
+      expect([cluster.nodes[1], cluster.nodes[2]]).toContain(hosts[0]);
+    } finally {
+      await cluster.stop();
+    }
+  });
+
+  it("avoids a loaded silo with resource-optimized placement", async () => {
+    const cluster = buildCluster(3);
+    await cluster.start();
+    try {
+      // Seed activations on silo-0 (preferLocal from node 0) so it is the loaded silo.
+      await cluster.nodes[0]!.getGrain(ISeed, "a").ping();
+      await cluster.nodes[0]!.getGrain(ISeed, "b").ping();
+      await cluster.nodes[0]!.getGrain(ISeed, "c").ping();
+
+      // A resource-optimized grain placed from the loaded node avoids silo-0.
+      await cluster.nodes[0]!.getGrain(IBalanced, "x").ping();
+      const hosts = cluster.hostsOf(new GrainId("Balanced", "x"));
+      expect(hosts).toHaveLength(1);
+      expect(hosts[0]).not.toBe(cluster.nodes[0]);
+    } finally {
+      await cluster.stop();
+    }
+  });
+});

--- a/packages/runtime/src/distributed-dispatcher.placement.test.ts
+++ b/packages/runtime/src/distributed-dispatcher.placement.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { RejectionError } from "@tsva/core/errors";
+import { GrainId } from "@tsva/core/grain-id";
+import type { InvocationRequest } from "@tsva/core/request";
+import { SiloAddress } from "@tsva/core/silo-address";
+import type { Catalog } from "@tsva/runtime/catalog";
+import type { GrainDirectory } from "@tsva/directory/grain-directory";
+import type { LocationCache } from "@tsva/directory/location-cache";
+import {
+  DistributedDispatcher,
+  type DistributedDispatcherDeps,
+} from "@tsva/runtime/distributed-dispatcher";
+import type { PlacementFilter } from "@tsva/runtime/placement/placement-filter";
+import { RandomPlacement } from "@tsva/runtime/placement/random-placement";
+
+const silo = (n: number) => new SiloAddress(`silo-${n}`, `uid-${n}`, `silo-${n}:1`);
+const local = silo(0);
+const candidates = [silo(0), silo(1), silo(2)];
+
+const request = (): InvocationRequest => ({
+  target: new GrainId("Counter", "k"),
+  interfaceId: 1,
+  method: "ping",
+  args: [],
+  options: {},
+  reentrancyId: "r",
+});
+
+/** Deps wired so a placement always misses the cache/directory and forwards remotely. */
+function deps(overrides: Partial<DistributedDispatcherDeps> = {}): {
+  deps: DistributedDispatcherDeps;
+  send: ReturnType<typeof vi.fn>;
+} {
+  const send = vi.fn().mockResolvedValue("ok");
+  return {
+    send,
+    deps: {
+      local,
+      directory: { lookup: async () => undefined } as unknown as GrainDirectory,
+      cache: {
+        get: () => undefined,
+        put: () => undefined,
+        invalidate: () => undefined,
+      } as unknown as LocationCache,
+      catalog: {} as unknown as Catalog,
+      remote: { send },
+      activeSilos: () => candidates,
+      placementFor: () => new RandomPlacement(),
+      filtersFor: () => [],
+      placementContext: () => ({ random: () => 0.9 }),
+      ...overrides,
+    },
+  };
+}
+
+/** A filter keeping only the named silo. */
+const only = (ringKey: string): PlacementFilter => ({
+  filter: (_t, cs) => cs.filter((s) => s.ringKey === ringKey),
+});
+
+describe("DistributedDispatcher placement filters", () => {
+  it("applies filters to prune candidates before the strategy chooses", async () => {
+    const { deps: d, send } = deps({ filtersFor: () => [only("silo-1")] });
+    // Random would point past silo-1, but filtering leaves only silo-1.
+    await new DistributedDispatcher(d).invoke(request());
+    expect(send).toHaveBeenCalledTimes(1);
+    expect((send.mock.calls[0]![0] as SiloAddress).ringKey).toBe("silo-1");
+  });
+
+  it("throws a noCandidates RejectionError when filtering prunes every silo", async () => {
+    const { deps: d } = deps({ filtersFor: () => [only("silo-9")] });
+    const err = await new DistributedDispatcher(d).invoke(request()).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(RejectionError);
+    expect((err as RejectionError).kind).toBe("noCandidates");
+  });
+
+  it("places via the strategy when no filters are declared", async () => {
+    const { deps: d, send } = deps(); // default random 0.9 -> silo-2 (remote)
+    await new DistributedDispatcher(d).invoke(request());
+    expect(send).toHaveBeenCalledTimes(1);
+    expect((send.mock.calls[0]![0] as SiloAddress).ringKey).toBe("silo-2");
+  });
+});

--- a/packages/runtime/src/distributed-dispatcher.ts
+++ b/packages/runtime/src/distributed-dispatcher.ts
@@ -8,6 +8,7 @@ import type { GrainDirectory } from "@tsva/directory/grain-directory";
 import type { LocationCache } from "@tsva/directory/location-cache";
 import type { Catalog } from "@tsva/runtime/catalog";
 import type { Dispatcher } from "@tsva/runtime/dispatcher";
+import type { PlacementFilter } from "@tsva/runtime/placement/placement-filter";
 import type {
   PlacementContext,
   PlacementStrategy,
@@ -26,7 +27,9 @@ export interface DistributedDispatcherDeps {
   remote: RemoteInvoker;
   activeSilos: () => SiloAddress[];
   placementFor: (grainType: GrainType) => PlacementStrategy;
-  /** Extra placement context (activation counts, RNG); `localSilo` is filled in. */
+  /** Filters that prune candidate silos by metadata before the strategy chooses. */
+  filtersFor: (grainType: GrainType) => readonly PlacementFilter[];
+  /** Extra placement context (activation counts, metadata, RNG); `localSilo` is filled in. */
   placementContext: () => Omit<PlacementContext, "localSilo">;
   /**
    * Optional version-aware pre-filter (grain-interface versioning). Wired only
@@ -99,19 +102,27 @@ export class DistributedDispatcher implements Dispatcher {
   }
 
   private async placeAndInvoke(req: InvocationRequest): Promise<unknown> {
-    const active = this.deps.activeSilos();
-    // Version-aware placement: prefer compatible silos, but fall back to the full
-    // set when none qualify (best-effort — placement never fails on version).
-    let candidates: readonly SiloAddress[] = active;
+    const ctx: PlacementContext = { localSilo: this.deps.local, ...this.deps.placementContext() };
+    // Hard metadata filters first: prune the candidate set by silo metadata; if
+    // none qualify, placement fails (the grain has a constraint nothing satisfies).
+    let candidates: readonly SiloAddress[] = this.deps.activeSilos();
+    for (const filter of this.deps.filtersFor(req.target.type)) {
+      candidates = filter.filter(req.target.type, candidates, ctx);
+    }
+    if (candidates.length === 0) {
+      throw new RejectionError(
+        `no placement candidates for ${req.target.type} after filtering`,
+        "noCandidates",
+      );
+    }
+    // Version-aware placement: prefer compatible silos within the eligible set,
+    // but fall back to it when none qualify (best-effort — never fails on version).
     if (this.deps.versionFilter !== undefined) {
-      const compatible = await this.deps.versionFilter(req, active);
+      const compatible = await this.deps.versionFilter(req, candidates);
       if (compatible.length > 0) candidates = compatible;
     }
     const strategy = this.deps.placementFor(req.target.type);
-    const targetSilo = strategy.choose(req.target.type, candidates, {
-      localSilo: this.deps.local,
-      ...this.deps.placementContext(),
-    });
+    const targetSilo = strategy.choose(req.target.type, candidates, ctx);
     return targetSilo.equals(this.deps.local)
       ? this.deliverLocal(req)
       : this.deps.remote.send(targetSilo, req);

--- a/packages/runtime/src/placement/metadata-match-filter.ts
+++ b/packages/runtime/src/placement/metadata-match-filter.ts
@@ -1,0 +1,32 @@
+import type { GrainType } from "@tsva/core/grain-type";
+import type { SiloAddress } from "@tsva/core/silo-address";
+import type { PlacementFilter } from "@tsva/runtime/placement/placement-filter";
+import type { PlacementContext } from "@tsva/runtime/placement/placement-strategy";
+import { ROLE_METADATA_KEY } from "@tsva/runtime/placement/silo-metadata";
+
+/**
+ * Keeps only candidates whose advertised silo metadata defines every required
+ * key/value pair (Orleans `PreferredMatchSiloMetadataPlacementFilter`). A silo
+ * with no metadata, or missing any required key, is pruned.
+ */
+export class MetadataMatchFilter implements PlacementFilter {
+  constructor(private readonly required: Readonly<Record<string, string>>) {}
+
+  filter(
+    _grainType: GrainType,
+    candidates: readonly SiloAddress[],
+    context: PlacementContext,
+  ): readonly SiloAddress[] {
+    const lookup = context.siloMetadata ?? (() => undefined);
+    const required = Object.entries(this.required);
+    return candidates.filter((silo) => {
+      const meta = lookup(silo);
+      return meta !== undefined && required.every(([key, value]) => meta[key] === value);
+    });
+  }
+}
+
+/** A filter that keeps only silos advertising the given role. */
+export function roleMatchFilter(role: string): PlacementFilter {
+  return new MetadataMatchFilter({ [ROLE_METADATA_KEY]: role });
+}

--- a/packages/runtime/src/placement/placement-director.ts
+++ b/packages/runtime/src/placement/placement-director.ts
@@ -1,8 +1,12 @@
-import type { GrainMetadata } from "@tsva/core/grain-metadata";
+import type { GrainMetadata, PlacementFilterDescriptor } from "@tsva/core/grain-metadata";
 import { ActivationCountPlacement } from "@tsva/runtime/placement/activation-count-placement";
+import { MetadataMatchFilter } from "@tsva/runtime/placement/metadata-match-filter";
+import type { PlacementFilter } from "@tsva/runtime/placement/placement-filter";
 import { PreferLocalPlacement } from "@tsva/runtime/placement/prefer-local-placement";
 import { RandomPlacement } from "@tsva/runtime/placement/random-placement";
+import { ResourceOptimizedPlacement } from "@tsva/runtime/placement/resource-optimized-placement";
 import type { PlacementStrategy } from "@tsva/runtime/placement/placement-strategy";
+import { SiloRoleBasedPlacement } from "@tsva/runtime/placement/silo-role-based-placement";
 import { StatelessWorkerPlacement } from "@tsva/runtime/placement/stateless-worker-placement";
 
 /** Resolve the placement strategy a grain type's metadata selects. */
@@ -13,9 +17,35 @@ export function placementStrategyFor(metadata: GrainMetadata): PlacementStrategy
       return new PreferLocalPlacement();
     case "activationCount":
       return new ActivationCountPlacement();
+    case "siloRole": {
+      const role = metadata.options.role;
+      if (role === undefined)
+        throw new Error(`${metadata.grainType}: placement "siloRole" requires options.role`);
+      return new SiloRoleBasedPlacement(role);
+    }
+    case "resourceOptimized":
+      return new ResourceOptimizedPlacement();
     case "random":
     case undefined:
     default:
       return new RandomPlacement();
+  }
+}
+
+/**
+ * Resolve the placement filters a grain type declares, applied before the strategy
+ * runs. Filters are no-ops for stateless workers (always local, never registered),
+ * so none are returned for them.
+ */
+export function placementFiltersFor(metadata: GrainMetadata): readonly PlacementFilter[] {
+  if (metadata.options.stateless) return [];
+  const descriptors = metadata.options.placementFilters ?? [];
+  return descriptors.map(toFilter);
+}
+
+function toFilter(descriptor: PlacementFilterDescriptor): PlacementFilter {
+  switch (descriptor.kind) {
+    case "metadataMatch":
+      return new MetadataMatchFilter(descriptor.match);
   }
 }

--- a/packages/runtime/src/placement/placement-filter.ts
+++ b/packages/runtime/src/placement/placement-filter.ts
@@ -1,0 +1,16 @@
+import type { GrainType } from "@tsva/core/grain-type";
+import type { SiloAddress } from "@tsva/core/silo-address";
+import type { PlacementContext } from "@tsva/runtime/placement/placement-strategy";
+
+/**
+ * Prunes the candidate silos by metadata before a placement strategy chooses
+ * among them (Orleans `PlacementFilterStrategy`). Filters compose: the output of
+ * one is the input to the next.
+ */
+export interface PlacementFilter {
+  filter(
+    grainType: GrainType,
+    candidates: readonly SiloAddress[],
+    context: PlacementContext,
+  ): readonly SiloAddress[];
+}

--- a/packages/runtime/src/placement/placement-strategy.ts
+++ b/packages/runtime/src/placement/placement-strategy.ts
@@ -1,11 +1,20 @@
 import type { GrainType } from "@tsva/core/grain-type";
 import type { SiloAddress } from "@tsva/core/silo-address";
 
+/** Per-silo resource signals for load-aware placement; extensible with cpu/memory later. */
+export interface SiloResourceStats {
+  activationCount?: number;
+}
+
 /** Information a placement strategy may consult when choosing a silo. */
 export interface PlacementContext {
   localSilo: SiloAddress;
   /** Current activation count on a silo, for load-aware strategies. */
   activationCount?: (silo: SiloAddress) => number;
+  /** Static metadata a silo advertises via membership (role, zone, ...), for metadata filters. */
+  siloMetadata?: (silo: SiloAddress) => Readonly<Record<string, string>> | undefined;
+  /** Resource signals for resource-optimized placement; local from the catalog, remote from membership. */
+  resourceStats?: (silo: SiloAddress) => SiloResourceStats | undefined;
   /** Injectable RNG so placement is deterministic in tests. */
   random?: () => number;
 }

--- a/packages/runtime/src/placement/placement.test.ts
+++ b/packages/runtime/src/placement/placement.test.ts
@@ -2,10 +2,16 @@ import { describe, expect, it } from "vitest";
 import type { GrainMetadata } from "@tsva/core/grain-metadata";
 import { SiloAddress } from "@tsva/core/silo-address";
 import { ActivationCountPlacement } from "@tsva/runtime/placement/activation-count-placement";
-import { placementStrategyFor } from "@tsva/runtime/placement/placement-director";
+import { MetadataMatchFilter } from "@tsva/runtime/placement/metadata-match-filter";
+import {
+  placementFiltersFor,
+  placementStrategyFor,
+} from "@tsva/runtime/placement/placement-director";
 import type { PlacementContext } from "@tsva/runtime/placement/placement-strategy";
 import { PreferLocalPlacement } from "@tsva/runtime/placement/prefer-local-placement";
 import { RandomPlacement } from "@tsva/runtime/placement/random-placement";
+import { ResourceOptimizedPlacement } from "@tsva/runtime/placement/resource-optimized-placement";
+import { SiloRoleBasedPlacement } from "@tsva/runtime/placement/silo-role-based-placement";
 import { StatelessWorkerPlacement } from "@tsva/runtime/placement/stateless-worker-placement";
 
 const silo = (n: number) => new SiloAddress(`silo-${n}`, `uid-${n}`, `silo-${n}:1`);
@@ -16,6 +22,12 @@ const meta = (options: Partial<GrainMetadata["options"]> = {}): GrainMetadata =>
   reentrant: false,
   implicitSubscriptions: [],
 });
+
+/** A `siloMetadata` accessor backed by a `ringKey -> metadata` map. */
+const metadataOf =
+  (table: Record<string, Record<string, string>>) =>
+  (s: SiloAddress): Readonly<Record<string, string>> | undefined =>
+    table[s.ringKey];
 
 describe("RandomPlacement", () => {
   it("picks the candidate the RNG points at", () => {
@@ -76,6 +88,118 @@ describe("StatelessWorkerPlacement", () => {
   });
 });
 
+describe("MetadataMatchFilter", () => {
+  it("keeps only silos matching every required key", () => {
+    const ctx: PlacementContext = {
+      localSilo: silo(0),
+      siloMetadata: metadataOf({ "silo-0": { role: "worker" }, "silo-1": { role: "gateway" } }),
+    };
+    const kept = new MetadataMatchFilter({ role: "worker" }).filter("Counter", candidates, ctx);
+    expect(kept.map((s) => s.ringKey)).toEqual(["silo-0"]);
+  });
+
+  it("requires all keys to match", () => {
+    const ctx: PlacementContext = {
+      localSilo: silo(0),
+      siloMetadata: metadataOf({
+        "silo-0": { role: "worker", zone: "a" },
+        "silo-1": { role: "worker", zone: "b" },
+      }),
+    };
+    const kept = new MetadataMatchFilter({ role: "worker", zone: "a" }).filter(
+      "Counter",
+      candidates,
+      ctx,
+    );
+    expect(kept.map((s) => s.ringKey)).toEqual(["silo-0"]);
+  });
+
+  it("prunes silos with no metadata and returns empty when none match", () => {
+    const ctx: PlacementContext = { localSilo: silo(0) }; // no siloMetadata accessor
+    expect(new MetadataMatchFilter({ role: "worker" }).filter("Counter", candidates, ctx)).toEqual(
+      [],
+    );
+  });
+});
+
+describe("SiloRoleBasedPlacement", () => {
+  const ctx = (random?: () => number): PlacementContext => ({
+    localSilo: silo(0),
+    siloMetadata: metadataOf({
+      "silo-0": { role: "gateway" },
+      "silo-1": { role: "worker" },
+      "silo-2": { role: "worker" },
+    }),
+    ...(random !== undefined ? { random } : {}),
+  });
+
+  it("routes only to silos advertising the role", () => {
+    // random 0 -> first of the matched [silo-1, silo-2]
+    expect(
+      new SiloRoleBasedPlacement("worker").choose(
+        "Counter",
+        candidates,
+        ctx(() => 0),
+      ).ringKey,
+    ).toBe("silo-1");
+    expect(
+      new SiloRoleBasedPlacement("worker").choose(
+        "Counter",
+        candidates,
+        ctx(() => 0.99),
+      ).ringKey,
+    ).toBe("silo-2");
+  });
+
+  it("throws when no silo has the role", () => {
+    expect(() =>
+      new SiloRoleBasedPlacement("missing").choose("Counter", candidates, ctx()),
+    ).toThrow();
+  });
+});
+
+describe("ResourceOptimizedPlacement", () => {
+  it("picks the silo with the lowest activation count", () => {
+    const stats = new Map([
+      ["silo-0", 10],
+      ["silo-1", 2],
+      ["silo-2", 7],
+    ]);
+    const ctx: PlacementContext = {
+      localSilo: silo(0),
+      resourceStats: (s) => ({ activationCount: stats.get(s.ringKey) ?? 0 }),
+    };
+    expect(new ResourceOptimizedPlacement().choose("Counter", candidates, ctx).ringKey).toBe(
+      "silo-1",
+    );
+  });
+
+  it("falls back to activationCount when resourceStats is absent", () => {
+    const load = new Map([
+      ["silo-0", 5],
+      ["silo-1", 9],
+      ["silo-2", 1],
+    ]);
+    const ctx: PlacementContext = {
+      localSilo: silo(0),
+      activationCount: (s) => load.get(s.ringKey) ?? 0,
+    };
+    expect(new ResourceOptimizedPlacement().choose("Counter", candidates, ctx).ringKey).toBe(
+      "silo-2",
+    );
+  });
+
+  it("breaks ties by preferring the local silo", () => {
+    const ctx: PlacementContext = {
+      localSilo: silo(2),
+      resourceStats: () => ({ activationCount: 0 }), // all equal
+    };
+    expect(new ResourceOptimizedPlacement().choose("Counter", candidates, ctx).ringKey).toBe(
+      "silo-2",
+    );
+  });
+});
+
 describe("placementStrategyFor", () => {
   it("maps metadata to the right strategy, defaulting to random", () => {
     expect(placementStrategyFor(meta())).toBeInstanceOf(RandomPlacement);
@@ -86,8 +210,56 @@ describe("placementStrategyFor", () => {
     expect(placementStrategyFor(meta({ placement: "activationCount" }))).toBeInstanceOf(
       ActivationCountPlacement,
     );
+    expect(placementStrategyFor(meta({ placement: "siloRole", role: "worker" }))).toBeInstanceOf(
+      SiloRoleBasedPlacement,
+    );
+    expect(placementStrategyFor(meta({ placement: "resourceOptimized" }))).toBeInstanceOf(
+      ResourceOptimizedPlacement,
+    );
     expect(placementStrategyFor(meta({ stateless: true }))).toBeInstanceOf(
       StatelessWorkerPlacement,
     );
+  });
+
+  it("requires a role for siloRole placement", () => {
+    expect(() => placementStrategyFor(meta({ placement: "siloRole" }))).toThrow();
+  });
+
+  it("stateless takes precedence over a placement value", () => {
+    expect(
+      placementStrategyFor(meta({ stateless: true, placement: "resourceOptimized" })),
+    ).toBeInstanceOf(StatelessWorkerPlacement);
+  });
+});
+
+describe("placementFiltersFor", () => {
+  it("returns no filters by default", () => {
+    expect(placementFiltersFor(meta())).toEqual([]);
+  });
+
+  it("builds a MetadataMatchFilter from a descriptor", () => {
+    const filters = placementFiltersFor(
+      meta({ placementFilters: [{ kind: "metadataMatch", match: { role: "worker" } }] }),
+    );
+    expect(filters).toHaveLength(1);
+    expect(filters[0]).toBeInstanceOf(MetadataMatchFilter);
+    const ctx: PlacementContext = {
+      localSilo: silo(0),
+      siloMetadata: metadataOf({ "silo-1": { role: "worker" } }),
+    };
+    expect(filters[0]!.filter("Counter", candidates, ctx).map((s) => s.ringKey)).toEqual([
+      "silo-1",
+    ]);
+  });
+
+  it("returns no filters for stateless workers", () => {
+    expect(
+      placementFiltersFor(
+        meta({
+          stateless: true,
+          placementFilters: [{ kind: "metadataMatch", match: { role: "x" } }],
+        }),
+      ),
+    ).toEqual([]);
   });
 });

--- a/packages/runtime/src/placement/resource-optimized-placement.ts
+++ b/packages/runtime/src/placement/resource-optimized-placement.ts
@@ -1,0 +1,34 @@
+import type { GrainType } from "@tsva/core/grain-type";
+import type { SiloAddress } from "@tsva/core/silo-address";
+import type {
+  PlacementContext,
+  PlacementStrategy,
+} from "@tsva/runtime/placement/placement-strategy";
+
+/**
+ * Places the grain on the least-loaded silo (Orleans `ResourceOptimizedPlacement`).
+ * Load is the silo's activation count, read from `resourceStats` (falling back to
+ * `activationCount`, then 0). Ties prefer the local silo, keeping placement
+ * deterministic and favouring co-location.
+ */
+export class ResourceOptimizedPlacement implements PlacementStrategy {
+  choose(
+    _grainType: GrainType,
+    candidates: readonly SiloAddress[],
+    ctx: PlacementContext,
+  ): SiloAddress {
+    if (candidates.length === 0) throw new Error("no placement candidates");
+    const load = (silo: SiloAddress): number =>
+      ctx.resourceStats?.(silo)?.activationCount ?? ctx.activationCount?.(silo) ?? 0;
+    let best = candidates[0]!;
+    let bestLoad = load(best);
+    for (const silo of candidates.slice(1)) {
+      const l = load(silo);
+      if (l < bestLoad || (l === bestLoad && silo.equals(ctx.localSilo))) {
+        best = silo;
+        bestLoad = l;
+      }
+    }
+    return best;
+  }
+}

--- a/packages/runtime/src/placement/silo-metadata.ts
+++ b/packages/runtime/src/placement/silo-metadata.ts
@@ -1,0 +1,2 @@
+/** Well-known silo-metadata key naming a silo's role, consulted by role-based placement. */
+export const ROLE_METADATA_KEY = "role";

--- a/packages/runtime/src/placement/silo-role-based-placement.ts
+++ b/packages/runtime/src/placement/silo-role-based-placement.ts
@@ -1,0 +1,32 @@
+import type { GrainType } from "@tsva/core/grain-type";
+import type { SiloAddress } from "@tsva/core/silo-address";
+import { roleMatchFilter } from "@tsva/runtime/placement/metadata-match-filter";
+import type { PlacementFilter } from "@tsva/runtime/placement/placement-filter";
+import {
+  pickRandom,
+  type PlacementContext,
+  type PlacementStrategy,
+} from "@tsva/runtime/placement/placement-strategy";
+
+/**
+ * Places the grain on a silo advertising a given role (Orleans
+ * `SiloRoleBasedPlacement`). Reuses the role-match filter so role logic lives in
+ * one place, then picks randomly among the matches. Throws if no silo has the role.
+ */
+export class SiloRoleBasedPlacement implements PlacementStrategy {
+  private readonly roleFilter: PlacementFilter;
+
+  constructor(private readonly role: string) {
+    this.roleFilter = roleMatchFilter(role);
+  }
+
+  choose(
+    grainType: GrainType,
+    candidates: readonly SiloAddress[],
+    ctx: PlacementContext,
+  ): SiloAddress {
+    const matched = this.roleFilter.filter(grainType, candidates, ctx);
+    if (matched.length === 0) throw new Error(`no silo with role "${this.role}"`);
+    return pickRandom(matched, ctx.random ?? Math.random);
+  }
+}

--- a/packages/runtime/src/static-membership.ts
+++ b/packages/runtime/src/static-membership.ts
@@ -19,11 +19,18 @@ export class StaticMembershipService implements MembershipService {
   constructor(
     private readonly local: SiloAddress,
     initial: readonly SiloAddress[],
+    private readonly metadata?: (silo: SiloAddress) => Readonly<Record<string, string>> | undefined,
   ) {
     this.snapshot = {
       version: 1,
-      silos: initial.map((address) => ({ address, status: "active" })),
+      silos: initial.map((address) => this.member(address, "active")),
     };
+  }
+
+  /** Build a member, attaching the resolver's metadata for the silo when present. */
+  private member(address: SiloAddress, status: SiloStatus): SiloMember {
+    const meta = this.metadata?.(address);
+    return { address, status, ...(meta !== undefined ? { metadata: meta } : {}) };
   }
 
   current(): MembershipSnapshot {
@@ -42,12 +49,18 @@ export class StaticMembershipService implements MembershipService {
 
   /** Replace the whole view (all `active`), bumping the version. */
   setSilos(addresses: readonly SiloAddress[]): void {
-    this.publish(addresses.map((address) => ({ address, status: "active" as SiloStatus })));
+    this.publish(addresses.map((address) => this.member(address, "active")));
   }
 
-  addSilo(address: SiloAddress, status: SiloStatus = "active"): void {
+  addSilo(
+    address: SiloAddress,
+    status: SiloStatus = "active",
+    metadata?: Readonly<Record<string, string>>,
+  ): void {
     if (this.snapshot.silos.some((m) => m.address.equals(address))) return;
-    this.publish([...this.snapshot.silos, { address, status }]);
+    const member =
+      metadata !== undefined ? { address, status, metadata } : this.member(address, status);
+    this.publish([...this.snapshot.silos, member]);
   }
 
   removeSilo(address: SiloAddress): void {

--- a/todo.md
+++ b/todo.md
@@ -274,6 +274,14 @@ order, starting with transactions.
       grain ids) alongside the registry's explicit subscribers, deduplicated; in-memory provider
       stays explicit-only. Tests: metadata/observer unit, pure `implicitSubscriberIds`, dispatcher
       delivery (class + functional, no-observer drop), and a Redis pulling-agent e2e (skip-if-down).
+- [x] Placement filters + metadata-aware strategies — `PlacementFilterStrategy` layer
+      (`PlacementFilter` + `MetadataMatchFilter`, Orleans `PreferredMatchSiloMetadataPlacementFilter`)
+      prunes candidate silos by metadata before the strategy runs, applied in the dispatcher before
+      `choose`; `SiloRoleBasedPlacement` and `ResourceOptimizedPlacement` strategies. Silo metadata
+      rides `SiloMember.metadata` (config + `StaticMembershipService` resolver); `PlacementContext`
+      gained `siloMetadata`/`resourceStats` accessors. Unit + dispatcher + multi-silo integration
+      tests. Follow-ups: populate `SiloMember.metadata` from Kubernetes pod labels; report remote
+      `resourceStats` via membership gossip (today a peer's load is zero/metadata-only).
 - [ ] Directory range handoff — replace the phase-2 drop-and-rebuild with a versioned, lossless
       handoff on membership change (per [docs/06](docs/06-grain-directory-and-placement.md)).
 - [~] Observability (cross-cutting) — OpenTelemetry traces propagated via request context, metrics


### PR DESCRIPTION
Implement the placement-filter layer and additional placement strategies to enable metadata-driven grain placement decisions, closing the parity gap with Orleans.

## Summary

This change adds support for **placement filters** — a composable layer that prunes candidate silos by metadata before a placement strategy runs — and two new placement strategies: **silo-role-based** and **resource-optimized**. Grains can now declare placement filters via `@grain({ placementFilters: [...] })` and select role-based or load-aware placement strategies. Silos advertise static metadata (e.g., `{ role: "worker" }`) that filters and strategies consult to make placement decisions.

## Key Changes

- **Placement filters** (`PlacementFilter` interface, `MetadataMatchFilter` implementation):
  - New `PlacementFilter` interface for metadata-driven candidate pruning
  - `MetadataMatchFilter` keeps only silos matching required key/value pairs
  - Filters compose and are applied before the strategy runs
  - Filters are inert for stateless workers (always local, never registered)

- **New placement strategies**:
  - `SiloRoleBasedPlacement`: places only on silos advertising a given role, then picks randomly
  - `ResourceOptimizedPlacement`: places on the least-loaded silo by activation count, with tie-breaking favoring the local silo

- **Silo metadata support**:
  - `SiloMember` now carries optional `metadata` field (e.g., `{ role: "worker" }`)
  - `StaticMembershipService` accepts a metadata resolver function
  - `ClusterNode` accepts a `metadata` option to advertise static silo metadata
  - `PlacementContext` gains `siloMetadata` and `resourceStats` accessors

- **Grain metadata extensions**:
  - `GrainOptions` adds `placement: "siloRole" | "resourceOptimized"`, `role`, and `placementFilters` fields
  - `PlacementFilterDescriptor` type for serializable filter declarations

- **Integration**:
  - `DistributedDispatcher` applies filters before invoking the strategy
  - Throws `noCandidates` rejection when filtering prunes all candidates
  - `placementFiltersFor()` function resolves filter descriptors to instances

- **Tests**:
  - Unit tests for all new filters and strategies in `placement.test.ts`
  - Integration tests in `cluster.placement.test.ts` verifying end-to-end placement behavior across a 3-silo cluster
  - `distributed-dispatcher.placement.test.ts` verifying filter application in the dispatcher

## Notable Implementation Details

- Filters are applied in sequence; the output of one becomes the input to the next
- `ResourceOptimizedPlacement` reads load from `resourceStats` (falling back to `activationCount`, then 0) to support future extensibility beyond activation counts
- Role-based placement reuses `MetadataMatchFilter` internally to keep role logic centralized
- Stateless workers bypass filters entirely (they are never directory-registered and always resolve locally)
- The local silo's metadata and load are known directly; peers' come from membership entries (no cross-silo load gossip yet)

https://claude.ai/code/session_014YvBWhsBCJgqqrn4KEvhUA