### PR TITLE
Migrate remaining examples to functional-first grain style

### DIFF
--- a/EPICS.md
+++ b/EPICS.md
@@ -32,13 +32,14 @@ decisions.
       **OpenTelemetry tracing**, **metrics** (call counter + duration histogram, activation gauge,
       directory-cache hit/miss), and **structured logging**, all on the call-filter seam and no-op
       without an SDK/logger. (Reminder/stream-lag gauges deferred as optional polish.)
+- [x] **Functional-first examples** — every example grain is authored with `defineGrain` + hooks,
+      matching the docs; one `@grain()` class (`examples/thermostat`) is kept on purpose as the living
+      interop example the functional aggregator consumes from.
 
 ## 🚧 In progress
 
 - [~] **External client** — in-process gateway-routed client ships; higher-level gateway discovery +
       a WebSocket client e2e remain.
-- [~] **Functional-first examples** — docs lead functional; a few examples are still `@grain()`
-      classes to migrate (one kept as a living interop example).
 
 ## 📋 TODO — remaining for Orleans 10 parity
 

--- a/examples/chat/src/chat-room-grain.ts
+++ b/examples/chat/src/chat-room-grain.ts
@@ -1,5 +1,4 @@
-import { grain } from "@tsva/core/decorators";
-import { Grain } from "@tsva/core/grain";
+import { defineGrain } from "@tsva/core/define-grain";
 import { CHAT, type ChatMessage, type IChatRoom } from "@tsva/example-chat/interfaces";
 
 /**
@@ -7,12 +6,11 @@ import { CHAT, type ChatMessage, type IChatRoom } from "@tsva/example-chat/inter
  * stream and every member that subscribed receives it. The room holds no member
  * list — the stream is the membership.
  */
-@grain()
-export class ChatRoomGrain extends Grain implements IChatRoom {
-  async say(from: string, text: string): Promise<void> {
-    await this.runtime
+export const ChatRoomGrain = defineGrain<IChatRoom>("ChatRoom", (ctx) => ({
+  say: async (from: string, text: string): Promise<void> => {
+    await ctx.runtime
       .getStreamProvider()
-      .getStream<ChatMessage>(CHAT, this.id.key)
+      .getStream<ChatMessage>(CHAT, ctx.id.key)
       .publish({ from, text });
-  }
-}
+  },
+}));

--- a/examples/chat/src/chat-user-grain.ts
+++ b/examples/chat/src/chat-user-grain.ts
@@ -1,5 +1,4 @@
-import { grain } from "@tsva/core/decorators";
-import { Grain } from "@tsva/core/grain";
+import { defineGrain } from "@tsva/core/define-grain";
 import type { StreamHandler } from "@tsva/core/stream";
 import { CHAT, type ChatMessage, type IChatUser } from "@tsva/example-chat/interfaces";
 
@@ -13,22 +12,21 @@ import { CHAT, type ChatMessage, type IChatUser } from "@tsva/example-chat/inter
  * neighbour's. `onNext` mutates `received` with no lock — proof it runs as a
  * turn on this activation.
  */
-@grain()
-export class ChatUserGrain extends Grain implements IChatUser {
-  private received: ChatMessage[] = [];
+export const ChatUserGrain = defineGrain<IChatUser>("ChatUser", (ctx) => {
+  const received: ChatMessage[] = [];
 
-  async join(room: string): Promise<void> {
-    const stream = this.runtime.getStreamProvider().getStream<ChatMessage>(CHAT, room);
-    const mine = await stream.getSubscriptions();
-    if (mine.length > 0) await mine[0]!.resume(this.handler());
-    else await stream.subscribe(this.handler());
-  }
+  const handler = (): StreamHandler<ChatMessage> => ({
+    onNext: async (message) => void received.push(message),
+  });
 
-  async history(): Promise<ChatMessage[]> {
-    return [...this.received]; // a snapshot — never leak the live internal array
-  }
+  return {
+    join: async (room: string): Promise<void> => {
+      const stream = ctx.runtime.getStreamProvider().getStream<ChatMessage>(CHAT, room);
+      const mine = await stream.getSubscriptions();
+      if (mine.length > 0) await mine[0]!.resume(handler());
+      else await stream.subscribe(handler());
+    },
 
-  private handler(): StreamHandler<ChatMessage> {
-    return { onNext: async (message) => void this.received.push(message) };
-  }
-}
+    history: async (): Promise<ChatMessage[]> => [...received], // a snapshot — never leak the live internal array
+  };
+});

--- a/examples/cluster/src/leaderboard-grain.ts
+++ b/examples/cluster/src/leaderboard-grain.ts
@@ -1,5 +1,4 @@
-import { grain } from "@tsva/core/decorators";
-import { Grain } from "@tsva/core/grain";
+import { defineGrain } from "@tsva/core/define-grain";
 import type { ILeaderboard, ScoreEntry } from "@tsva/example-cluster/interfaces";
 
 /**
@@ -7,19 +6,19 @@ import type { ILeaderboard, ScoreEntry } from "@tsva/example-cluster/interfaces"
  * in the cluster are routed to this one activation and run as serialized turns,
  * so the `Map` is only ever touched by one turn at a time.
  */
-@grain()
-export class LeaderboardGrain extends Grain implements ILeaderboard {
-  private readonly best = new Map<string, number>();
+export const LeaderboardGrain = defineGrain<ILeaderboard>("Leaderboard", () => {
+  const best = new Map<string, number>();
 
-  async record(player: string, score: number): Promise<void> {
-    const current = this.best.get(player);
-    if (current === undefined || score > current) this.best.set(player, score);
-  }
+  return {
+    record: async (player: string, score: number): Promise<void> => {
+      const current = best.get(player);
+      if (current === undefined || score > current) best.set(player, score);
+    },
 
-  async top(limit = 10): Promise<ScoreEntry[]> {
-    return [...this.best.entries()]
-      .map(([player, score]) => ({ player, score }))
-      .sort((a, b) => b.score - a.score)
-      .slice(0, limit);
-  }
-}
+    top: async (limit = 10): Promise<ScoreEntry[]> =>
+      [...best.entries()]
+        .map(([player, score]) => ({ player, score }))
+        .sort((a, b) => b.score - a.score)
+        .slice(0, limit),
+  };
+});

--- a/examples/greeter/src/greeter-grain.ts
+++ b/examples/greeter/src/greeter-grain.ts
@@ -1,5 +1,4 @@
-import { grain } from "@tsva/core/decorators";
-import { Grain } from "@tsva/core/grain";
+import { defineGrain } from "@tsva/core/define-grain";
 import type { IGreeter } from "@tsva/example-greeter/interfaces";
 
 /**
@@ -11,21 +10,20 @@ import type { IGreeter } from "@tsva/example-greeter/interfaces";
  * - the `count` is volatile activation state — after the grain deactivates while
  *   idle, the next call reactivates it fresh and the count starts again at 1.
  */
-@grain()
-export class GreeterGrain extends Grain implements IGreeter {
-  private prefix = "uninitialised";
-  private count = 0;
+export const GreeterGrain = defineGrain<IGreeter>("Greeter", (ctx) => {
+  let prefix = "uninitialised";
+  let count = 0;
 
-  override async onActivate(): Promise<void> {
-    this.prefix = `[${String(this.id.key)}]`;
-  }
+  return {
+    onActivate: async () => {
+      prefix = `[${String(ctx.id.key)}]`;
+    },
 
-  async greet(name: string): Promise<string> {
-    this.count++;
-    return `${this.prefix} Hello, ${name}! (greeting #${this.count})`;
-  }
+    greet: async (name: string): Promise<string> => {
+      count++;
+      return `${prefix} Hello, ${name}! (greeting #${count})`;
+    },
 
-  async greetings(): Promise<number> {
-    return this.count;
-  }
-}
+    greetings: async (): Promise<number> => count,
+  };
+});

--- a/examples/k8s-silo/src/counter-grain.ts
+++ b/examples/k8s-silo/src/counter-grain.ts
@@ -1,6 +1,4 @@
-import { grain, persistentState } from "@tsva/core/decorators";
-import { Grain } from "@tsva/core/grain";
-import type { PersistentState } from "@tsva/core/persistent-state";
+import { defineGrain, usePersistentState } from "@tsva/core/define-grain";
 import type { CounterReply, ICounter } from "@tsva/example-k8s-silo/interfaces";
 
 interface CounterState {
@@ -15,18 +13,18 @@ const hostName = (): string => process.env.POD_NAME ?? "local";
  * host pod dies the activation reactivates on a survivor and resumes from the
  * stored value rather than starting over.
  */
-@grain()
-export class CounterGrain extends Grain implements ICounter {
-  @persistentState("counter", { defaultValue: (): CounterState => ({ value: 0 }) })
-  private state!: PersistentState<CounterState>;
+export const CounterGrain = defineGrain<ICounter>("Counter", (ctx) => {
+  const state = usePersistentState<CounterState>(ctx, "counter", {
+    defaultValue: (): CounterState => ({ value: 0 }),
+  });
 
-  async increment(): Promise<CounterReply> {
-    this.state.value.value += 1;
-    await this.state.write();
-    return { value: this.state.value.value, host: hostName() };
-  }
+  return {
+    increment: async (): Promise<CounterReply> => {
+      state.value.value += 1;
+      await state.write();
+      return { value: state.value.value, host: hostName() };
+    },
 
-  async current(): Promise<CounterReply> {
-    return { value: this.state.value.value, host: hostName() };
-  }
-}
+    current: async (): Promise<CounterReply> => ({ value: state.value.value, host: hostName() }),
+  };
+});

--- a/examples/thermostat/src/fleet-aggregator-grain.ts
+++ b/examples/thermostat/src/fleet-aggregator-grain.ts
@@ -1,5 +1,4 @@
-import { grain } from "@tsva/core/decorators";
-import { Grain } from "@tsva/core/grain";
+import { defineGrain } from "@tsva/core/define-grain";
 import type { StreamHandler } from "@tsva/core/stream";
 import {
   TELEMETRY,
@@ -7,35 +6,34 @@ import {
   type ThermostatStatus,
 } from "@tsva/example-thermostat/interfaces";
 
-/** Subscribes to a device's telemetry stream and keeps a rolling average. */
-@grain()
-export class FleetAggregatorGrain extends Grain implements IFleetAggregator {
-  private sum = 0;
-  private count = 0;
+/**
+ * Subscribes to a device's telemetry stream and keeps a rolling average. The
+ * functional counterpart to the class-based `ThermostatGrain` it consumes from —
+ * the two styles interoperate over the same stream (see `thermostat-grain.ts`).
+ */
+export const FleetAggregatorGrain = defineGrain<IFleetAggregator>("FleetAggregator", (ctx) => {
+  let sum = 0;
+  let count = 0;
 
-  override async onActivate(): Promise<void> {
-    const stream = this.runtime
-      .getStreamProvider()
-      .getStream<ThermostatStatus>(TELEMETRY, this.id.key);
-    const existing = await stream.getSubscriptions();
-    if (existing.length > 0) await existing[0]!.resume(this.handler());
-    else await stream.subscribe(this.handler());
-  }
+  const handler = (): StreamHandler<ThermostatStatus> => ({
+    onNext: async (status) => {
+      sum += status.tempC;
+      count++;
+    },
+  });
 
-  async averageTemp(): Promise<number> {
-    return this.count === 0 ? 0 : this.sum / this.count;
-  }
+  return {
+    onActivate: async () => {
+      const stream = ctx.runtime
+        .getStreamProvider()
+        .getStream<ThermostatStatus>(TELEMETRY, ctx.id.key);
+      const existing = await stream.getSubscriptions();
+      if (existing.length > 0) await existing[0]!.resume(handler());
+      else await stream.subscribe(handler());
+    },
 
-  async sampleCount(): Promise<number> {
-    return this.count;
-  }
+    averageTemp: async (): Promise<number> => (count === 0 ? 0 : sum / count),
 
-  private handler(): StreamHandler<ThermostatStatus> {
-    return {
-      onNext: async (status) => {
-        this.sum += status.tempC;
-        this.count++;
-      },
-    };
-  }
-}
+    sampleCount: async (): Promise<number> => count,
+  };
+});

--- a/examples/thermostat/src/thermostat-grain.ts
+++ b/examples/thermostat/src/thermostat-grain.ts
@@ -27,6 +27,13 @@ const defaultState = (): ThermostatState => ({
  * The worked Orleans thermostat: two interfaces on one grain, durable state via
  * `@persistentState`, a durable self-check reminder, and telemetry published to
  * a stream — single-threaded, no locks.
+ *
+ * Retained deliberately as the `@grain()` class form. Functional-first
+ * (`defineGrain` + hooks) is the documented default (ADR 0009) and every other
+ * example now uses it — but the class is the runtime substrate both styles
+ * compile down to, so one living example keeps that path exercised and shows the
+ * two interoperate: the functional `FleetAggregatorGrain` in this same example
+ * consumes the telemetry this class publishes.
  */
 @grain()
 export class ThermostatGrain extends Grain implements IThermostat, IThermostatControl, Remindable {

--- a/todo.md
+++ b/todo.md
@@ -370,9 +370,11 @@ order, starting with transactions.
       the substrate / interop surface. ADR 0009/0010 bumped to Accepted; README + `docs/01`/`02`/`07`/
       `08`/`09`/`11`/`12`/`13` reoriented functional-first with a short class-substrate note; the
       `examples/bank` class account grain dropped (functional + dispatch variants kept).
-- [ ] Migrate the remaining examples to functional-first so they match the docs: `examples/greeter`,
-      `examples/chat`, `examples/cluster`, `examples/thermostat`, `examples/k8s-silo` (each currently
-      a `@grain()` class). Keep one class grain somewhere as a living interop example.
+- [x] Migrated the remaining examples to functional-first so they match the docs: `examples/greeter`,
+      `examples/chat`, `examples/cluster`, `examples/k8s-silo`, and the `FleetAggregator` of
+      `examples/thermostat` are now `defineGrain` factories. `ThermostatGrain` is kept deliberately as
+      the `@grain()` class — the living interop example, consumed by the functional aggregator over
+      the telemetry stream. Smoke tests stay green.
 - [ ] Optional ergonomics from the review: move the facet hooks onto `ctx`
       (`ctx.persistentState(...)` / `ctx.reducerState(...)`) to drop the `INSTANCE`-symbol smuggling
       and the misleading `use*` prefix; add `useReminder` / `useTimer` / `useActivate` sugar.


### PR DESCRIPTION
Converts all remaining class-based example grains to functional-first `defineGrain` factories, aligning examples with the documented default (ADR 0009) and improving consistency across the codebase.

## Summary

All example grains now use the functional `defineGrain` + hooks pattern instead of `@grain()` class decorators, except for `ThermostatGrain` which is deliberately retained as a class-based example to demonstrate interoperability between the two styles.

## Changes

- **examples/greeter**: `GreeterGrain` converted to `defineGrain` factory with local state variables
- **examples/chat**: Both `ChatUserGrain` and `ChatRoomGrain` converted to functional style
- **examples/cluster**: `LeaderboardGrain` converted to `defineGrain` factory
- **examples/k8s-silo**: `CounterGrain` converted to use `defineGrain` with `usePersistentState` hook
- **examples/thermostat**: `FleetAggregatorGrain` converted to functional style; `ThermostatGrain` kept as class-based grain to serve as the living interop example (consumed by the functional aggregator over telemetry stream)
- **Documentation**: Updated `todo.md` and `EPICS.md` to reflect completion of functional-first examples migration

## Implementation Details

- Replaced `@grain()` decorator + `Grain` base class with `defineGrain<Interface>(name, factory)` calls
- Converted instance fields to local variables in factory closures
- Converted instance methods to object literal properties returning async functions
- Updated `@persistentState` decorator usage to `usePersistentState(ctx, ...)` hook in counter grain
- Grain context (`ctx`) passed as factory parameter provides access to `runtime`, `id`, and other activation context
- All smoke tests remain green; interoperability between functional and class grains verified through thermostat example

https://claude.ai/code/session_01UdWEoQyXngTPH3vEuCEcXW