### PR TITLE
Add Postgres grain storage and reminder table providers

### DIFF
--- a/EPICS.md
+++ b/EPICS.md
@@ -71,5 +71,7 @@ decisions.
 
 ## ⏸ Deferred
 
-- [ ] **Additional durable providers** — Postgres grain storage / reminder table and other stream
-      backings, behind the same interfaces. Redis is the shipped default.
+- [x] **Additional durable providers (Postgres)** — `PostgresGrainStorage` and
+      `PostgresReminderTable` ship behind the same interfaces (`addPostgresStorage` /
+      `usePostgresReminders`); Redis remains the shipped default. Other stream backings remain
+      deferred.

--- a/docs/08-timers-and-reminders.md
+++ b/docs/08-timers-and-reminders.md
@@ -182,7 +182,9 @@ grain's `registerReminder` delegates to the service, and a tick reactivates the 
 membership change across silos. A durable `RedisReminderTable` also ships (`useRedisReminders`):
 reminders are Redis hashes indexed in a sorted set by grain-hash so `readRange` is a server-side
 range query, with atomic Lua upsert/remove and etag CAS — interchangeable with the in-memory table.
-The Postgres table is future work.
+A durable `PostgresReminderTable` also ships (`usePostgresReminders`): each reminder is a row with an
+indexed `hash` column so `readRange` (including wrap-around) is a server-side range query, with an
+etag-CAS remove — likewise interchangeable.
 
 ## Choosing between them
 

--- a/docs/11-public-api-and-examples.md
+++ b/docs/11-public-api-and-examples.md
@@ -139,12 +139,15 @@ The snippets above are the target surface. The shipped surface differs in a few 
 - Grains are registered with the interfaces they serve —
   `registerGrain(ThermostatGrain, { interfaces: [IThermostat, IThermostatControl] })` — because
   TypeScript interfaces are erased at runtime and cannot be reflected.
-- Both in-memory and Redis providers ship. In-memory (dev/tests): `useMemoryStorage()` /
+- In-memory, Redis and Postgres providers ship. In-memory (dev/tests): `useMemoryStorage()` /
   `addStorage(name, p)`, `useReminders(table?)`, `useMemoryStreams()`. Durable Redis:
   `addRedisStorage(name, { url, keyPrefix? })`, `useRedisReminders({ url, keyPrefix? })`, and
-  `addRedisStreams(name, { url, keyPrefix? })` — each connects its client when the silo starts and
-  disconnects when it stops (via host `onStart`/`onStop` hooks). The Postgres providers and stream
-  partitioning (the `partitions` option above) are future work behind the same builder shape.
+  `addRedisStreams(name, { url, keyPrefix? })`. Durable Postgres:
+  `addPostgresStorage(name, { connectionString, tableName? })` and
+  `usePostgresReminders({ connectionString, tableName? })` — each connects (and creates its backing
+  table on start) when the silo starts and disconnects when it stops (via host `onStart`/`onStop`
+  hooks). Stream partitioning (the `partitions` option above) is future work behind the same builder
+  shape.
 - Persistent state is acquired with `usePersistentState(ctx, name, { defaultValue })` — or the
   `@persistentState(name, { defaultValue })` decorator it wraps — and injected before `onActivate`;
   the `getStorage` accessor on `GrainRuntime` is not implemented (the hook/decorator is the supported

--- a/docs/12-project-structure-and-tooling.md
+++ b/docs/12-project-structure-and-tooling.md
@@ -36,8 +36,9 @@ ts-virtual-actors/
 Implemented today: `core`, `messaging`, `directory`, `runtime`, `clustering-k8s`, `persistence`,
 `reminders`, `streams`, `hosting`, `client`, and the `examples/*` above. The `persistence` /
 `reminders` / `streams` packages ship both their **in-memory** providers and durable **Redis**
-providers (grain storage, reminder table, and streams) behind the same interfaces; Postgres backings
-and stream partitioning over the ring are future work. The Redis providers reuse the tagged JSON
+providers (grain storage, reminder table, and streams) behind the same interfaces; **Postgres** grain
+storage and reminder table also ship, while a Postgres stream backing and stream partitioning over the
+ring are future work. The Redis and Postgres providers reuse the tagged JSON
 round-trip in `@tsva/core/value-codec` (which the messaging serializers also use), so persisted state
 and stream events preserve runtime value types (`Date`/`bigint`/`Guid`/`GrainId`).
 

--- a/docs/13-roadmap-and-phases.md
+++ b/docs/13-roadmap-and-phases.md
@@ -36,8 +36,8 @@ core-runtime block) and placement filters. The Orleans-10 additions of durable j
 (`DurableGrain`) and durable jobs need an ADR each (journaling overlaps the existing
 reducer/persistent-state model).
 
-**Deferred:** additional providers (Postgres storage/reminders, other stream backings) — alternatives
-to the shipped Redis defaults, not parity gaps.
+**Deferred:** additional stream backings — alternatives to the shipped Redis defaults, not parity
+gaps. (Postgres grain storage and the Postgres reminder table now ship alongside Redis.)
 
 ## Phase 1 — Single-silo core actor model
 
@@ -84,10 +84,9 @@ builder; reference manifests; graceful drain on `SIGTERM`.
 ## Phase 4 — Persistence
 
 `PersistentState` facet, `@persistentState`, the storage provider contract, etag concurrency;
-in-memory and **Redis (default)** providers. (A Postgres provider is deferred as an additional
-provider — not a parity gap.)
+in-memory, **Redis (default)** and Postgres providers.
 
-- Deliverables: `persistence` with memory/redis providers; runtime read-on-activate wiring.
+- Deliverables: `persistence` with memory/redis/postgres providers; runtime read-on-activate wiring.
 - **Exit criteria:**
   - State written by a grain survives deactivation and pod restart (Redis).
   - A conflicting write (stale etag) raises `InconsistentStateError`.
@@ -97,8 +96,7 @@ provider — not a parity gap.)
 ## Phase 5 — Timers and reminders
 
 In-memory timers; durable reminders with the `ReminderTable` contract, hash-range ownership, and
-rebalancing; **Redis (default)** + in-memory tables. (A Postgres table is deferred as an additional
-provider — not a parity gap.)
+rebalancing; **Redis (default)**, Postgres, and in-memory tables.
 
 - Deliverables: timers in `runtime`; `reminders` with memory/redis tables.
 - **Exit criteria:**
@@ -192,8 +190,8 @@ verified.
 
 ## Deferred (not parity gaps)
 
-- **Additional providers** — Postgres grain storage and reminder table, plus other databases and
-  stream backings/queue adapters. Redis is the shipped default; these are alternatives.
+- **Additional providers** — other databases and stream backings/queue adapters. Redis is the
+  shipped default; Postgres grain storage and reminder table also ship; these are alternatives.
 
 ## Beyond parity (post-Orleans-10 directions)
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@opentelemetry/sdk-metrics": "^2.7.1",
     "@opentelemetry/sdk-trace-base": "^2.7.1",
     "@swc/core": "^1.15.40",
+    "@types/pg": "^8.20.0",
     "eslint": "^10.4.0",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",

--- a/packages/hosting/package.json
+++ b/packages/hosting/package.json
@@ -17,6 +17,7 @@
     "@tsva/runtime": "workspace:*",
     "@tsva/streams": "workspace:*",
     "@tsva/transactions": "workspace:*",
+    "pg": "^8.21.0",
     "redis": "^5.12.1"
   }
 }

--- a/packages/hosting/src/postgres-persistence.test.ts
+++ b/packages/hosting/src/postgres-persistence.test.ts
@@ -1,0 +1,92 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, describe, expect, it } from "vitest";
+import { Pool } from "pg";
+import { grain, persistentState } from "@tsva/core/decorators";
+import { Grain } from "@tsva/core/grain";
+import { defineGrainInterface } from "@tsva/core/grain-interface";
+import type { GrainWithStringKey } from "@tsva/core/key-kinds";
+import type { PersistentState } from "@tsva/core/persistent-state";
+import { SiloAddress } from "@tsva/core/silo-address";
+import { InProcessNetwork } from "@tsva/messaging/in-process-transport";
+import { createSilo } from "@tsva/hosting/silo-builder";
+
+const PG_URL = process.env.PG_URL ?? "postgres://localhost:5432/postgres";
+
+async function reachable(connectionString: string): Promise<Pool | undefined> {
+  const probe = new Pool({ connectionString });
+  probe.on("error", () => {});
+  try {
+    await probe.query("SELECT 1");
+    return probe;
+  } catch {
+    await probe.end().catch(() => {});
+    return undefined;
+  }
+}
+
+const admin = await reachable(PG_URL);
+const tableName = `tsva_test_${randomUUID().replace(/-/g, "")}`;
+
+afterAll(async () => {
+  if (admin === undefined) return;
+  await admin.query(`DROP TABLE IF EXISTS ${tableName}`);
+  await admin.end();
+});
+
+interface BalanceState {
+  cents: number;
+}
+
+interface IAccount extends GrainWithStringKey {
+  deposit(cents: number): Promise<number>;
+  getBalance(): Promise<number>;
+}
+const IAccount = defineGrainInterface<IAccount>("IAccount.postgres", {
+  options: { getBalance: { readOnly: true } },
+});
+
+@grain()
+class AccountGrain extends Grain implements IAccount {
+  @persistentState("balance", { defaultValue: (): BalanceState => ({ cents: 0 }) })
+  private balance!: PersistentState<BalanceState>;
+
+  async deposit(cents: number): Promise<number> {
+    this.balance.value.cents += cents;
+    await this.balance.write();
+    return this.balance.value.cents;
+  }
+
+  async getBalance(): Promise<number> {
+    return this.balance.value.cents;
+  }
+}
+
+const local = new SiloAddress("silo-0", "uid-0", "silo-0:11111");
+
+function buildSilo() {
+  return createSilo({ clusterId: "c1", local })
+    .useStaticMembership([local])
+    .useInProcessTransport(new InProcessNetwork())
+    .addPostgresStorage("default", { connectionString: PG_URL, tableName })
+    .registerGrain(AccountGrain, { interfaces: [IAccount] })
+    .build();
+}
+
+describe.skipIf(admin === undefined)("Postgres persistence end-to-end", () => {
+  it("survives a silo restart via the durable Postgres store", async () => {
+    const first = buildSilo();
+    await first.start();
+    expect(await first.getGrain(IAccount, "acc-1").deposit(100)).toBe(100);
+    expect(await first.getGrain(IAccount, "acc-1").deposit(50)).toBe(150);
+    await first.stop(); // pod dies, Postgres pool closes
+
+    const restarted = buildSilo(); // new pod, same durable store
+    await restarted.start();
+    try {
+      // Read-on-activate repopulates the grain from Postgres, not local memory.
+      expect(await restarted.getGrain(IAccount, "acc-1").getBalance()).toBe(150);
+    } finally {
+      await restarted.stop();
+    }
+  });
+});

--- a/packages/hosting/src/postgres-reminders.test.ts
+++ b/packages/hosting/src/postgres-reminders.test.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, describe, expect, it } from "vitest";
+import { Pool } from "pg";
+import { grain } from "@tsva/core/decorators";
+import { Grain } from "@tsva/core/grain";
+import { defineGrainInterface } from "@tsva/core/grain-interface";
+import type { GrainWithStringKey } from "@tsva/core/key-kinds";
+import type { Remindable, TickStatus } from "@tsva/core/reminder";
+import { SiloAddress } from "@tsva/core/silo-address";
+import { FakeTimeProvider } from "@tsva/core/test-support/fake-time-provider";
+import { InProcessNetwork } from "@tsva/messaging/in-process-transport";
+import { createSilo } from "@tsva/hosting/silo-builder";
+
+const PG_URL = process.env.PG_URL ?? "postgres://localhost:5432/postgres";
+
+async function reachable(connectionString: string): Promise<Pool | undefined> {
+  const probe = new Pool({ connectionString });
+  probe.on("error", () => {});
+  try {
+    await probe.query("SELECT 1");
+    return probe;
+  } catch {
+    await probe.end().catch(() => {});
+    return undefined;
+  }
+}
+
+const admin = await reachable(PG_URL);
+const tableName = `tsva_test_${randomUUID().replace(/-/g, "")}`;
+const checks = new Map<string, number>();
+
+afterAll(async () => {
+  if (admin === undefined) return;
+  await admin.query(`DROP TABLE IF EXISTS ${tableName}`);
+  await admin.end();
+});
+
+interface IBilling extends GrainWithStringKey {
+  scheduleSelfCheck(): Promise<void>;
+  checkCount(): Promise<number>;
+}
+const IBilling = defineGrainInterface<IBilling>("IBilling.postgres");
+
+@grain()
+class BillingGrain extends Grain implements IBilling, Remindable {
+  async scheduleSelfCheck(): Promise<void> {
+    await this.runtime.registerReminder("self-check", { seconds: 60 }, { seconds: 60 });
+  }
+  async checkCount(): Promise<number> {
+    return checks.get(String(this.id.key)) ?? 0;
+  }
+  async receiveReminder(name: string, _status: TickStatus): Promise<void> {
+    if (name === "self-check") {
+      const key = String(this.id.key);
+      checks.set(key, (checks.get(key) ?? 0) + 1);
+    }
+  }
+}
+
+const local = new SiloAddress("silo-0", "uid-0", "silo-0:11111");
+
+describe.skipIf(admin === undefined)("Postgres reminders end-to-end", () => {
+  it("fires a reminder durably recorded in Postgres", async () => {
+    checks.clear();
+    const time = new FakeTimeProvider();
+    const silo = createSilo({ clusterId: "c1", local, time })
+      .useStaticMembership([local])
+      .useInProcessTransport(new InProcessNetwork())
+      .usePostgresReminders({ connectionString: PG_URL, tableName })
+      .registerGrain(BillingGrain, { interfaces: [IBilling] })
+      .build();
+    await silo.start();
+    try {
+      await silo.getGrain(IBilling, "acct").scheduleSelfCheck();
+      time.advance(180_000); // three 60s periods
+      await new Promise((r) => setTimeout(r, 0));
+      expect(await silo.getGrain(IBilling, "acct").checkCount()).toBe(3);
+    } finally {
+      await silo.stop();
+    }
+  });
+});

--- a/packages/hosting/src/silo-builder.ts
+++ b/packages/hosting/src/silo-builder.ts
@@ -20,7 +20,9 @@ import { WebSocketTransport } from "@tsva/messaging/web-socket-transport";
 import type { ReminderTable } from "@tsva/core/reminder";
 import { systemTimeProvider, type TimeProvider } from "@tsva/core/time-provider";
 import { createClient } from "redis";
+import { Pool } from "pg";
 import { MemoryGrainStorage } from "@tsva/persistence/memory-grain-storage";
+import { PostgresGrainStorage } from "@tsva/persistence/postgres-grain-storage";
 import { RedisGrainStorage } from "@tsva/persistence/redis-grain-storage";
 import { bindPersistentStates } from "@tsva/persistence/state-activator";
 import { bindReducerStates } from "@tsva/persistence/reducer-state-activator";
@@ -38,6 +40,7 @@ import type { TransactionalStateStorage } from "@tsva/core/transactional-storage
 import type { StreamProvider } from "@tsva/core/stream";
 import { LocalReminderService } from "@tsva/reminders/local-reminder-service";
 import { MemoryReminderTable } from "@tsva/reminders/memory-reminder-table";
+import { PostgresReminderTable } from "@tsva/reminders/postgres-reminder-table";
 import { RedisReminderTable } from "@tsva/reminders/redis-reminder-table";
 import { MemoryStreamProvider } from "@tsva/streams/memory-stream-provider";
 import { RedisPullingStreamProvider } from "@tsva/streams/redis-pulling-stream-provider";
@@ -116,6 +119,28 @@ export class SiloBuilder {
       client,
       options.keyPrefix !== undefined ? { keyPrefix: options.keyPrefix } : {},
     );
+    return this;
+  }
+
+  /**
+   * Enable durable reminders backed by Postgres. The connection pool is created
+   * here, the reminder table is created on silo start (`start()`), and the pool
+   * is closed on stop; `tableName` namespaces rows (defaults to `"tsva_reminders"`).
+   */
+  usePostgresReminders(options: { connectionString: string; tableName?: string }): this {
+    const pool = new Pool({ connectionString: options.connectionString });
+    pool.on("error", () => {});
+    const table = new PostgresReminderTable(
+      pool,
+      options.tableName !== undefined ? { tableName: options.tableName } : {},
+    );
+    this.starters.push(async () => {
+      await table.start();
+    });
+    this.closers.push(async () => {
+      await pool.end();
+    });
+    this.reminderTable = table;
     return this;
   }
 
@@ -283,6 +308,32 @@ export class SiloBuilder {
         options.keyPrefix !== undefined ? { keyPrefix: options.keyPrefix } : {},
       ),
     );
+  }
+
+  /**
+   * Register a Postgres-backed storage provider. The connection pool is created
+   * here, the backing table is created on silo start (`start()`), and the pool is
+   * closed on stop; `tableName` namespaces rows in a Postgres shared by several
+   * clusters (defaults to `"tsva_grain_state"`). Good when state must also be
+   * queried outside the actor model.
+   */
+  addPostgresStorage(
+    name: string,
+    options: { connectionString: string; tableName?: string },
+  ): this {
+    const pool = new Pool({ connectionString: options.connectionString });
+    pool.on("error", () => {}); // surfaced by start()/queries; don't crash the process
+    const provider = new PostgresGrainStorage(
+      pool,
+      options.tableName !== undefined ? { tableName: options.tableName } : {},
+    );
+    this.starters.push(async () => {
+      await provider.start();
+    });
+    this.closers.push(async () => {
+      await pool.end();
+    });
+    return this.addStorage(name, provider);
   }
 
   /**

--- a/packages/persistence/package.json
+++ b/packages/persistence/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@tsva/core": "workspace:*",
+    "pg": "^8.21.0",
     "redis": "^5.12.1"
   }
 }

--- a/packages/persistence/src/postgres-grain-storage.test.ts
+++ b/packages/persistence/src/postgres-grain-storage.test.ts
@@ -1,0 +1,162 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { Pool } from "pg";
+import { InconsistentStateError } from "@tsva/core/errors";
+import { GrainId } from "@tsva/core/grain-id";
+import type { GrainStorage } from "@tsva/core/grain-storage";
+import { PersistentStateImpl } from "@tsva/persistence/persistent-state-impl";
+import { PostgresGrainStorage } from "@tsva/persistence/postgres-grain-storage";
+
+const PG_URL = process.env.PG_URL ?? "postgres://localhost:5432/postgres";
+
+/** Probe Postgres once at load time so the suite skips cleanly without it. */
+async function reachable(connectionString: string): Promise<Pool | undefined> {
+  const probe = new Pool({ connectionString });
+  probe.on("error", () => {});
+  try {
+    await probe.query("SELECT 1");
+    return probe;
+  } catch {
+    await probe.end().catch(() => {});
+    return undefined;
+  }
+}
+
+const pool = await reachable(PG_URL);
+// A unique table isolates this run from anything else in the shared Postgres.
+const table = `tsva_test_${randomUUID().replace(/-/g, "")}`;
+
+interface Balance {
+  cents: number;
+}
+
+const id = new GrainId("Account", "a1");
+const makeStorage = (): GrainStorage => new PostgresGrainStorage(pool!, { tableName: table });
+const makeState = (storage: GrainStorage, name = "balance") =>
+  new PersistentStateImpl<Balance>(name, id, storage, () => ({ cents: 0 }));
+
+afterAll(async () => {
+  if (pool === undefined) return;
+  await pool.query(`DROP TABLE IF EXISTS ${table}`);
+  await pool.end();
+});
+
+describe.skipIf(pool === undefined)("PostgresGrainStorage", () => {
+  beforeEach(async () => {
+    const storage = makeStorage() as PostgresGrainStorage;
+    await storage.start();
+    await pool!.query(`TRUNCATE TABLE ${table}`);
+  });
+
+  it("starts empty with a default value", async () => {
+    const state = makeState(makeStorage());
+    await state.read();
+    expect(state.exists).toBe(false);
+    expect(state.value.cents).toBe(0);
+    expect(state.etag).toBeUndefined();
+  });
+
+  it("persists a write and reloads it on a fresh activation", async () => {
+    const storage = makeStorage();
+    const first = makeState(storage);
+    first.value.cents = 100;
+    await first.write();
+    expect(first.exists).toBe(true);
+    expect(first.etag).toBeDefined();
+
+    // A fresh storage instance proves it round-trips through Postgres, not memory.
+    const reactivated = makeState(makeStorage());
+    await reactivated.read();
+    expect(reactivated.value.cents).toBe(100);
+  });
+
+  it("raises InconsistentStateError when a stale writer loses the race", async () => {
+    const storage = makeStorage();
+    const a = makeState(storage);
+    await a.read();
+    a.value.cents = 1;
+    await a.write();
+
+    const b = makeState(makeStorage());
+    await b.read(); // reads a's etag
+
+    a.value.cents = 2;
+    await a.write(); // bumps the etag
+
+    b.value.cents = 3;
+    await expect(b.write()).rejects.toBeInstanceOf(InconsistentStateError);
+  });
+
+  it("rejects a blind write over an existing record", async () => {
+    const a = makeState(makeStorage());
+    a.value.cents = 1;
+    await a.write();
+
+    const blind = makeState(makeStorage()); // never read -> no etag
+    blind.value.cents = 9;
+    await expect(blind.write()).rejects.toBeInstanceOf(InconsistentStateError);
+  });
+
+  it("clears the record and resets to the default", async () => {
+    const storage = makeStorage();
+    const state = makeState(storage);
+    state.value.cents = 50;
+    await state.write();
+    await state.clear();
+    expect(state.exists).toBe(false);
+    expect(state.value.cents).toBe(0);
+
+    const reloaded = makeState(makeStorage());
+    await reloaded.read();
+    expect(reloaded.exists).toBe(false);
+  });
+
+  it("treats clearing an absent record as a no-op", async () => {
+    const state = makeState(makeStorage());
+    await state.read();
+    await expect(state.clear()).resolves.toBeUndefined();
+    expect(state.exists).toBe(false);
+  });
+
+  it("rejects a stale clear", async () => {
+    const a = makeState(makeStorage());
+    a.value.cents = 1;
+    await a.write();
+
+    const b = makeState(makeStorage());
+    await b.read(); // reads a's etag
+    a.value.cents = 2;
+    await a.write(); // bumps the etag
+
+    await expect(b.clear()).rejects.toBeInstanceOf(InconsistentStateError);
+  });
+
+  it("round-trips runtime value types (Date) through the codec", async () => {
+    interface WithDate {
+      at: Date;
+    }
+    const when = new Date("2026-05-25T09:00:00.000Z");
+    const a = new PersistentStateImpl<WithDate>("dated", id, makeStorage(), () => ({
+      at: new Date(0),
+    }));
+    a.value.at = when;
+    await a.write();
+
+    const b = new PersistentStateImpl<WithDate>("dated", id, makeStorage(), () => ({
+      at: new Date(0),
+    }));
+    await b.read();
+    expect(b.value.at).toBeInstanceOf(Date);
+    expect(b.value.at.getTime()).toBe(when.getTime());
+  });
+
+  it("keeps named states independent", async () => {
+    const balance = makeState(makeStorage(), "balance");
+    balance.value.cents = 5;
+    await balance.write();
+
+    const limit = makeState(makeStorage(), "limit");
+    await limit.read();
+    expect(limit.exists).toBe(false);
+  });
+});

--- a/packages/persistence/src/postgres-grain-storage.ts
+++ b/packages/persistence/src/postgres-grain-storage.ts
@@ -1,0 +1,144 @@
+import { randomUUID } from "node:crypto";
+import type { Pool } from "pg";
+import { InconsistentStateError } from "@tsva/core/errors";
+import type { GrainId } from "@tsva/core/grain-id";
+import type { GrainStorage, StateHolder } from "@tsva/core/grain-storage";
+import { deserializeValue, serializeValue } from "@tsva/core/value-codec";
+
+export interface PostgresGrainStorageOptions {
+  /** Table holding the state rows (defaults to `"tsva_grain_state"`). */
+  tableName?: string;
+}
+
+// Table names are interpolated (Postgres cannot bind identifiers), so guard
+// them against anything but a plain SQL identifier; all other inputs are bound.
+const IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
+
+// Concurrent silos can race `CREATE TABLE IF NOT EXISTS`; the loser sees a
+// duplicate error even though the table now exists, which is the desired state.
+function isDuplicate(err: unknown): boolean {
+  const code = (err as { code?: string }).code;
+  return code === "23505" || code === "42P07";
+}
+
+/**
+ * Durable, cluster-shared storage provider backed by Postgres. Each named state
+ * is one row (`grain_id`, `state_name`, serialized `data`, `etag`); writes and
+ * clears are conditional single statements so optimistic concurrency holds
+ * across silos — the same etag contract as `MemoryGrainStorage` /
+ * `RedisGrainStorage`. Good when state must also be queried outside the actor
+ * model. `start()` creates the table (idempotent); the host runs it on start.
+ */
+export class PostgresGrainStorage implements GrainStorage {
+  private readonly table: string;
+
+  constructor(
+    private readonly pool: Pool,
+    options: PostgresGrainStorageOptions = {},
+  ) {
+    this.table = options.tableName ?? "tsva_grain_state";
+    if (!IDENTIFIER.test(this.table)) throw new Error(`invalid table name: ${this.table}`);
+  }
+
+  async start(): Promise<void> {
+    try {
+      await this.pool.query(
+        `CREATE TABLE IF NOT EXISTS ${this.table} (
+           grain_id text NOT NULL,
+           state_name text NOT NULL,
+           data text NOT NULL,
+           etag text NOT NULL,
+           PRIMARY KEY (grain_id, state_name)
+         )`,
+      );
+    } catch (err) {
+      if (!isDuplicate(err)) throw err;
+    }
+  }
+
+  async read<T>(stateName: string, grainId: GrainId, state: StateHolder<T>): Promise<void> {
+    const res = await this.pool.query<{ data: string; etag: string }>(
+      `SELECT data, etag FROM ${this.table} WHERE grain_id = $1 AND state_name = $2`,
+      [grainId.toString(), stateName],
+    );
+    const row = res.rows[0];
+    if (row === undefined) {
+      state.exists = false;
+      state.etag = undefined;
+      return;
+    }
+    state.value = deserializeValue<T>(row.data);
+    state.etag = row.etag;
+    state.exists = true;
+  }
+
+  async write<T>(stateName: string, grainId: GrainId, state: StateHolder<T>): Promise<void> {
+    const etag = randomUUID();
+    // No row -> insert succeeds regardless of expected etag (matches the memory
+    // provider). An existing row only updates when the caller's etag still
+    // matches; a blind (`''`, never a UUID) or stale etag updates zero rows.
+    const res = await this.pool.query<{ etag: string }>(
+      `INSERT INTO ${this.table} (grain_id, state_name, data, etag)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (grain_id, state_name) DO UPDATE
+         SET data = EXCLUDED.data, etag = EXCLUDED.etag
+         WHERE ${this.table}.etag = $5
+       RETURNING etag`,
+      [grainId.toString(), stateName, serializeValue(state.value), etag, state.etag ?? ""],
+    );
+    if (res.rows.length === 0) {
+      throw await this.conflict("writing", stateName, grainId, state.etag);
+    }
+    state.etag = etag;
+    state.exists = true;
+  }
+
+  async clear<T>(stateName: string, grainId: GrainId, state: StateHolder<T>): Promise<void> {
+    // One atomic statement reports whether a row existed and whether the
+    // etag-guarded delete fired: an absent row is a no-op; a present row that
+    // did not delete (blank or stale etag) is a conflict.
+    const res = await this.pool.query<{
+      stored_etag: string | null;
+      present: boolean;
+      deleted: boolean;
+    }>(
+      `WITH existing AS (
+         SELECT etag FROM ${this.table} WHERE grain_id = $1 AND state_name = $2
+       ), deleted AS (
+         DELETE FROM ${this.table} WHERE grain_id = $1 AND state_name = $2 AND etag = $3
+         RETURNING 1
+       )
+       SELECT (SELECT etag FROM existing) AS stored_etag,
+              EXISTS (SELECT 1 FROM existing) AS present,
+              EXISTS (SELECT 1 FROM deleted) AS deleted`,
+      [grainId.toString(), stateName, state.etag ?? ""],
+    );
+    const row = res.rows[0]!;
+    if (row.present && !row.deleted) {
+      throw new InconsistentStateError(
+        `etag conflict clearing ${stateName} for ${grainId.toString()}`,
+        state.etag,
+        row.stored_etag ?? undefined,
+      );
+    }
+    state.etag = undefined;
+    state.exists = false;
+  }
+
+  private async conflict(
+    verb: string,
+    stateName: string,
+    grainId: GrainId,
+    expected: string | undefined,
+  ): Promise<InconsistentStateError> {
+    const res = await this.pool.query<{ etag: string }>(
+      `SELECT etag FROM ${this.table} WHERE grain_id = $1 AND state_name = $2`,
+      [grainId.toString(), stateName],
+    );
+    return new InconsistentStateError(
+      `etag conflict ${verb} ${stateName} for ${grainId.toString()}`,
+      expected,
+      res.rows[0]?.etag,
+    );
+  }
+}

--- a/packages/reminders/package.json
+++ b/packages/reminders/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@tsva/core": "workspace:*",
+    "pg": "^8.21.0",
     "redis": "^5.12.1"
   }
 }

--- a/packages/reminders/src/postgres-reminder-table.test.ts
+++ b/packages/reminders/src/postgres-reminder-table.test.ts
@@ -1,0 +1,162 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { Pool } from "pg";
+import { GrainId } from "@tsva/core/grain-id";
+import { FakeTimeProvider } from "@tsva/core/test-support/fake-time-provider";
+import { LocalReminderService, type HashRange } from "@tsva/reminders/local-reminder-service";
+import { PostgresReminderTable } from "@tsva/reminders/postgres-reminder-table";
+
+const PG_URL = process.env.PG_URL ?? "postgres://localhost:5432/postgres";
+
+async function reachable(connectionString: string): Promise<Pool | undefined> {
+  const probe = new Pool({ connectionString });
+  probe.on("error", () => {});
+  try {
+    await probe.query("SELECT 1");
+    return probe;
+  } catch {
+    await probe.end().catch(() => {});
+    return undefined;
+  }
+}
+
+const pool = await reachable(PG_URL);
+const table = `tsva_test_${randomUUID().replace(/-/g, "")}`;
+const makeTable = () => new PostgresReminderTable(pool!, { tableName: table });
+
+const WHOLE: HashRange = [0, 0x1_0000_0000];
+const billing = new GrainId("Billing", "acct-1");
+
+afterAll(async () => {
+  if (pool === undefined) return;
+  await pool.query(`DROP TABLE IF EXISTS ${table}`);
+  await pool.end();
+});
+
+describe.skipIf(pool === undefined)("PostgresReminderTable", () => {
+  beforeEach(async () => {
+    await makeTable().start();
+    await pool!.query(`TRUNCATE TABLE ${table}`);
+  });
+
+  it("upserts, reads and removes with etag CAS", async () => {
+    const table = makeTable();
+    const etag = await table.upsert({
+      grainId: billing,
+      name: "invoice",
+      startAt: new Date(0),
+      period: { hours: 24 },
+    });
+    const read = await table.read(billing, "invoice");
+    expect(read?.etag).toBe(etag);
+    expect(read?.startAt).toBeInstanceOf(Date);
+    expect(read?.period).toEqual({ hours: 24 });
+    expect(await table.remove(billing, "invoice", "wrong-etag")).toBe(false);
+    expect(await table.remove(billing, "invoice", etag)).toBe(true);
+    expect(await table.read(billing, "invoice")).toBeUndefined();
+  });
+
+  it("reads only the entries whose grain hashes into a range", async () => {
+    const table = makeTable();
+    await table.upsert({ grainId: billing, name: "r", startAt: new Date(0), period: { ms: 0 } });
+    const hash = billing.getUniformHashCode();
+    expect(await table.readRange(hash, hash + 1)).toHaveLength(1);
+    expect(await table.readRange(hash + 1, hash + 2)).toHaveLength(0);
+  });
+
+  it("reads entries from a range that wraps the ring", async () => {
+    const table = makeTable();
+    await table.upsert({ grainId: billing, name: "r", startAt: new Date(0), period: { ms: 0 } });
+    const hash = billing.getUniformHashCode();
+    // Wrap (begin > end) that includes the hash: hash >= begin holds.
+    expect(await table.readRange(hash, hash - 1)).toHaveLength(1);
+    // Wrap that excludes the hash: neither hash >= begin nor hash < end.
+    expect(await table.readRange(hash + 1, hash)).toHaveLength(0);
+  });
+
+  it("lists every reminder registered for one grain", async () => {
+    const table = makeTable();
+    await table.upsert({ grainId: billing, name: "a", startAt: new Date(0), period: { ms: 0 } });
+    await table.upsert({ grainId: billing, name: "b", startAt: new Date(0), period: { ms: 0 } });
+    const other = new GrainId("Billing", "acct-2");
+    await table.upsert({ grainId: other, name: "a", startAt: new Date(0), period: { ms: 0 } });
+
+    const forBilling = await table.readForGrain(billing);
+    expect(forBilling.map((e) => e.name).sort()).toEqual(["a", "b"]);
+  });
+
+  it("overwrites in place with a fresh etag on re-upsert", async () => {
+    const table = makeTable();
+    const first = await table.upsert({
+      grainId: billing,
+      name: "invoice",
+      startAt: new Date(0),
+      period: { ms: 0 },
+    });
+    const second = await table.upsert({
+      grainId: billing,
+      name: "invoice",
+      startAt: new Date(1000),
+      period: { ms: 5 },
+    });
+    expect(second).not.toBe(first);
+    expect(await table.remove(billing, "invoice", first)).toBe(false);
+    const read = await table.read(billing, "invoice");
+    expect(read?.etag).toBe(second);
+    expect(read?.period).toEqual({ ms: 5 });
+  });
+});
+
+describe.skipIf(pool === undefined)("LocalReminderService over PostgresReminderTable", () => {
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  beforeEach(async () => {
+    await makeTable().start();
+    await pool!.query(`TRUNCATE TABLE ${table}`);
+  });
+
+  it("fires a due reminder durably recorded in Postgres", async () => {
+    const time = new FakeTimeProvider();
+    const table = makeTable();
+    const fired: string[] = [];
+    const service = new LocalReminderService(
+      table,
+      time,
+      async (_g, name) => {
+        fired.push(name);
+      },
+      [WHOLE],
+    );
+
+    await service.register(billing, "invoice", { ms: 1000 }, { ms: 1_000_000 });
+    time.advance(1000);
+    await flush();
+    expect(fired).toEqual(["invoice"]);
+    service.stop();
+  });
+
+  it("a fresh silo taking over the range resumes firing from Postgres", async () => {
+    const time = new FakeTimeProvider();
+
+    // Original owner registers, then "dies" without firing.
+    const original = new LocalReminderService(makeTable(), time, async () => undefined, [WHOLE]);
+    await original.register(billing, "invoice", { ms: 1000 }, { ms: 1_000_000 });
+    original.stop();
+
+    // A successor reads the durable table and picks the reminder up.
+    const fired: string[] = [];
+    const successor = new LocalReminderService(
+      makeTable(),
+      time,
+      async (_g, name) => {
+        fired.push(name);
+      },
+      [],
+    );
+    await successor.refreshOwnership([WHOLE]);
+    time.advance(1000);
+    await flush();
+    expect(fired).toEqual(["invoice"]);
+    successor.stop();
+  });
+});

--- a/packages/reminders/src/postgres-reminder-table.ts
+++ b/packages/reminders/src/postgres-reminder-table.ts
@@ -1,0 +1,134 @@
+import { randomUUID } from "node:crypto";
+import type { Pool } from "pg";
+import type { Duration } from "@tsva/core/duration";
+import type { GrainId } from "@tsva/core/grain-id";
+import type { ReminderEntry, ReminderRegistration, ReminderTable } from "@tsva/core/reminder";
+import { deserializeValue, serializeValue } from "@tsva/core/value-codec";
+
+export interface PostgresReminderTableOptions {
+  /** Table holding the reminder rows (defaults to `"tsva_reminders"`). */
+  tableName?: string;
+}
+
+// Table/index names are interpolated (Postgres cannot bind identifiers), so
+// guard them against anything but a plain SQL identifier; all values are bound.
+const IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
+
+function isDuplicate(err: unknown): boolean {
+  const code = (err as { code?: string }).code;
+  return code === "23505" || code === "42P07";
+}
+
+/** The codec-serialized payload of a reminder (etag is stored alongside). */
+interface ReminderData {
+  grainId: GrainId;
+  name: string;
+  startAt: Date;
+  period: Duration;
+}
+
+/**
+ * Durable, cluster-shared reminder table backed by Postgres, mirroring the
+ * Redis table. Each reminder is one row keyed by `(grain_id, name)`; a `hash`
+ * column (the grain's uniform hash code) is indexed so `readRange` ownership —
+ * including wrap-around — is a server-side range query, and `readForGrain` is a
+ * `grain_id` lookup. Upsert is unconditional with a fresh etag; remove is an
+ * etag compare-and-set. Interchangeable with `MemoryReminderTable`. `start()`
+ * creates the table (idempotent); the host runs it on start.
+ */
+export class PostgresReminderTable implements ReminderTable {
+  private readonly table: string;
+
+  constructor(
+    private readonly pool: Pool,
+    options: PostgresReminderTableOptions = {},
+  ) {
+    this.table = options.tableName ?? "tsva_reminders";
+    if (!IDENTIFIER.test(this.table)) throw new Error(`invalid table name: ${this.table}`);
+  }
+
+  async start(): Promise<void> {
+    try {
+      await this.pool.query(
+        `CREATE TABLE IF NOT EXISTS ${this.table} (
+           grain_id text NOT NULL,
+           name text NOT NULL,
+           hash bigint NOT NULL,
+           data text NOT NULL,
+           etag text NOT NULL,
+           PRIMARY KEY (grain_id, name)
+         )`,
+      );
+      await this.pool.query(
+        `CREATE INDEX IF NOT EXISTS ${this.table}_hash_idx ON ${this.table} (hash)`,
+      );
+    } catch (err) {
+      if (!isDuplicate(err)) throw err;
+    }
+  }
+
+  async upsert(registration: ReminderRegistration): Promise<string> {
+    const { grainId, name } = registration;
+    const etag = randomUUID();
+    const data: ReminderData = {
+      grainId,
+      name,
+      startAt: registration.startAt,
+      period: registration.period,
+    };
+    await this.pool.query(
+      `INSERT INTO ${this.table} (grain_id, name, hash, data, etag)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (grain_id, name) DO UPDATE
+         SET hash = EXCLUDED.hash, data = EXCLUDED.data, etag = EXCLUDED.etag`,
+      // bigint is bound as a string so values above 2^31 round-trip safely.
+      [grainId.toString(), name, String(grainId.getUniformHashCode()), serializeValue(data), etag],
+    );
+    return etag;
+  }
+
+  async remove(grainId: GrainId, name: string, etag: string): Promise<boolean> {
+    const res = await this.pool.query(
+      `DELETE FROM ${this.table} WHERE grain_id = $1 AND name = $2 AND etag = $3`,
+      [grainId.toString(), name, etag],
+    );
+    return res.rowCount === 1;
+  }
+
+  async read(grainId: GrainId, name: string): Promise<ReminderEntry | undefined> {
+    const res = await this.pool.query<{ data: string; etag: string }>(
+      `SELECT data, etag FROM ${this.table} WHERE grain_id = $1 AND name = $2`,
+      [grainId.toString(), name],
+    );
+    return this.toEntry(res.rows[0]);
+  }
+
+  async readForGrain(grainId: GrainId): Promise<ReminderEntry[]> {
+    const res = await this.pool.query<{ data: string; etag: string }>(
+      `SELECT data, etag FROM ${this.table} WHERE grain_id = $1`,
+      [grainId.toString()],
+    );
+    return res.rows.map((r) => this.toEntry(r)!);
+  }
+
+  async readRange(hashBegin: number, hashEnd: number): Promise<ReminderEntry[]> {
+    // Half-open mirror of MemoryReminderTable.inRange, server-side: non-wrap
+    // (begin <= end) is [begin, end); wrap (begin > end) is hash >= begin OR
+    // hash < end. bigint bounds are bound as strings.
+    const res = await this.pool.query<{ data: string; etag: string }>(
+      `SELECT data, etag FROM ${this.table}
+       WHERE CASE WHEN $1::bigint <= $2::bigint
+         THEN hash >= $1::bigint AND hash < $2::bigint
+         ELSE hash >= $1::bigint OR  hash < $2::bigint
+       END`,
+      [String(hashBegin), String(hashEnd)],
+    );
+    return res.rows.map((r) => this.toEntry(r)!);
+  }
+
+  private toEntry(row: { data: string; etag: string } | undefined): ReminderEntry | undefined {
+    if (row === undefined) return undefined;
+    const data = deserializeValue<ReminderData>(row.data);
+    return { ...data, etag: row.etag };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@swc/core':
         specifier: ^1.15.40
         version: 1.15.40
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       eslint:
         specifier: ^10.4.0
         version: 10.4.0
@@ -223,6 +226,9 @@ importers:
       '@tsva/transactions':
         specifier: workspace:*
         version: link:../transactions
+      pg:
+        specifier: ^8.21.0
+        version: 8.21.0
       redis:
         specifier: ^5.12.1
         version: 5.12.1(@opentelemetry/api@1.9.1)
@@ -260,6 +266,9 @@ importers:
       '@tsva/core':
         specifier: workspace:*
         version: link:../core
+      pg:
+        specifier: ^8.21.0
+        version: 8.21.0
       redis:
         specifier: ^5.12.1
         version: 5.12.1(@opentelemetry/api@1.9.1)
@@ -269,6 +278,9 @@ importers:
       '@tsva/core':
         specifier: workspace:*
         version: link:../core
+      pg:
+        specifier: ^8.21.0
+        version: 8.21.0
       redis:
         specifier: ^5.12.1
         version: 5.12.1(@opentelemetry/api@1.9.1)
@@ -720,6 +732,9 @@ packages:
 
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/stream-buffers@3.0.8':
     resolution: {integrity: sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==}
@@ -1331,6 +1346,40 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.13.0:
+    resolution: {integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.14.0:
+    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.21.0:
+    resolution: {integrity: sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1341,6 +1390,22 @@ packages:
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1401,6 +1466,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1611,6 +1680,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -1950,6 +2023,12 @@ snapshots:
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 25.9.1
+      pg-protocol: 1.14.0
+      pg-types: 2.2.0
 
   '@types/stream-buffers@3.0.8':
     dependencies:
@@ -2535,6 +2614,41 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.13.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.21.0):
+    dependencies:
+      pg: 8.21.0
+
+  pg-protocol@1.14.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.21.0:
+    dependencies:
+      pg-connection-string: 2.13.0
+      pg-pool: 3.14.0(pg@8.21.0)
+      pg-protocol: 1.14.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -2544,6 +2658,16 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -2616,6 +2740,8 @@ snapshots:
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
@@ -2810,5 +2936,7 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.0: {}
+
+  xtend@4.0.2: {}
 
   yocto-queue@0.1.0: {}

--- a/todo.md
+++ b/todo.md
@@ -71,7 +71,13 @@ Work items, grouped by the phase they belong to in
       builder `addRedisStorage(name, { url, keyPrefix? })` connects on `start()` / disconnects on
       `stop()` via host `onStart`/`onStop` hooks. Integration-tested against a real Redis
       (skip-if-down): etag conflicts, value-codec round-trip, and state surviving a silo restart.
-- [ ] Postgres provider — **deferred** (additional provider, not a parity gap; Redis is the shipped default)
+- [x] Postgres provider — `PostgresGrainStorage` (one row per state with an `etag` column; a
+      conditional `INSERT ... ON CONFLICT DO UPDATE ... WHERE etag = $expected` gives the same etag
+      optimistic-concurrency contract as the in-memory/Redis providers, atomic across silos); builder
+      `addPostgresStorage(name, { connectionString, tableName? })` creates the table on `start()` /
+      closes the pool on `stop()` via host `onStart`/`onStop` hooks. Integration-tested against a real
+      Postgres (skip-if-down): etag conflicts, value-codec round-trip, and state surviving a silo
+      restart.
 
 ## Phase 5 — Timers and reminders
 
@@ -94,7 +100,13 @@ Work items, grouped by the phase they belong to in
       Builder `useRedisReminders({ url, keyPrefix? })`. Integration-tested (skip-if-down): CAS,
       range/wrap queries, codec round-trip, firing through `LocalReminderService`, and a successor
       silo resuming a reminder from Redis.
-- [ ] Postgres reminder table — **deferred** (additional provider, not a parity gap; Redis is the shipped default)
+- [x] Postgres reminder table — `PostgresReminderTable` (each reminder a row keyed by
+      `(grain_id, name)` with an indexed `hash` column so `readRange` hash-range ownership is a
+      server-side query, including wrap-around; a `grain_id` lookup backs `readForGrain`;
+      unconditional upsert with a fresh etag and an etag-CAS remove). Builder
+      `usePostgresReminders({ connectionString, tableName? })`. Integration-tested (skip-if-down):
+      CAS, range/wrap queries, codec round-trip, firing through `LocalReminderService`, and a
+      successor silo resuming a reminder from Postgres.
 
 ## Phase 6 — Event streams
 


### PR DESCRIPTION
Implement durable, cluster-shared persistence and reminder backends backed by Postgres, complementing the existing Redis providers.

## Summary

This PR adds two new Postgres-backed providers to the persistence and reminders subsystems:

1. **`PostgresGrainStorage`** — A grain state storage provider that stores each named state as a single row with an `etag` column for optimistic concurrency control. Uses `INSERT ... ON CONFLICT DO UPDATE ... WHERE etag = $expected` to enforce the same etag contract across silos as the in-memory and Redis providers.

2. **`PostgresReminderTable`** — A reminder table implementation that stores reminders durably with a `hash` column indexed for efficient range queries. Supports the same upsert/remove/read operations as the memory and Redis tables, enabling durable reminder scheduling across silo restarts.

## Key Changes

- **`packages/persistence/src/postgres-grain-storage.ts`** — New `PostgresGrainStorage` class implementing `GrainStorage`. Creates a table with `(grain_id, state_name, data, etag)` columns; `start()` creates the table idempotently; read/write/clear operations use parameterized queries with etag-guarded conditional updates.

- **`packages/reminders/src/postgres-reminder-table.ts`** — New `PostgresReminderTable` class implementing `ReminderTable`. Stores reminders with a `hash` column indexed for `readRange()` ownership queries; upsert is unconditional with a fresh etag; remove is etag compare-and-set.

- **`packages/hosting/src/silo-builder.ts`** — Added `addPostgresStorage(name, { connectionString, tableName? })` and `usePostgresReminders({ connectionString, tableName? })` builder methods. Both create connection pools on configuration, initialize tables on silo start, and close pools on stop.

- **Integration tests** — Added comprehensive test suites:
  - `postgres-grain-storage.test.ts` — Tests etag conflicts, blind writes, clears, value-codec round-trips, and named state independence.
  - `postgres-reminder-table.test.ts` — Tests upsert/read/remove with etag CAS, hash range queries (including wrap-around), and `LocalReminderService` integration.
  - `postgres-persistence.test.ts` — End-to-end test verifying grain state survives a silo restart via Postgres.
  - `postgres-reminders.test.ts` — End-to-end test verifying reminders fire durably from Postgres.

- **Documentation and tracking** — Updated roadmap, public API docs, and `todo.md` to reflect Postgres providers as shipped (not deferred).

## Notable Implementation Details

- Table/index names are validated against `[a-z_][a-z0-9_]*` to prevent SQL injection; all other inputs are parameterized.
- Duplicate key errors (code `23505` or `42P07`) during `CREATE TABLE IF NOT EXISTS` are silently ignored, allowing concurrent silo starts.
- The `clear()` operation uses a CTE to atomically check existence and etag before deleting, providing precise conflict reporting.
- `readRange()` for reminders handles wrap-around hash ranges server-side: non-wrap queries use `hash >= begin AND hash < end`; wrap queries use `hash >= begin OR hash < end`.
- Bigint hash values are bound as strings to safely round-trip values above 2^31.
- All tests skip cleanly if Postgres is unreachable, using `describe.skipIf()`.

https://claude.ai/code/session_01V2zKZq1tCRHFRwMdhxuaBD