### PR TITLE
Implement versioned directory handoff on membership change

### DIFF
--- a/docs/06-grain-directory-and-placement.md
+++ b/docs/06-grain-directory-and-placement.md
@@ -112,17 +112,22 @@ sequenceDiagram
 - **On leave/crash:** entries the dead silo *owned* are lost (acceptable — they were ephemeral), and
   entries *pointing at* the dead silo are removed everywhere. Affected grains reactivate on next
   call.
-- **On join:** the newcomer takes over ranges from its ring neighbours. The previous owners hand off
-  the live entries in those ranges (Orleans does a versioned handoff with range "wedges"). A simpler
-  acceptable variant for early phases is to **drop and lazily rebuild** entries in moved ranges,
-  trading a few redundant reactivations for much less handoff machinery; the roadmap
-  ([13](13-roadmap-and-phases.md)) starts there and adds handoff later.
+- **On join:** the newcomer takes over ranges from its ring neighbours. The previous owners **hand
+  off** the live entries in those ranges rather than dropping them. On a view change each silo sets
+  aside the entries whose range it has lost to a still-live successor, and the newcomer **recovers**
+  the ranges it now owns by pulling those entries from the previous owners (a versioned handoff with
+  range "wedges", as Orleans does). Reads for a range still being recovered **wait** for the pull to
+  finish, so a moved grain is found at its existing activation instead of being needlessly
+  reactivated. If a pull is lost the directory falls back to **drop-and-lazily-rebuild** for those
+  ranges — a few redundant reactivations rather than a corrupt entry.
 
 The implementation reaches the owning partition through a pluggable **directory peer**. By default it
-routes `lookup` / `register` / `unregister` to the owning silo as **system messages** over the same
-transport and correlation path that grain calls use (an in-process peer remains for single-process
-tests). On a view change each silo recomputes the ring and drops entries pointing at, or owned by,
-silos that have left.
+routes `lookup` / `register` / `unregister` / `recover` to the owning silo as **system messages** over
+the same transport and correlation path that grain calls use (an in-process peer remains for
+single-process tests). Every directory message carries the sender's applied view *version*: a silo
+that is behind catches up before serving, and one that is ahead and no longer owns the grain redirects
+the caller (a `staleView` rejection) so it refreshes its view and re-resolves the owner. On a view
+change each silo recomputes the ring and drops entries pointing at silos that have left.
 
 All of this is keyed off the membership view *version*, so concurrent view changes are linearised by
 version and a silo never mixes entries from two different ring topologies.

--- a/docs/13-roadmap-and-phases.md
+++ b/docs/13-roadmap-and-phases.md
@@ -32,9 +32,9 @@ Grain call filters and cross-cutting observability (request context, OpenTelemet
 structured logs) ship too, on the grain-call-filter seam, as does implicit stream subscription.
 
 **Remaining for parity (Orleans 10):** grain migration and the activation rebalancer (the v10
-core-runtime block), lossless directory range handoff, and placement
-filters. The Orleans-10 additions of durable journaling (`DurableGrain`) and durable jobs need an
-ADR each (journaling overlaps the existing reducer/persistent-state model).
+core-runtime block) and placement filters. The Orleans-10 additions of durable journaling
+(`DurableGrain`) and durable jobs need an ADR each (journaling overlaps the existing
+reducer/persistent-state model).
 
 **Deferred:** additional providers (Postgres storage/reminders, other stream backings) — alternatives
 to the shipped Redis defaults, not parity gaps.
@@ -161,7 +161,11 @@ verified.
   exposes a handler under `STREAM_SUBSCRIPTION_OBSERVER` and the pulling agent fans each event out to
   implicit subscribers (by key) alongside explicit ones (see [09](09-event-streams.md)).
 - **Directory range handoff** — replace the phase-2 drop-and-rebuild with a versioned, lossless
-  handoff on membership change (per [06](06-grain-directory-and-placement.md)).
+  handoff on membership change (per [06](06-grain-directory-and-placement.md)). **Shipped** — on a
+  view change the silo losing a range sets its live entries aside and the new owner recovers them by
+  pulling from the previous owner; directory ops carry the membership view version (a behind owner
+  catches up, a stale caller is redirected via a `staleView` rejection), and reads for a
+  still-recovering range wait, so a join no longer reactivates the moved grains.
 - **Grain call filters** — incoming/outgoing interception around grain calls for cross-cutting
   concerns (auth, retries, trace propagation), mirroring Orleans' `IIncomingGrainCallFilter` /
   `IOutgoingGrainCallFilter` ([ADR 0012](adr/0012-grain-call-filters.md)). This is also the seam the

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -12,7 +12,8 @@ export type RejectionKind =
   | "overloaded"
   | "deserialization"
   | "noActivation"
-  | "noCandidates";
+  | "noCandidates"
+  | "staleView";
 
 /** A runtime-level refusal the caller can inspect to decide whether to retry. */
 export class RejectionError extends Error {

--- a/packages/directory/src/directory.test.ts
+++ b/packages/directory/src/directory.test.ts
@@ -69,6 +69,60 @@ describe("LocalDirectoryPartition", () => {
     expect(dir.size).toBe(1);
     expect(dir.lookup(new GrainId("Counter", "y"))).toBeDefined();
   });
+
+  it("drain classifies every entry in one pass, removing drops and handoffs", () => {
+    const dir = new LocalDirectoryPartition();
+    const x = addr("x", siloA);
+    const y = addr("y", siloB);
+    const z = addr("z", siloA);
+    dir.register(x);
+    dir.register(y);
+    dir.register(z);
+
+    // Drop the siloB host, hand off x, keep z.
+    const handed = dir.drain((e) =>
+      e.silo.equals(siloB) ? "drop" : e.grainId.equals(x.grainId) ? "handoff" : "keep",
+    );
+
+    expect(handed).toEqual([x]);
+    expect(dir.size).toBe(1);
+    expect(dir.lookup(z.grainId)).toEqual(z);
+    expect(dir.lookup(x.grainId)).toBeUndefined();
+    expect(dir.lookup(y.grainId)).toBeUndefined();
+  });
+
+  it("acceptHandoff registers entries it still owns", () => {
+    const dir = new LocalDirectoryPartition();
+    const a = addr("x", siloA);
+    dir.acceptHandoff([a], () => true);
+    expect(dir.lookup(a.grainId)).toEqual(a);
+  });
+
+  it("acceptHandoff never overwrites a fresher entry (a concurrent reactivation wins)", () => {
+    const dir = new LocalDirectoryPartition();
+    const fresh = addr("x", siloB);
+    const stale = addr("x", siloA, "stale-activation");
+    dir.register(fresh);
+    dir.acceptHandoff([stale], () => true);
+    expect(dir.lookup(fresh.grainId)).toEqual(fresh);
+  });
+
+  it("acceptHandoff ignores entries whose range has moved away (the versioned guard)", () => {
+    const dir = new LocalDirectoryPartition();
+    const a = addr("x", siloA);
+    dir.acceptHandoff([a], () => false); // no longer owned here
+    expect(dir.lookup(a.grainId)).toBeUndefined();
+    expect(dir.size).toBe(0);
+  });
+
+  it("entriesIn returns the live entries matching a predicate", () => {
+    const dir = new LocalDirectoryPartition();
+    const x = addr("x", siloA);
+    const y = addr("y", siloB);
+    dir.register(x);
+    dir.register(y);
+    expect(dir.entriesIn((e) => e.silo.equals(siloA))).toEqual([x]);
+  });
 });
 
 describe("LocationCache", () => {

--- a/packages/directory/src/distributed-grain-directory.test.ts
+++ b/packages/directory/src/distributed-grain-directory.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { newActivationId } from "@tsva/core/activation-id";
+import { RejectionError } from "@tsva/core/errors";
 import type { GrainAddress } from "@tsva/core/grain-address";
 import { GrainId } from "@tsva/core/grain-id";
 import { SiloAddress } from "@tsva/core/silo-address";
@@ -57,6 +58,39 @@ describe("DistributedGrainDirectory", () => {
     // Whoever the owning partition accepted first wins for both callers.
     expect(winnerA.activationId).toBe(winnerB.activationId);
     expect(winnerA.activationId).toBe(fromA.activationId);
+  });
+
+  it("refreshes its view and re-resolves the owner when a peer reports a stale view", async () => {
+    const partition = new LocalDirectoryPartition();
+    const a = addr("k", siloA);
+    partition.register(a);
+
+    // Our (stale) ring routes the grain to siloB; the peer rejects as stale.
+    // refresh() corrects the ring to point at the local owner, where it resolves.
+    let owner: SiloAddress = siloB;
+    const peer: DirectoryPeer = {
+      lookup: async () => {
+        throw new RejectionError("stale directory view", "staleView");
+      },
+      register: async () => a,
+      unregister: async () => undefined,
+    };
+    const stub = { ownerOf: () => owner } as unknown as ConsistentHashRing;
+
+    let refreshed = 0;
+    const dir = new DistributedGrainDirectory(
+      siloA,
+      partition,
+      () => stub,
+      peer,
+      () => {
+        refreshed++;
+        owner = siloA;
+      },
+    );
+
+    expect(await dir.lookup(a.grainId)).toEqual(a);
+    expect(refreshed).toBe(1);
   });
 
   it("drops local entries pointing at a departed silo", async () => {

--- a/packages/directory/src/distributed-grain-directory.ts
+++ b/packages/directory/src/distributed-grain-directory.ts
@@ -1,3 +1,4 @@
+import { RejectionError } from "@tsva/core/errors";
 import type { GrainAddress } from "@tsva/core/grain-address";
 import type { GrainId } from "@tsva/core/grain-id";
 import type { SiloAddress } from "@tsva/core/silo-address";
@@ -6,12 +7,21 @@ import type { DirectoryPeer } from "@tsva/directory/directory-peer";
 import type { GrainDirectory } from "@tsva/directory/grain-directory";
 import type { LocalDirectoryPartition } from "@tsva/directory/local-directory-partition";
 
+/** Bounded re-resolution attempts when a peer reports our membership view is stale. */
+const MAX_STALE_RETRIES = 5;
+
 /**
  * The distributed directory as seen from one silo. The ring (derived from the
  * current membership view) decides which silo owns a grain's entry: owned-here
  * operations hit the local partition; others route to the owner via the peer.
  * Because every silo computes the same ring from the same view, they agree on
  * owners without coordination, so `register` CAS is authoritative.
+ *
+ * Two membership-change concerns ride on this path. A caller whose ring is stale
+ * is told so by the owner (a `staleView` rejection); it then `refresh`es its view
+ * and re-resolves the owner. And an owner-local access waits on `onOwnedAccess`
+ * so a range still being recovered after a join is not read before its entries
+ * have been pulled — closing the reactivation window the old drop-and-rebuild had.
  */
 export class DistributedGrainDirectory implements GrainDirectory {
   constructor(
@@ -19,30 +29,71 @@ export class DistributedGrainDirectory implements GrainDirectory {
     private readonly partition: LocalDirectoryPartition,
     private readonly ring: () => ConsistentHashRing,
     private readonly peer: DirectoryPeer,
+    private readonly refresh: () => void = () => undefined,
+    private readonly onOwnedAccess: (grainId: GrainId) => Promise<void> = async () => undefined,
   ) {}
 
   async lookup(grainId: GrainId): Promise<GrainAddress | undefined> {
-    const owner = this.ring().ownerOf(grainId);
-    return owner.equals(this.local)
-      ? this.partition.lookup(grainId)
-      : this.peer.lookup(owner, grainId);
+    return this.route(
+      grainId,
+      () => this.partition.lookup(grainId),
+      (owner) => this.peer.lookup(owner, grainId),
+    );
   }
 
   async register(addr: GrainAddress, previous?: GrainAddress): Promise<GrainAddress> {
-    const owner = this.ring().ownerOf(addr.grainId);
-    return owner.equals(this.local)
-      ? this.partition.register(addr, previous)
-      : this.peer.register(owner, addr, previous);
+    return this.route(
+      addr.grainId,
+      () => this.partition.register(addr, previous),
+      (owner) => this.peer.register(owner, addr, previous),
+    );
   }
 
   async unregister(addr: GrainAddress): Promise<void> {
-    const owner = this.ring().ownerOf(addr.grainId);
-    if (owner.equals(this.local)) this.partition.unregister(addr);
-    else await this.peer.unregister(owner, addr);
+    await this.route(
+      addr.grainId,
+      () => {
+        this.partition.unregister(addr);
+        return undefined;
+      },
+      async (owner) => {
+        await this.peer.unregister(owner, addr);
+        return undefined;
+      },
+    );
   }
 
   /** Applied locally on every silo when a peer leaves: drop entries pointing at it. */
   async unregisterSilo(silo: SiloAddress): Promise<void> {
     this.partition.unregisterSilo(silo);
   }
+
+  /**
+   * Resolve the owner of `grainId` and run the operation there. Owned-here reads
+   * wait for any in-flight range recovery first; remote calls re-resolve and
+   * retry (bounded) when the owner reports our view is stale.
+   */
+  private async route<T>(
+    grainId: GrainId,
+    onOwned: () => T | Promise<T>,
+    onRemote: (owner: SiloAddress) => Promise<T>,
+  ): Promise<T> {
+    for (let attempt = 0; ; attempt++) {
+      const owner = this.ring().ownerOf(grainId);
+      if (owner.equals(this.local)) {
+        await this.onOwnedAccess(grainId);
+        return onOwned();
+      }
+      try {
+        return await onRemote(owner);
+      } catch (err) {
+        if (attempt >= MAX_STALE_RETRIES || !isStaleView(err)) throw err;
+        this.refresh(); // advance our view, then recompute the owner and retry
+      }
+    }
+  }
+}
+
+function isStaleView(err: unknown): boolean {
+  return err instanceof RejectionError && err.kind === "staleView";
 }

--- a/packages/directory/src/local-directory-partition.ts
+++ b/packages/directory/src/local-directory-partition.ts
@@ -52,4 +52,48 @@ export class LocalDirectoryPartition {
       if (entry.silo.equals(silo)) this.entries.delete(key);
     }
   }
+
+  /**
+   * Reconcile the partition against a new ring in a single pass: classify each
+   * entry as kept, dropped (its host silo left — the grain is gone) or handed
+   * off (the new ring assigns its range to another live silo). Dropped and
+   * handed-off entries leave the live partition; the handed-off ones are
+   * returned so the caller can retain them for a successor to pull.
+   */
+  drain(classify: (entry: GrainAddress) => "keep" | "drop" | "handoff"): GrainAddress[] {
+    const handoff: GrainAddress[] = [];
+    for (const [key, entry] of this.entries) {
+      const decision = classify(entry);
+      if (decision === "keep") continue;
+      if (decision === "handoff") handoff.push(entry);
+      this.entries.delete(key);
+    }
+    return handoff;
+  }
+
+  /**
+   * Adopt a batch of entries recovered from a previous owner: register-if-absent
+   * each one this silo still owns under the current ring. Never overwrites a
+   * fresher entry (a concurrent reactivation wins via the CAS), and skips any
+   * entry whose range has since moved to another silo — the versioned guard that
+   * keeps a partition from ever mixing two ring topologies.
+   */
+  acceptHandoff(
+    entries: readonly GrainAddress[],
+    isOwnedHere: (entry: GrainAddress) => boolean,
+  ): void {
+    for (const entry of entries) {
+      if (!isOwnedHere(entry)) continue;
+      this.register(entry);
+    }
+  }
+
+  /** The live entries matching `predicate` — used to serve a range-recovery pull. */
+  entriesIn(predicate: (entry: GrainAddress) => boolean): GrainAddress[] {
+    const matches: GrainAddress[] = [];
+    for (const entry of this.entries.values()) {
+      if (predicate(entry)) matches.push(entry);
+    }
+    return matches;
+  }
 }

--- a/packages/runtime/src/cluster-node.ts
+++ b/packages/runtime/src/cluster-node.ts
@@ -116,14 +116,25 @@ interface RejectionPayload {
   kind: RejectionError["kind"];
 }
 
-/** A directory partition operation routed to the owning silo over the transport. */
+/**
+ * A directory partition operation routed to the owning silo over the transport.
+ * Every op carries the sender's applied membership view `version` so the owner
+ * can linearise it against its own view (catch up if behind, redirect a stale
+ * caller). `recover` pulls a previous owner's handed-off entries on a join.
+ */
 type DirectoryOp =
-  | { kind: "lookup"; grainId: GrainId }
-  | { kind: "register"; addr: GrainAddress; previous?: GrainAddress | undefined }
-  | { kind: "unregister"; addr: GrainAddress };
+  | { kind: "lookup"; grainId: GrainId; version: number }
+  | { kind: "register"; addr: GrainAddress; previous?: GrainAddress | undefined; version: number }
+  | { kind: "unregister"; addr: GrainAddress; version: number }
+  | { kind: "recover"; version: number };
+
+/** Stand-in target grain for batch ops with no single grain (fills the envelope only). */
+const DIRECTORY_OP_TARGET = new GrainId("$directory", "op");
 
 function directoryOpGrainId(op: DirectoryOp): GrainId {
-  return op.kind === "lookup" ? op.grainId : op.addr.grainId;
+  if (op.kind === "lookup") return op.grainId;
+  if (op.kind === "recover") return DIRECTORY_OP_TARGET;
+  return op.addr.grainId;
 }
 
 /** Carries a migrating activation's identity and dehydrated state to its new host. */
@@ -170,13 +181,34 @@ export class ClusterNode {
   private ring: ConsistentHashRing;
   private listener: Listener | undefined;
 
+  /** The membership view version `this.ring` was built from. */
+  private appliedVersion: number;
+  /** Entries this silo handed off at the last view change, retained for a successor to pull. */
+  private handoffSnapshot: GrainAddress[] = [];
+  /** In-flight range recovery after a join; owned reads wait on it so none miss. */
+  private recovery: Promise<void> | undefined;
+  /** Callers awaiting `this.appliedVersion` to reach a given version. */
+  private viewWaiters: Array<{ version: number; resolve: () => void }> = [];
+
   /** Routes directory operations to the owning silo's partition over the transport. */
   private readonly transportPeer: DirectoryPeer = {
-    lookup: (owner, grainId) => this.sendDirectory(owner, { kind: "lookup", grainId }),
-    register: (owner, addr, previous) =>
-      this.sendDirectory(owner, { kind: "register", addr, previous }) as Promise<GrainAddress>,
+    lookup: async (owner, grainId) => {
+      const r = await this.sendDirectory(owner, {
+        kind: "lookup",
+        grainId,
+        version: this.appliedVersion,
+      });
+      return r == null ? undefined : (r as GrainAddress);
+    },
+    register: async (owner, addr, previous) =>
+      (await this.sendDirectory(owner, {
+        kind: "register",
+        addr,
+        previous,
+        version: this.appliedVersion,
+      })) as GrainAddress,
     unregister: async (owner, addr) => {
-      await this.sendDirectory(owner, { kind: "unregister", addr });
+      await this.sendDirectory(owner, { kind: "unregister", addr, version: this.appliedVersion });
     },
   };
 
@@ -188,6 +220,7 @@ export class ClusterNode {
     this.director = compatibilityDirector(options.versionCompatibility ?? "backwardCompatible");
     this.selector = versionSelector(options.versionSelector ?? "latest");
     this.ring = this.buildRing();
+    this.appliedVersion = options.membership.current().version;
     this.connections = new ConnectionManager(options.transport, options.local, options.clusterId);
     this.factory = new GrainFactory((interfaceId) => this.resolveGrainType(interfaceId));
     this.serializer =
@@ -198,6 +231,8 @@ export class ClusterNode {
       this.partition,
       () => this.ring,
       options.directoryPeer ?? this.transportPeer,
+      () => this.updateView(), // refresh on a stale-view rejection, then re-resolve
+      (grainId) => this.awaitRecovered(grainId), // gate owned reads on range recovery
     );
     this.catalog = new Catalog({
       grainTypes: this.grainTypes,
@@ -363,6 +398,15 @@ export class ClusterNode {
       this.onMessage(message),
     );
     this.collector.start();
+    // Join recovery: when joining an already-running cluster, pull the live entries
+    // for the ranges we now own from the incumbents instead of letting their grains
+    // lazily reactivate. Only past the initial formation (version 1): at cold start
+    // the peers in the view may still be coming up, there is nothing to recover yet,
+    // and connecting to a not-yet-listening peer would just churn the connection pool.
+    const others = this.otherActiveSilos();
+    if (others.length > 0 && this.isLocalActive() && this.appliedVersion > 1) {
+      this.beginRecovery(others, this.appliedVersion);
+    }
   }
 
   async stop(): Promise<void> {
@@ -372,14 +416,23 @@ export class ClusterNode {
     await this.catalog.deactivateAll({ code: "shutting-down", description: "node stopping" });
   }
 
-  /** Recompute the ring and drop entries for silos that have left the view. */
+  /**
+   * Reconcile the directory with a membership view change (versioned, lossless).
+   * Drop cache/connections for departed silos; in one partition pass drop entries
+   * whose host silo has left (the grain is gone) and set aside entries whose range
+   * the new ring assigns to another live silo (retained for that successor to pull).
+   * If this silo has just joined the active set, recover the ranges it now owns
+   * from the incumbents so their grains are not needlessly reactivated.
+   */
   updateView(): void {
-    const stillActive = new Set(
-      activeSilos(this.options.membership.current()).map((s) => s.ringKey),
-    );
-    for (const member of this.ring.silos()) {
-      if (!stillActive.has(member.ringKey)) {
-        this.partition.unregisterSilo(member);
+    const snapshot = this.options.membership.current();
+    const local = this.options.local;
+    const oldRing = this.ring;
+    const newRing = this.buildRing();
+    const live = new Set(activeSilos(snapshot).map((s) => s.ringKey));
+
+    for (const member of oldRing.silos()) {
+      if (!live.has(member.ringKey)) {
         this.cache.invalidateSilo(member);
         void this.connections.drop(member);
       }
@@ -388,11 +441,104 @@ export class ClusterNode {
     // drop them all and re-fetch lazily on the next version-aware placement.
     this.manifestCache.clear();
     this.manifestInflight.clear();
-    this.ring = this.buildRing();
+
+    this.handoffSnapshot = this.partition.drain((entry) => {
+      if (!live.has(entry.silo.ringKey)) return "drop"; // host gone — grain reactivates
+      return newRing.ownerOf(entry.grainId).equals(local) ? "keep" : "handoff";
+    });
+
+    const wasActive = oldRing.silos().some((s) => s.equals(local));
+    this.ring = newRing;
+    this.appliedVersion = snapshot.version;
+    this.resolveViewWaiters();
+
+    if (!wasActive && live.has(local.ringKey)) {
+      this.beginRecovery(this.otherActiveSilos(), snapshot.version);
+    }
   }
 
   private buildRing(): ConsistentHashRing {
     return new ConsistentHashRing(activeSilos(this.options.membership.current()));
+  }
+
+  private ownsNow(grainId: GrainId): boolean {
+    return this.ring.ownerOf(grainId).equals(this.options.local);
+  }
+
+  private isLocalActive(): boolean {
+    return activeSilos(this.options.membership.current()).some((s) => s.equals(this.options.local));
+  }
+
+  private otherActiveSilos(): SiloAddress[] {
+    return activeSilos(this.options.membership.current()).filter(
+      (s) => !s.equals(this.options.local),
+    );
+  }
+
+  /** Resolve `appliedVersion` reaching `version`; self-advance if our view already shows it. */
+  private async awaitView(version: number): Promise<void> {
+    if (this.appliedVersion >= version) return;
+    if (this.options.membership.current().version >= version) {
+      this.updateView();
+      if (this.appliedVersion >= version) return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      const onResolve = (): void => {
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        this.viewWaiters = this.viewWaiters.filter((w) => w.resolve !== onResolve);
+        reject(new RejectionError(`membership view ${version} not reached`, "staleView"));
+      }, this.callTimeoutMs);
+      this.viewWaiters.push({ version, resolve: onResolve });
+    });
+  }
+
+  private resolveViewWaiters(): void {
+    const remaining: typeof this.viewWaiters = [];
+    for (const w of this.viewWaiters) {
+      if (this.appliedVersion >= w.version) w.resolve();
+      else remaining.push(w);
+    }
+    this.viewWaiters = remaining;
+  }
+
+  /** Owned reads wait on an in-flight join recovery so they never see a transient miss. */
+  private async awaitRecovered(_grainId: GrainId): Promise<void> {
+    if (this.recovery !== undefined) await this.recovery;
+  }
+
+  /** Pull the ranges we now own from the given previous owners and merge them in. */
+  private beginRecovery(sources: readonly SiloAddress[], version: number): void {
+    if (sources.length === 0) return;
+    const newRing = this.ring;
+    const done = Promise.all(
+      sources.map(async (owner) => {
+        try {
+          const entries = (await this.sendDirectory(owner, { kind: "recover", version })) as
+            | GrainAddress[]
+            | undefined;
+          if (entries !== undefined) {
+            this.partition.acceptHandoff(entries, (e) =>
+              newRing.ownerOf(e.grainId).equals(this.options.local),
+            );
+          }
+        } catch {
+          // best-effort: a failed pull degrades to lazy rebuild for that source's ranges
+        }
+      }),
+    ).then(() => undefined);
+    this.recovery = done;
+    void done.finally(() => {
+      if (this.recovery === done) this.recovery = undefined;
+    });
+  }
+
+  /** Serve a successor's recovery pull: the entries we handed off whose host is still live. */
+  private serveRecover(): GrainAddress[] {
+    const live = new Set(activeSilos(this.options.membership.current()).map((s) => s.ringKey));
+    return this.handoffSnapshot.filter((e) => live.has(e.silo.ringKey));
   }
 
   private placementFor(grainType: GrainType): PlacementStrategy {
@@ -691,10 +837,7 @@ export class ClusterNode {
     void this.receiveRequest(message);
   }
 
-  private async sendDirectory(
-    owner: SiloAddress,
-    op: DirectoryOp,
-  ): Promise<GrainAddress | undefined> {
+  private async sendDirectory(owner: SiloAddress, op: DirectoryOp): Promise<unknown> {
     const conn = await this.connections.get(owner);
     const correlationId = nextCorrelationId();
     const message: Message = {
@@ -709,9 +852,7 @@ export class ClusterNode {
     };
     const pending = this.correlation.register(correlationId, this.callTimeoutMs);
     conn.send(message);
-    const result = this.interpretResponse(await pending);
-    // A "not found" lookup serializes back as null; normalise to undefined.
-    return result == null ? undefined : (result as GrainAddress);
+    return this.interpretResponse(await pending);
   }
 
   private async handleDirectoryRequest(message: Message): Promise<void> {
@@ -719,7 +860,7 @@ export class ClusterNode {
     if (replyTo === undefined) return;
     try {
       const op = this.serializer.deserialize<DirectoryOp>(message.body);
-      const result = this.applyDirectoryOp(op);
+      const result = await this.applyDirectoryOp(op);
       await this.reply(
         replyTo,
         responseTo(message, "success", this.serializer.serialize(result), this.options.local),
@@ -770,15 +911,30 @@ export class ClusterNode {
     );
   }
 
-  private applyDirectoryOp(op: DirectoryOp): GrainAddress | undefined {
+  private async applyDirectoryOp(
+    op: DirectoryOp,
+  ): Promise<GrainAddress | GrainAddress[] | undefined> {
+    // Linearise against our view: catch up if the caller is ahead of us; redirect
+    // the caller if it is behind and we no longer own the target (a `staleView`
+    // rejection it re-resolves), so we never serve under two ring topologies.
+    if (op.version > this.appliedVersion) await this.awaitView(op.version);
+    if (op.kind !== "recover" && op.version < this.appliedVersion) {
+      const grainId = op.kind === "lookup" ? op.grainId : op.addr.grainId;
+      if (!this.ownsNow(grainId)) throw new RejectionError("stale directory view", "staleView");
+    }
     switch (op.kind) {
       case "lookup":
+        await this.awaitRecovered(op.grainId);
         return this.partition.lookup(op.grainId);
       case "register":
+        await this.awaitRecovered(op.addr.grainId);
         return this.partition.register(op.addr, op.previous);
       case "unregister":
+        await this.awaitRecovered(op.addr.grainId);
         this.partition.unregister(op.addr);
         return undefined;
+      case "recover":
+        return this.serveRecover();
     }
   }
 

--- a/packages/runtime/src/cluster.test.ts
+++ b/packages/runtime/src/cluster.test.ts
@@ -6,6 +6,7 @@ import { defineGrainInterface } from "@tsva/core/grain-interface";
 import type { GrainWithStringKey } from "@tsva/core/key-kinds";
 import type { MembershipService } from "@tsva/core/membership";
 import { SiloAddress } from "@tsva/core/silo-address";
+import { ConsistentHashRing } from "@tsva/directory/consistent-hash-ring";
 import { InProcessNetwork, InProcessTransport } from "@tsva/messaging/in-process-transport";
 import { ClusterNode } from "@tsva/runtime/cluster-node";
 import { StaticMembershipService } from "@tsva/runtime/static-membership";
@@ -57,29 +58,41 @@ class MembershipView implements MembershipService {
   }
 }
 
-function buildCluster(count: number) {
+function buildCluster(count: number, opts: { random?: () => number } = {}) {
+  // Default deterministic placement -> first candidate (silo-0).
+  const random = opts.random ?? (() => 0);
   const network = new InProcessNetwork();
   const addresses = Array.from({ length: count }, (_, i) => silo(i));
   const membership = new StaticMembershipService(addresses[0]!, addresses);
 
   // No directoryPeer: each node routes directory operations over the transport.
-  const nodes = addresses.map((local) => {
+  const makeNode = (local: SiloAddress) => {
     const node = new ClusterNode({
       local,
       clusterId: CLUSTER,
       membership: new MembershipView(membership, local),
       transport: new InProcessTransport(network, CLUSTER),
-      random: () => 0, // deterministic placement -> first candidate (silo-0)
+      random,
     });
     node.registerGrain(CounterGrain, { interfaces: [ICounter] });
     node.registerGrain(LocalGrain, { interfaces: [ILocal] });
     return node;
-  });
+  };
+
+  const nodes = addresses.map(makeNode);
 
   return {
     nodes,
     membership,
     hostsOf: (grainId: GrainId) => nodes.filter((n) => n.isActive(grainId)),
+    /** Add a silo to the view and start a node for it (mirrors a pod joining). */
+    addNode: async (local: SiloAddress) => {
+      membership.addSilo(local);
+      const node = makeNode(local);
+      nodes.push(node);
+      await node.start();
+      return node;
+    },
     start: async () => {
       for (const n of nodes) await n.start();
     },
@@ -87,6 +100,14 @@ function buildCluster(count: number) {
       for (const n of nodes) await n.stop();
     },
   };
+}
+
+/** First `Counter/*` key the ring assigns to `owner` — to arrange a deterministic move. */
+function counterKeyOwnedBy(ring: ConsistentHashRing, owner: SiloAddress): string {
+  for (let i = 0; ; i++) {
+    const key = `k-${i}`;
+    if (ring.ownerOf(new GrainId("Counter", key)).equals(owner)) return key;
+  }
 }
 
 describe("multi-silo cluster", () => {
@@ -154,6 +175,40 @@ describe("multi-silo cluster", () => {
       expect(cluster.hostsOf(grainId)).toEqual([cluster.nodes[1]]);
     } finally {
       await cluster.nodes[1]!.stop();
+    }
+  });
+
+  it("hands off a moved range on join so the grain is not reactivated", async () => {
+    // random -> 0.99 picks the LAST candidate: silo-1 of two, silo-2 of three.
+    // So on a directory miss the grain would reactivate on the newcomer (silo-2),
+    // not its existing host (silo-1) — making a lost handoff observable.
+    const cluster = buildCluster(2, { random: () => 0.99 });
+    await cluster.start();
+
+    // A key the post-join ring assigns to the newcomer, so silo-2 becomes its
+    // directory owner and must recover the entry to keep the grain in place.
+    const ring3 = new ConsistentHashRing([silo(0), silo(1), silo(2)]);
+    const key = counterKeyOwnedBy(ring3, silo(2));
+    const grainId = new GrainId("Counter", key);
+
+    try {
+      // Activate on silo-1 (the last of two candidates) and build up state.
+      expect(await cluster.nodes[0]!.getGrain(ICounter, key).increment(5)).toBe(5);
+      expect(cluster.hostsOf(grainId)).toEqual([cluster.nodes[1]]);
+
+      // silo-2 joins; it owns the key's range now and recovers it on start. The
+      // incumbents adopt the new view (as the host loop would).
+      const node2 = await cluster.addNode(silo(2));
+      cluster.nodes[0]!.updateView();
+      cluster.nodes[1]!.updateView();
+
+      // Calling from the new owner immediately after the join: the lookup waits
+      // for recovery rather than missing, so the call reaches the original host
+      // with its state intact (7), and no second activation is created.
+      expect(await node2.getGrain(ICounter, key).increment(2)).toBe(7);
+      expect(cluster.hostsOf(grainId)).toEqual([cluster.nodes[1]]);
+    } finally {
+      await cluster.stop();
     }
   });
 });

--- a/packages/runtime/src/distributed-dispatcher.ts
+++ b/packages/runtime/src/distributed-dispatcher.ts
@@ -131,6 +131,7 @@ export class DistributedDispatcher implements Dispatcher {
 
 function isStaleRejection(err: unknown): boolean {
   return (
-    err instanceof RejectionError && (err.kind === "noActivation" || err.kind === "unknownTarget")
+    err instanceof RejectionError &&
+    (err.kind === "noActivation" || err.kind === "unknownTarget" || err.kind === "staleView")
   );
 }

--- a/todo.md
+++ b/todo.md
@@ -282,8 +282,13 @@ order, starting with transactions.
       gained `siloMetadata`/`resourceStats` accessors. Unit + dispatcher + multi-silo integration
       tests. Follow-ups: populate `SiloMember.metadata` from Kubernetes pod labels; report remote
       `resourceStats` via membership gossip (today a peer's load is zero/metadata-only).
-- [ ] Directory range handoff — replace the phase-2 drop-and-rebuild with a versioned, lossless
-      handoff on membership change (per [docs/06](docs/06-grain-directory-and-placement.md)).
+- [x] Directory range handoff — replaced the phase-2 drop-and-rebuild with a versioned, lossless
+      handoff on membership change (per [docs/06](docs/06-grain-directory-and-placement.md)): on a
+      view change the silo losing a range sets its live entries aside (`LocalDirectoryPartition.drain`)
+      and the new owner recovers them by pulling from the previous owner (a `recover` directory op,
+      merged register-if-absent); directory ops carry the membership view version so a behind owner
+      self-advances and a stale caller is redirected (`staleView` rejection → refresh + re-resolve),
+      and owned reads wait on in-flight recovery so a join no longer reactivates the moved grains.
 - [~] Observability (cross-cutting) — OpenTelemetry traces propagated via request context, metrics
       (activations, turn latency, directory hit rate, reminder/stream lag), and structured logs.
   - [x] Slice 1 — ambient request context (Orleans `RequestContext`): `requestContext.get/set/getAll`


### PR DESCRIPTION
Replace the drop-and-rebuild approach for moved ranges with a versioned, lossless handoff mechanism. When a silo joins the cluster, it now recovers live entries from previous owners instead of letting grains lazily reactivate, eliminating unnecessary reactivations and keeping grains at their existing activations.

## Key Changes

- **Versioned directory operations:** All directory ops (`lookup`, `register`, `unregister`) now carry the sender's applied membership view version, allowing the owner to linearize requests and detect stale callers. Added a new `recover` op for pulling handed-off entries.

- **Range handoff on view change:** When the ring changes, `LocalDirectoryPartition.drain()` classifies each entry as kept, dropped (host silo left), or handed off (range moved to another live silo). Handed-off entries are retained in `handoffSnapshot` for successors to pull.

- **Join recovery:** On joining an active cluster, a newcomer calls `beginRecovery()` to pull its newly-owned ranges from previous owners via the `recover` op. Owned reads wait on `awaitRecovered()` so they don't miss during the pull window.

- **Stale view handling:** When a remote owner reports a stale view (via `RejectionError` with kind `"staleView"`), the caller refreshes its membership view and re-resolves the owner (bounded to 5 retries). This ensures the directory never serves under two ring topologies.

- **View linearization:** Added `appliedVersion` tracking and `viewWaiters` queue so callers ahead of the local view can wait for it to catch up before proceeding.

## Implementation Details

- `DistributedGrainDirectory.route()` now handles both owned-local and remote cases, waiting on recovery for owned reads and retrying with refresh on stale-view rejections.
- `LocalDirectoryPartition` gains `drain()`, `acceptHandoff()`, and `entriesIn()` methods to support the handoff workflow.
- Directory peer now includes `recover` in the `DirectoryOp` union; a stand-in grain ID (`DIRECTORY_OP_TARGET`) fills the envelope for batch ops.
- Added integration test verifying a moved grain stays at its original activation after a join, rather than being reactivated.
- Updated `todo.md` and roadmap docs to mark this feature as shipped.

https://claude.ai/code/session_01FhsHBLFNE775WvwZvXn4kD