### PR TITLE
ADR 0018: Design durable jobs (sharded, at-least-once execution)

### DIFF
--- a/EPICS.md
+++ b/EPICS.md
@@ -59,7 +59,10 @@ decisions.
       ([ADR 0015](docs/adr/0015-broadcast-channels.md)).
 - [ ] **Durable journaling (`DurableGrain`)** — Orleans 10 `Orleans.Journaling`; needs an ADR
       (overlaps reducer/persistent state).
-- [ ] **Durable jobs** — Orleans 10 `Orleans.DurableJobs` (durable workflows); needs an ADR.
+- [~] **Durable jobs** — Orleans 10 `Orleans.DurableJobs`: a sharded, durable, at-least-once
+      scheduled-execution engine (not a workflow engine). Designed in
+      [ADR 0018](docs/adr/0018-durable-jobs.md) (`@tsva/durable-jobs`); design only, not yet
+      implemented.
 
 ## 🔭 Beyond parity (future)
 

--- a/docs/13-roadmap-and-phases.md
+++ b/docs/13-roadmap-and-phases.md
@@ -32,9 +32,10 @@ Grain call filters and cross-cutting observability (request context, OpenTelemet
 structured logs) ship too, on the grain-call-filter seam, as does implicit stream subscription.
 
 **Remaining for parity (Orleans 10):** grain migration and the activation rebalancer (the v10
-core-runtime block) and placement filters. The Orleans-10 additions of durable journaling
-(`DurableGrain`) and durable jobs need an ADR each (journaling overlaps the existing
-reducer/persistent-state model).
+core-runtime block) and placement filters. The Orleans-10 addition of durable journaling
+(`DurableGrain`) still needs an ADR (it overlaps the existing reducer/persistent-state model);
+durable jobs is now designed in [ADR 0018](adr/0018-durable-jobs.md) (design only, not yet
+implemented).
 
 **Deferred:** additional providers (Postgres storage/reminders, other stream backings) — alternatives
 to the shipped Redis defaults, not parity gaps.
@@ -187,8 +188,12 @@ verified.
 - **Durable journaling (`DurableGrain`)** — needs an ADR: Orleans 10's `Orleans.Journaling`
   (`DurableValue`/`DurableDictionary`/`DurableList`/… that journal mutations automatically) overlaps
   the existing reducer/persistent-state model; decide whether to adopt it or map it onto what ships.
-- **Durable jobs** — needs an ADR: Orleans 10's `Orleans.DurableJobs` (durable execution / workflow
-  engine) is a large, optional addition.
+- **Durable jobs** — designed in [ADR 0018](adr/0018-durable-jobs.md) (design only, not yet
+  implemented). Orleans 10's `Orleans.DurableJobs` is — despite the name — **not** a workflow/replay
+  engine but a **sharded, durable, at-least-once scheduled-execution** engine (one-shot grain
+  invocations bucketed by due time, with retries, per-silo concurrency control, slow-start, and
+  crash-failover with poison-shard protection). The ADR ports it as `@tsva/durable-jobs`, layered on
+  the runtime the way `@tsva/reminders` is, with a four-slice plan.
 
 ## Deferred (not parity gaps)
 

--- a/docs/adr/0018-durable-jobs.md
+++ b/docs/adr/0018-durable-jobs.md
@@ -1,0 +1,249 @@
+# ADR 0018 — Durable jobs (sharded, durable, at-least-once scheduled execution)
+
+- Status: Proposed — design only, no implementation. Slice plan with exit criteria below.
+- Context docs: [07 — Persistence](../07-persistence.md),
+  [06 — Grain directory and placement](../06-grain-directory-and-placement.md),
+  [13 — Roadmap](../13-roadmap-and-phases.md);
+  [ADR 0005](0005-redis-default-providers.md) (default durable backend),
+  [ADR 0009](0009-functional-grains.md) (functional authoring),
+  [ADR 0015](0015-broadcast-channels.md) (the symbol-keyed handler idiom),
+  [ADR 0016](0016-activation-rebalancer.md) (elected/membership-driven background work).
+
+> Orleans references (read to ground this ADR): `Orleans.DurableJobs/DurableJob.cs`,
+> `IDurableJobHandler.cs` (`IJobRunContext`, `IDurableJobHandler.ExecuteJobAsync`),
+> `DurableJobRunResult.cs` (`Completed` / `PollAfter` / `Failed`), `ScheduleJobRequest.cs`,
+> `ILocalDurableJobManager.cs`, `IDurableJobReceiverExtension.cs` (the per-grain receiver, `RunId`
+> task tracking, `[AlwaysInterleave]`), `JobShard.cs` (`IJobShard` + the abstract
+> `PersistAddJobAsync` / `PersistRemoveJobAsync` / `PersistRetryJobAsync` hooks),
+> `InMemoryJobQueue.cs` (due-time priority queue), `JobShardManager.cs`
+> (`AssignJobShardsAsync`, dead-silo adoption, `AdoptedCount` / poison shards),
+> `ShardExecutor.cs` (concurrency limiter, concurrency slow-start, overload backoff, the poll loop,
+> retry), `LocalDurableJobManager.cs` (the `SystemTarget`, shard-key bucketing, the periodic check,
+> shard-claim ramp-up), `Hosting/DurableJobsOptions.cs` + `DurableJobsExtensions.cs`. There is **no**
+> `Orleans.DurableJobs.Abstractions` project — the whole feature lives in one assembly — and it has
+> **no dependency on `Orleans.Journaling`**.
+
+## Context
+
+Reminders ([roadmap phase 5](../13-roadmap-and-phases.md), `@tsva/reminders`) already give the port
+durable, single-fire-and-recurring callbacks: a grain registers a reminder, the durable
+`ReminderTable` keeps it, and the silo that owns the grain's hash range on the ring re-reads the
+table and fires it — surviving deactivation and the owning silo's death. That covers "wake grain
+*G* every *p*". It does **not** scale to "schedule a few million one-shot callbacks for arbitrary
+future times, run them with bounded per-silo concurrency, retry the failures, and don't melt a silo
+that just rejoined after an outage." Reminder ownership is keyed by *grain hash*, so a burst of
+jobs all targeting one grain (or all due at one instant) has nowhere to spread, and there is no
+retry, concurrency, or back-pressure model around the fire.
+
+Orleans 10 adds `Orleans.DurableJobs` for exactly this. **It is important to be precise about what it
+is, because the name misleads:** despite "jobs" suggesting a Temporal / Durable Task Framework-style
+*workflow* engine, the Orleans implementation is **not** an orchestration/deterministic-replay
+engine. There are no activities, no sub-orchestrations, no replay of a workflow function, no
+durable awaits inside a workflow body. The unit of work is a **single scheduled invocation of a
+target grain at a due time**, made durable, sharded for scale, retried on failure, and rebalanced
+across silos on membership change. It is best understood as **"reminders at scale, one-shot, with
+retries, concurrency control, and crash-failover of the work itself."** This ADR ports that, and
+the headline scope boundary (below) is to *not* grow it into a workflow engine.
+
+### How Orleans' engine actually works (the model we port)
+
+- **`DurableJob`** — `{ Id, Name, DueTime, TargetGrainId, ShardId, Metadata }`. A job names a target
+  grain and a due time; the target grain is expected to implement `IDurableJobHandler` (one method,
+  `ExecuteJobAsync(IJobRunContext, CancellationToken)`).
+- **Shards are time buckets, owned by one silo.** A job's shard key is
+  `floor(DueTime / ShardDuration)` (default `ShardDuration = 1h`); the shard owns every job whose
+  due time falls in `[start, end)`. A shard is owned and processed by **exactly one silo at a time**
+  — that is the single-writer guarantee, at *shard* granularity rather than *grain* granularity.
+  Sharding by *time* (not by grain key) is what lets a burst all targeting one grain spread across
+  silos and lets the system hold cheap, append-only buckets for the far future.
+- **`IJobShard` is the durable seam.** Its abstract `PersistAddJobAsync` / `PersistRemoveJobAsync`
+  / `PersistRetryJobAsync` hooks are the only contact with storage; an in-memory queue
+  (`InMemoryJobQueue`, a due-time priority queue polled each second) is the runtime working set. The
+  shipped `InMemoryJobShard` makes the persist hooks no-ops — explicitly dev/test only.
+- **`LocalDurableJobManager`** (a per-silo `SystemTarget`, started at the `Active` lifecycle stage)
+  is the orchestrator. `ScheduleJobAsync` buckets the request, gets-or-creates the writable shard,
+  persists the add, and enqueues. A periodic check (every 10 min, or immediately on a membership
+  change) reconciles owned shards from the store and **activates** any shard whose start time is
+  within `ShardActivationBufferPeriod` (default 5 min ahead).
+- **`ShardExecutor`** runs an activated shard: waits until start time, consumes due jobs, and for
+  each one takes a slot from a **concurrency limiter** (`MaxConcurrentJobsPerSilo`, default
+  `10_000 × procs`), with a **concurrency slow-start** (begin at `procCount`, double every 10 s up
+  to the max — avoids cold-cache starvation right after start) and an **overload backoff** (pause
+  consumption while `IOverloadDetector.IsOverloaded`). It calls the target via a per-grain
+  **receiver extension**.
+- **`DurableJobRunResult` drives the per-job outcome:** `Completed` → remove from the shard;
+  `PollAfter(delay)` → an inline poll loop (the executor sleeps `delay` and re-asks, holding the
+  concurrency slot — this is how a long-running handler is supervised without blocking the grain's
+  turn); `Failed(exception)` → the retry policy.
+- **Retries** are a pure policy `ShouldRetry(IJobRunContext, Exception) → DateTimeOffset?`: a new due
+  time to re-enqueue at, or `null` to drop. Default: up to 5 attempts, exponential backoff `2^n` s.
+  `IJobRunContext.DequeueCount` is the attempt counter.
+- **Failover and self-protection.** `JobShardManager.AssignJobShardsAsync` claims shards this silo
+  already owns, **orphaned** shards (an owner that drained set its owner to null), and shards from
+  **dead** silos (via the cluster membership snapshot). A shard adopted from a *dead* owner
+  increments an `AdoptedCount`; past `MaxAdoptedCount` (default 3) the shard is **poisoned** and
+  never reassigned — so one job that crashes its host can't bounce around killing silos. A freshly
+  started silo claims orphaned shards under a **ramp-up budget** (linear from `ShardClaimInitialBudget`
+  2 to `ShardClaimMaxBudget` 20 over `ShardClaimRampUpDuration` 5 min, then unlimited; overload ⇒ 0)
+  so disaster recovery doesn't immediately re-overwhelm the recovering node.
+
+### Delivery semantics
+
+**At-least-once.** A job is durable in the shard store and removed only after it completes; a silo
+that crashes mid-job loses the in-memory slot, another silo adopts the shard, and the job re-runs.
+**Handlers must be idempotent.** There is no exactly-once and no cross-job ordering guarantee beyond
+"a shard's jobs come due roughly in due-time order." Single ownership per shard means no concurrent
+double-processing in steady state (only a crash/adoption window can re-run).
+
+## Decision
+
+Port `Orleans.DurableJobs` faithfully as a new package, **`@tsva/durable-jobs`**, layered on the
+existing runtime exactly the way `@tsva/reminders` is — and **not** as a workflow engine. Keep
+Orleans' shard/ownership/retry/back-pressure model; express the authoring surface functional-first
+([ADR 0009](0009-functional-grains.md)); reuse the port's clock, membership, ring-leadership,
+dispatcher and Redis-default ([ADR 0005](0005-redis-default-providers.md)) seams rather than adding
+parallel machinery.
+
+### Package layout — `@tsva/durable-jobs`
+
+Structured as the mirror of `@tsva/reminders` (per-silo service + durable table + memory/Redis
+backings):
+
+- **Types** — `DurableJob`, `ScheduleJobRequest`, `JobRunContext`, `DurableJobRunResult`
+  (`completed` / `pollAfter(delay)` / `failed(error)`), `DurableJobsOptions`.
+- `local-durable-job-manager.ts` — the per-silo manager (analogue of `local-reminder-service.ts`):
+  bucket-and-schedule, the periodic shard check, membership-driven reconcile, claim-budget ramp-up.
+  Driven by the **injectable clock** so it is deterministically testable, exactly like the reminder
+  service.
+- `job-shard.ts` — the `JobShard` base with the three abstract `persistAdd/Remove/Retry` hooks;
+  `in-memory-job-queue.ts` — the due-time priority queue (second-granularity buckets, cancel/retry).
+- `shard-executor.ts` — concurrency limiter, concurrency slow-start, overload backoff, the poll loop,
+  the retry application.
+- `job-shard-store.ts` — the durable shard+job table **contract** (the `ReminderTable` analogue),
+  with `memory-job-shard-store.ts` (dev/test) and `redis-job-shard-store.ts` (the default,
+  [ADR 0005](0005-redis-default-providers.md)).
+
+### How it sits on the existing port
+
+- **Grains (the target / receiver).** Orleans auto-registers an `IDurableJobReceiverExtension` on
+  every grain so any grain implementing `IDurableJobHandler` is targetable without per-grain wiring,
+  and the extension tracks the running task by `RunId` so a poll returns status without re-running or
+  blocking the grain's turn (`[AlwaysInterleave]`). This port has no grain-extension mechanism but it
+  has the **symbol-keyed handler idiom** the equivalent features already use —
+  `STREAM_SUBSCRIPTION_OBSERVER`, `BROADCAST_CHANNEL_OBSERVER`, `INCOMING_CALL_FILTER`. So a target
+  grain opts in by exposing a `DURABLE_JOB_HANDLER` handler; the executor dispatches the job to it
+  over the existing dispatcher (the same path `receiveReminder` takes in `cluster-node.ts`). A small
+  per-activation receiver shim holds the `RunId → running task` map and answers polls, reproducing
+  the extension's behaviour on top of the dispatcher.
+- **Reminders.** Durable jobs reuse the *shape* of `LocalReminderService` — per-silo, backed by a
+  durable table, reconciled on membership change, clock-driven — and the same ring-leadership /
+  membership-snapshot seams. They deliberately **do not** reuse reminders' *hash-range* ownership:
+  the unit of ownership is the **time-bucketed shard**, claimed from the store with explicit
+  owner/adopt/poison bookkeeping, because jobs are bucketed by due time, not by grain key. Reminders
+  and durable jobs are complementary, not redundant: reminders for recurring per-grain wakeups,
+  durable jobs for high-volume one-shot scheduled work with retries and back-pressure.
+- **Persistence.** The shard store is its **own** durable table (Redis by default, like the
+  `ReminderTable`), not `GrainStorage` — jobs are queue entries keyed by shard, not grain state, so
+  there is no etag-per-job model and nothing to read-on-activate. It reuses the existing
+  serializer/value-codec ([04](../04-messaging-and-serialization.md)) for job metadata, and the
+  directory/ring + membership snapshot ([06](../06-grain-directory-and-placement.md)) for shard
+  claim and failover.
+- **Journaling (ADR 0017 — durable journaling, not yet written).** No journaling ADR exists yet
+  (the ADR series ends at 0016; durable journaling is the still-unwritten next slot, see
+  [docs/13](../13-roadmap-and-phases.md) and [EPICS](../../EPICS.md)). **Durable jobs do not need it,
+  and do not wait on it:** Orleans' own `Orleans.DurableJobs` has no dependency on
+  `Orleans.Journaling` — durability there is the `IJobShard` persist hooks, which this port maps onto
+  the shard store. If a journaling ADR later lands, the shard store *could* optionally journal its
+  mutations instead of doing discrete add/remove/retry writes, but that is an implementation choice
+  off this feature's critical path, not a prerequisite.
+
+### Public authoring surface (functional-first)
+
+Scheduling mirrors `registerReminder` on the grain runtime; handling mirrors the symbol-observer
+hooks; hosting mirrors `useReminders` / `useRedisReminders`.
+
+- **Schedule / cancel**, from any grain:
+
+  ```ts
+  const job = await ctx.runtime.scheduleJob({
+    target,                      // GrainId of the handler grain
+    name: "send-reminder-email",
+    dueTime: addHours(now, 24),
+    metadata: { userId },
+  });
+  await ctx.runtime.cancelJob(job); // best-effort; true if removed before it ran
+  ```
+
+- **Handle**, in the target grain's factory (functional-first; the class form exposes the same
+  handler under the `DURABLE_JOB_HANDLER` symbol):
+
+  ```ts
+  export const Mailer = defineGrain("Mailer", (ctx) => {
+    useDurableJobHandler(ctx, async (job) => {
+      await send(job.metadata.userId);
+      // resolve ⇒ Completed; throw ⇒ Failed (retry policy decides);
+      // return pollAfter(seconds(5)) ⇒ supervised long-running work
+    });
+    return { /* ... */ };
+  });
+  ```
+
+- **Hosting**: `createSilo().useDurableJobs(store?)`, `.useRedisDurableJobs({ url })`,
+  `.useMemoryDurableJobs()` (dev/test), with a `DurableJobsOptions` mirroring Orleans'
+  (`shardDuration`, `shardActivationBufferPeriod`, `maxConcurrentJobsPerSilo`, the slow-start knobs,
+  `shouldRetry`, `maxAdoptedCount`, and the shard-claim ramp-up budget).
+
+## Slice plan (TDD, vertical, testable)
+
+Each slice is demonstrable and tested before the next, following the workflow in
+[CLAUDE.md](../../CLAUDE.md) and the roadmap's exit-criteria discipline.
+
+- **Slice 1 — the pure model (no cluster, fake clock).** Shard-key bucketing
+  (`floor(dueTime/shardDuration)`), the in-memory due-time queue (priority by due time,
+  second-granularity buckets, cancel, retry-later preserving `dequeueCount`), the default retry
+  policy, and the claim-budget computation — all as pure functions.
+  - *Exit:* unit tests show jobs surface in due-time order; a cancelled job never surfaces; a
+    retried job re-surfaces at its new due time with `dequeueCount` incremented; the default policy
+    drops after 5 attempts with `2^n` s backoff; the claim budget interpolates and clamps as
+    specified. Fully deterministic on the injectable clock.
+- **Slice 2 — single-silo end-to-end on the memory store.** Manager + executor + the
+  `DURABLE_JOB_HANDLER` receiver, wired through the dispatcher.
+  - *Exit:* a scheduled job fires the target grain's handler **as a turn** at its due time; resolve
+    removes it; throwing retries with backoff up to N then drops; `cancelJob` before due removes it;
+    a handler returning `pollAfter` is re-polled and only removed on completion; the per-silo
+    concurrency limit and overload backoff are honoured.
+- **Slice 3 — durable store + restart.** The Redis `JobShardStore` implementing the persist hooks.
+  - *Exit:* a job scheduled before a silo restart is re-read from the store and fired after restart
+    (at-least-once); a job that ran but whose silo died before removal re-runs after adoption; the
+    memory store is asserted dev/test-only (no persistence across a fresh store).
+- **Slice 4 — multi-silo ownership & failover (kind e2e).** Shard claim from the store, dead-silo
+  adoption via the membership snapshot, poison protection, and the claim ramp-up; mirrors the
+  existing reminder-failover cluster test.
+  - *Exit:* killing a silo causes another to adopt and drain its shards with no lost jobs beyond
+    expected at-least-once redelivery; a shard adopted past `maxAdoptedCount` is poisoned and never
+    reassigned; a freshly started silo respects the ramp-up budget; graceful drain releases shards
+    (owner→null, adopted count reset) for another silo to pick up.
+
+## Scope boundaries and divergences
+
+- **Not a workflow / orchestration engine.** No activities, sub-orchestrations, deterministic
+  replay, or durable awaits inside a job body — a job is one scheduled grain invocation. This is the
+  defining boundary and it matches Orleans' actual `Orleans.DurableJobs`, not the Temporal/DTFx
+  engine the name evokes. A future workflow engine, if ever wanted, is a separate ADR built *on top*
+  of durable jobs, not this one.
+- **At-least-once, idempotent handlers required.** No exactly-once; no cross-job ordering beyond
+  due-time bucketing. Documented as a hard contract on the authoring surface.
+- **Time-bucketed shard ownership, not reminders' hash-range ownership** — a deliberate divergence,
+  required because jobs are bucketed by due time rather than grain key.
+- **Overload signal.** Orleans throttles on `IOverloadDetector`. The port has health/drain plumbing
+  but no per-silo load gossip (the same gap [ADR 0016](0016-activation-rebalancer.md) calls out). The
+  executor will expose an overload hook; the initial backing is a simple local signal (e.g.
+  concurrency-slot saturation / health state), with cluster-aware load deferred to the same future
+  work as the rebalancer's load reporting.
+- **Memory store is dev/test only** (no-op persistence), exactly as in Orleans.
+- **Cancellation** is cooperative via shard takeover (matching Orleans); a `CancellationToken`
+  threaded into handler bodies is not part of the first cut. A `cancelJob` race after a job has
+  started returns `false`.
+- **Deferred:** a query/index surface beyond the returned `DurableJob` handle (e.g. "list jobs for
+  target *G*", per-job status lookup), and pluggable non-Redis shard stores ([ADR 0005](0005-redis-default-providers.md)
+  keeps Postgres et al. as deferred additional providers, not parity gaps).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,3 +18,4 @@ Each ADR captures one significant decision, its context, the rationale, and its 
 - [0014 — Grain-interface versioning (version-aware placement)](0014-grain-interface-versioning.md)
 - [0015 — Broadcast channels (lightweight in-cluster pub/sub)](0015-broadcast-channels.md)
 - [0016 — Activation rebalancer (adaptive, entropy-minimizing)](0016-activation-rebalancer.md)
+- [0018 — Durable jobs (sharded, durable, at-least-once scheduled execution)](0018-durable-jobs.md)

--- a/todo.md
+++ b/todo.md
@@ -314,6 +314,25 @@ order, starting with transactions.
       Delivery awaits subscribers (one deliberate divergence from Orleans' fire-and-forget default).
       Tests: `channelKey` unit, namespace→types registration, dispatcher fan-out (class + functional +
       producer-grain publish, no-observer drop).
+- [ ] Durable journaling (`DurableGrain`) — Orleans 10 `Orleans.Journaling`; needs an ADR (overlaps
+      the reducer/persistent-state model). Next ADR slot (0017).
+- [~] Durable jobs — Orleans 10 `Orleans.DurableJobs`: a **sharded, durable, at-least-once
+      scheduled-execution** engine (one-shot grain invocations bucketed by due time, with retries,
+      per-silo concurrency control, slow-start, and crash-failover with poison-shard protection) —
+      **not** a workflow/replay engine despite the name. Designed in
+      [ADR 0018](docs/adr/0018-durable-jobs.md) as `@tsva/durable-jobs`, layered on the runtime the
+      way `@tsva/reminders` is (per-silo manager + durable shard store + memory/Redis backings; a
+      `DURABLE_JOB_HANDLER` symbol handler; `runtime.scheduleJob`/`cancelJob`; `useDurableJobs`).
+      Design only — implementation pending.
+  - [ ] Slice 1 — pure model: shard-key bucketing, the due-time job queue (cancel/retry), the default
+        retry policy, and the claim-budget computation, all pure + fake-clock unit-tested.
+  - [ ] Slice 2 — single-silo e2e on the memory store: a scheduled job fires the target's
+        `DURABLE_JOB_HANDLER` as a turn at due time; complete/throw-retry/cancel/`pollAfter`;
+        concurrency limit + overload backoff.
+  - [ ] Slice 3 — durable store + restart: Redis `JobShardStore`; a job survives silo restart and
+        re-fires (at-least-once); memory store asserted dev/test-only.
+  - [ ] Slice 4 — multi-silo ownership & failover (kind e2e): shard claim/adoption via membership,
+        poison-shard protection, claim ramp-up, graceful release on drain.
 - [~] Observability (cross-cutting) — OpenTelemetry traces propagated via request context, metrics
       (activations, turn latency, directory hit rate, reminder/stream lag), and structured logs.
   - [x] Slice 1 — ambient request context (Orleans `RequestContext`): `requestContext.get/set/getAll`


### PR DESCRIPTION
## Summary

This PR introduces ADR 0018, which designs `@tsva/durable-jobs` — a sharded, durable, at-least-once scheduled-execution engine for one-shot grain invocations. Despite the name, it is **not** a workflow/orchestration engine, but rather "reminders at scale with retries, concurrency control, and crash-failover."

The design faithfully ports Orleans 10's `Orleans.DurableJobs` model: jobs are bucketed by due time into shards (owned one-per-silo), executed with per-silo concurrency limits and slow-start ramp-up, retried on failure, and rebalanced across silos on membership change with poison-shard protection.

## Key Changes

- **ADR 0018** (`docs/adr/0018-durable-jobs.md`): Complete design document covering:
  - The Orleans model (shards as time buckets, single-writer per shard, at-least-once delivery)
  - Package layout mirroring `@tsva/reminders` (manager, executor, store contract, memory/Redis backings)
  - Integration points (symbol-keyed `DURABLE_JOB_HANDLER`, dispatcher, ring-leadership, clock injection)
  - Public authoring surface (functional-first: `scheduleJob`, `cancelJob`, `useDurableJobHandler`)
  - Four-slice TDD plan with explicit exit criteria (pure model → single-silo e2e → durable store → multi-silo failover)
  - Scope boundaries (not a workflow engine, at-least-once with idempotent handlers, time-bucketed ownership, deferred query surface)

- **Updated `todo.md`**: Added durable jobs to the roadmap with the four slices and marked as design-only pending implementation.

- **Updated `docs/13-roadmap-and-phases.md`**: Clarified that durable jobs is designed (ADR 0018) but not yet implemented, and corrected the characterization from "workflow engine" to "sharded, durable, at-least-once scheduled-execution engine."

- **Updated `EPICS.md`**: Marked durable jobs as designed (ADR 0018) with the same clarification.

- **Updated `docs/adr/README.md`**: Added reference to ADR 0018.

## Notable Design Decisions

- **Time-bucketed shards, not hash-range ownership**: Jobs are bucketed by `floor(dueTime / shardDuration)` rather than grain key, enabling high-volume bursts to spread across silos and cheap append-only buckets for the far future.
- **Layered on existing runtime**: Reuses clock injection, membership snapshots, ring-leadership, dispatcher, and Redis defaults — no parallel machinery.
- **Symbol-keyed handler idiom**: Target grains expose a `DURABLE_JOB_HANDLER` handler (matching the pattern used by streams and broadcast channels), dispatched over the existing grain-call path.
- **Explicit failover model**: Shards claimed from the store with owner/adopt/poison bookkeeping; dead-silo adoption via membership snapshot; poison protection (max 3 adoptions) prevents one crashing job from bouncing around killing silos.
- **Concurrency control with slow-start**: Per-silo concurrency limiter with linear ramp-up (avoid cold-cache starvation) and overload backoff (pause on health signal).
- **No journaling dependency**: Durability is the shard store's persist hooks, not `Orleans.Journaling` — a deliberate independence from the still-unwritten durable-journaling ADR.

## Status

Design only — implementation pending. The four-slice plan follows the project's TDD and vertical-slice discipline, with each slice demonstrable and tested before the next.

https://claude.ai/code/session_01KR3XdQTic1x8DMtnYLenEx