### PR TITLE
feat(journaling): durable journaling — DurableGrain (ADR 0017)

### DIFF
--- a/EPICS.md
+++ b/EPICS.md
@@ -22,6 +22,12 @@ runtime). See [`todo.md`](todo.md) for outstanding work, [`docs/`](docs/) for th
 - **Cross-grain ACID transactions** ([ADR 0008](docs/adr/0008-cross-grain-transactions.md)) —
   `TransactionalState<T>` with timestamp-ordered wait-die locking, optimistic two-phase commit
   (TM elected from writers), durable storage, cross-silo participants, in-doubt recovery.
+- **Durable journaling (`DurableGrain`)** ([ADR 0019](docs/adr/0019-durable-journaling.md)) — a
+  per-grain `StateMachineManager` over `DurableValue`/`DurableDictionary`/`DurableList` that journals
+  each mutation to an append-only log and replays it on activation, with snapshot/compaction; a
+  `JournalStorage` seam (memory + Redis), `useDurable*` hooks + `@durable*` decorators, and
+  `useMemoryJournaling()`/`addRedisJournaling()`. Separate from the reducer snapshot facet and
+  `PersistentState`.
 - **Grain migration** — live activation move with state preserved (`IGrainMigrationParticipant`,
   `MigrateOnIdle`, directed placement).
 - **Grain-interface versioning** ([ADR 0014](docs/adr/0014-grain-interface-versioning.md)) — versions
@@ -48,7 +54,6 @@ runtime). See [`todo.md`](todo.md) for outstanding work, [`docs/`](docs/) for th
 
 - **Durable jobs** ([ADR 0018](docs/adr/0018-durable-jobs.md)) — sharded, durable, at-least-once
   scheduled execution.
-- **Durable journaling (`DurableGrain`)** — Orleans 10 `Orleans.Journaling`; still needs an ADR.
 - **Browser state replication** ([ADR 0017](docs/adr/0017-browser-state-replication.md), beyond parity).
 
 ## ⏸ Deferred

--- a/docs/13-roadmap-and-phases.md
+++ b/docs/13-roadmap-and-phases.md
@@ -31,7 +31,8 @@ retained class substrate. Also shipped: grain migration, grain-interface version
 ([ADR 0014](adr/0014-grain-interface-versioning.md)), implicit stream subscriptions, versioned
 directory range handoff, placement filters, broadcast channels ([ADR 0015](adr/0015-broadcast-channels.md)),
 grain call filters ([ADR 0012](adr/0012-grain-call-filters.md)), observability
-([ADR 0013](adr/0013-observability.md)), and the external client with gateway discovery + failover.
+([ADR 0013](adr/0013-observability.md)), durable journaling
+([ADR 0019](adr/0019-durable-journaling.md)), and the external client with gateway discovery + failover.
 
 ## Remaining for parity
 
@@ -39,8 +40,6 @@ grain call filters ([ADR 0012](adr/0012-grain-call-filters.md)), observability
   the distributed mechanism ship; the elected worker + builder + convergence e2e remain.
 - **Durable jobs** ([ADR 0018](adr/0018-durable-jobs.md)) — a sharded, durable, at-least-once
   scheduled-execution engine (`@tsva/durable-jobs`); designed, not yet implemented.
-- **Durable journaling (`DurableGrain`)** — Orleans 10 `Orleans.Journaling`; still needs an ADR (it
-  overlaps the reducer/persistent-state model).
 
 ## Deferred (not parity gaps)
 

--- a/docs/adr/0019-durable-journaling.md
+++ b/docs/adr/0019-durable-journaling.md
@@ -1,0 +1,118 @@
+# ADR 0019 — Durable journaling (`DurableGrain`)
+
+- Status: Accepted — implemented (`@tsva/journaling`)
+- Context docs: [07 — Persistence](../07-persistence.md), [02 — Actor model](../02-actor-model.md),
+  [13 — Roadmap](../13-roadmap-and-phases.md), [ADR 0006 — Reducer grains](0006-reducer-grains.md),
+  [ADR 0005 — Redis defaults](0005-redis-default-providers.md)
+
+> Orleans references (the model this ADR ports): `Orleans.Journaling/StateMachineManager.cs` and
+> `Orleans.Journaling/IStateMachineManager.cs` (the per-grain manager that owns one append-only log,
+> registers state machines, replays on activation, and snapshots), `Orleans.Journaling/IDurableStateMachine.cs`
+> (`Reset` / `Apply(ReadOnlySequence)` / snapshot), `Orleans.Journaling/{DurableValue,DurableDictionary,DurableList}.cs`
+> (the journalled structures), and the log-storage seam `Orleans.Journaling/{ILogStorage,IStateMachineStorage}.cs`.
+> Orleans' own prior art for the event-driven shape is `JournaledGrain<TState,TEvent>` ([ADR 0006](0006-reducer-grains.md)
+> already ports its *programming model* as the reducer snapshot facet; this ADR ports the *durable log*).
+
+## Context
+
+Two durable models ship today and both deliberately keep the **mutation history transient**:
+
+- **PersistentState** ([07](../07-persistence.md), `@persistentState` / `usePersistentState`) is a
+  mutable cell: read, mutate `value`, `write()` the whole value under etag optimistic concurrency. It
+  stores the *current value*, never how it got there.
+- **The reducer snapshot facet** ([ADR 0006](0006-reducer-grains.md), `@reducerState` /
+  `useReducerState`) folds past-tense events through a pure reducer into immutable state and persists
+  the **fold as a snapshot**. ADR 0006 is explicit that "the raised events are transient per-turn
+  values… this adds no new store" — it ports `JournaledGrain`'s *model* but **not** a durable event log.
+
+Orleans 10's `Orleans.Journaling` is the third path those two left open: a `DurableGrain` whose
+`DurableValue<T>` / `DurableDictionary<K,V>` / `DurableList<T>` **journal each mutation to an
+append-only log** and **replay the log on activation** to rebuild state, coordinated by an
+`IStateMachineManager` over `IDurableStateMachine`s. The durable artefact is the *log of mutations*,
+not a whole-value snapshot — periodic snapshots exist only to bound replay cost. The roadmap
+([13](../13-roadmap-and-phases.md)) flagged this as a parity gap pending an ADR to settle how it
+relates to, and stays separate from, the reducer/persistent facets. This ADR settles it.
+
+## Decision
+
+Add durable journaling as an **additive** facet — a new programming model and a new storage seam —
+faithfully porting Orleans' `IStateMachineManager` / `IDurableStateMachine` model. It does **not**
+replace or alter PersistentState or the reducer snapshot facet; a grain opts into one model. No change
+to `cluster-node.ts` / `activation.ts` beyond a single new call at the existing `stateBinder`
+facet-binding seam in `silo-builder.ts`.
+
+1. **Per-grain manager over an append-only log.** A `StateMachineManager` owns **one** append-only log
+   per grain (per provider); each durable structure registers as a named `DurableStateMachine`
+   (`reset()` / `apply(payload)` / `snapshot()`). On activation the manager reads the log **once** and
+   dispatches every entry to its owning machine — the single replay rebuilds all the grain's
+   structures. A mutation appends one framed entry (`{ machine, kind, payload }`, serialized through
+   the shared value-codec) through the manager, then updates the structure's in-memory state. This is
+   the faithful Orleans split: the manager frames/dispatches/persists, the machine interprets payloads.
+
+2. **A separate `JournalStorage` provider seam, same concurrency contract.** Journaling needs
+   append + read-log + atomic-replace, not the read/write/clear of a single cell, so it gets its own
+   provider interface and its own keyspace (`tsva:journal:…`, distinct from PersistentState's
+   `tsva:state:…`) — *not* `GrainStorage`. It keeps the **same optimistic-concurrency contract**: a
+   monotonically increasing numeric `version` is the CAS token (the etag analogue), and a conflicting
+   write raises the existing `InconsistentStateError`. Memory and Redis providers ship; the Redis one
+   reuses the `redis-grain-storage.ts` Lua/CAS pattern (a Redis list of entries plus a version key,
+   mutated under one atomic Lua eval).
+
+3. **Snapshotting bounds the log.** When the log crosses a configurable entry threshold on append, the
+   manager snapshots every machine and **atomically replaces** (truncates) the log under the same
+   version CAS. Replay is uniform — a snapshot frame is applied through the same `apply()` path as an
+   incremental op — so a compacted log replays exactly like an uncompacted one.
+
+### Overlap and boundary (explicit)
+
+| | PersistentState ([07](../07-persistence.md)) | Reducer snapshot ([ADR 0006](0006-reducer-grains.md)) | **Durable journaling (this ADR)** |
+| --- | --- | --- | --- |
+| Durable artefact | whole current value | folded-state snapshot | **append-only log of mutations** (+ periodic snapshot to bound replay) |
+| Mutation history | none | transient (events discarded) | **durable** — the log *is* the source of truth |
+| Storage seam | `GrainStorage` (`tsva:state:…`) | `GrainStorage` (reused) | **`JournalStorage`** (`tsva:journal:…`) |
+| Concurrency | etag CAS | etag CAS | **version CAS** (same `InconsistentStateError`) |
+| Rebuild on activate | one read | one read of the snapshot | **replay the log** (after the latest snapshot) |
+
+- **vs PersistentState** — both are single-grain and optimistic-concurrency-guarded, but PersistentState
+  rewrites the whole value while journaling appends deltas and replays. Different access pattern ⇒
+  different provider and keyspace. PersistentState is unchanged.
+- **vs the reducer snapshot facet** — both derive state from an ordered sequence of events/ops. ADR 0006
+  keeps the sequence transient and persists only the fold; journaling keeps the sequence **durable** and
+  snapshots only to bound replay. Journaling is the durable-log counterpart ADR 0006 deliberately left
+  out — not a replacement. A reducer grain that wants a durable event log is expressible as a
+  `DurableList` of events plus a `DurableValue` fold, but that is a choice, not a migration.
+
+The single-writer / one-turn-at-a-time model ([02](../02-actor-model.md)) does the hard part, exactly
+as it does for the reducer facet: appends and the replay are serialized and lock-free within an
+activation; the only concurrency is a cross-silo split-brain incarnation, which the version CAS fences
+out (the loser is a zombie that deactivates and re-replays the winner's log) — identical to how
+`RedisGrainStorage` guards PersistentState.
+
+## Consequences
+
+- **A new store and provider seam** (`JournalStorage`, memory + Redis) and a new package
+  `@tsva/journaling`, mirroring the `@tsva/persistence` / `@tsva/transactions` split; contracts the
+  runtime/hosting need live in `@tsva/core` (`journal-storage`, `durable-state-machine`,
+  `durable-state`, `durable-state-metadata`).
+- **One storage round-trip per mutation** (faithful to Orleans, which persists each op). Read cost is
+  bounded by the snapshot threshold, not the lifetime mutation count. Reads of current state are served
+  from memory.
+- **Mutators are async.** `DurableValue.set` / `DurableDictionary.set` / `DurableList.add` etc. return
+  promises (each appends to the log), unlike `@persistentState`'s in-memory mutate-then-`write()`.
+- **All durable structures on a grain share one log and one provider** (the manager owns it). A grain
+  may still use a non-default journaling provider; mixing providers across structures on one grain is
+  rejected.
+- **Additive and inert when unused.** Grains that declare no durable fields, and silos that configure no
+  journaling provider, are unaffected; the binder is a no-op.
+
+## Alternatives considered
+
+1. **Reuse `GrainStorage` and store the whole log as one value.** Rewriting the entire log on every
+   mutation reduces journaling to PersistentState-of-an-array — it loses append semantics, scales
+   poorly, and defeats the point. Rejected in favour of an append-only provider.
+2. **One log per facet (keyed by `stateName`) instead of a per-grain manager.** Simpler and matches the
+   `tsva:state:{grain}/{name}` key scheme, but diverges from Orleans' single-`IStateMachineManager`
+   model and loses atomic multi-structure snapshots. Rejected for fidelity.
+3. **Fold journaling into the reducer facet (make ADR 0006 events durable).** Conflates two deliberately
+   separate models — ADR 0006's value (pure, testable, snapshot-only folds) is independent of
+   durability. Kept separate and additive.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,3 +20,4 @@ Each ADR captures one significant decision, its context, the rationale, and its 
 - [0016 — Activation rebalancer (adaptive, entropy-minimizing)](0016-activation-rebalancer.md)
 - [0017 — Browser state replication and browser-hosted grains](0017-browser-state-replication.md)
 - [0018 — Durable jobs (sharded, durable, at-least-once scheduled execution)](0018-durable-jobs.md)
+- [0019 — Durable journaling (`DurableGrain`)](0019-durable-journaling.md)

--- a/packages/core/src/decorators.ts
+++ b/packages/core/src/decorators.ts
@@ -11,6 +11,7 @@ import { registerPersistentField } from "./persistent-state-metadata";
 import { registerReducerField } from "./reducer-state-metadata";
 import type { Reducer } from "./reducer-state";
 import { registerTransactionalField } from "./transactional-state-metadata";
+import { registerDurableField, type DurableKind } from "./durable-state-metadata";
 
 export interface PersistentStateOptions {
   /** Storage provider name; defaults to the silo's default provider. */
@@ -146,4 +147,45 @@ export function transactionalState<TState>(
       });
     });
   };
+}
+
+export interface DurableStateOptions {
+  /** Journal storage provider name; defaults to the silo's default provider. */
+  provider?: string;
+}
+
+/**
+ * Shared field decorator for the durable-journalling facets (see
+ * [ADR 0019](../../docs/adr/0019-durable-journaling.md)). The runtime binds the
+ * grain's single state-machine manager and replays its log before `onActivate`;
+ * each mutation appends to the log.
+ */
+function durableField(kind: DurableKind, stateName: string, options: DurableStateOptions) {
+  return function (_value: undefined, context: ClassFieldDecoratorContext): void {
+    if (context.kind !== "field") throw new Error("durable facets must decorate a field");
+    const fieldName = String(context.name);
+    context.addInitializer(function (this: unknown) {
+      registerDurableField(this as object, {
+        fieldName,
+        stateName,
+        kind,
+        ...(options.provider !== undefined ? { provider: options.provider } : {}),
+      });
+    });
+  };
+}
+
+/** Injects a `DurableValue<T>` journalled facet into a grain field. */
+export function durableState(stateName: string, options: DurableStateOptions = {}) {
+  return durableField("value", stateName, options);
+}
+
+/** Injects a `DurableDictionary<K,V>` journalled facet into a grain field. */
+export function durableDictionary(stateName: string, options: DurableStateOptions = {}) {
+  return durableField("dictionary", stateName, options);
+}
+
+/** Injects a `DurableList<T>` journalled facet into a grain field. */
+export function durableList(stateName: string, options: DurableStateOptions = {}) {
+  return durableField("list", stateName, options);
 }

--- a/packages/core/src/define-grain.ts
+++ b/packages/core/src/define-grain.ts
@@ -13,6 +13,8 @@ import {
 import type { GrainKeyFor } from "./key-kinds";
 import type { PersistentState } from "./persistent-state";
 import { registerPersistentField } from "./persistent-state-metadata";
+import type { DurableDictionary, DurableList, DurableValue } from "./durable-state";
+import { registerDurableField } from "./durable-state-metadata";
 import type { Reducer, ReducerState } from "./reducer-state";
 import { registerReducerField } from "./reducer-state-metadata";
 import type { TransactionalState } from "./transactional-state";
@@ -274,5 +276,120 @@ export function useTransactionalState<TState>(
   return {
     performRead: (read) => bound().performRead(read),
     performUpdate: (update) => bound().performUpdate(update),
+  };
+}
+
+export interface UseDurableStateOptions {
+  /** Journal storage provider name; defaults to the silo's default provider. */
+  provider?: string;
+}
+
+/**
+ * The functional counterpart of `@durableState`. Registers a durable-journalling
+ * value facet on the activation and returns a handle; the runtime binds the
+ * grain's single state-machine manager and replays the log before `onActivate`
+ * (see [ADR 0019](../../docs/adr/0019-durable-journaling.md)). The handle throws
+ * if used before then.
+ */
+export function useDurableState<T>(
+  ctx: GrainSetup,
+  stateName: string,
+  options: UseDurableStateOptions = {},
+): DurableValue<T> {
+  const instance = instanceOf(ctx);
+  const fieldName = `__tsva_durable$${stateName}`;
+  registerDurableField(instance, {
+    fieldName,
+    stateName,
+    kind: "value",
+    ...(options.provider !== undefined ? { provider: options.provider } : {}),
+  });
+  const bound = (): DurableValue<T> => {
+    const facet = (instance as Record<string, unknown>)[fieldName] as DurableValue<T> | undefined;
+    if (facet === undefined) throw new Error(`durable value "${stateName}" not yet bound`);
+    return facet;
+  };
+  return {
+    get value() {
+      return bound().value;
+    },
+    get: () => bound().get(),
+    set: (value) => bound().set(value),
+    clear: () => bound().clear(),
+  };
+}
+
+/**
+ * The functional counterpart of `@durableDictionary` — a journalled scalar-keyed
+ * map bound and replayed before `onActivate`.
+ */
+export function useDurableDictionary<K, V>(
+  ctx: GrainSetup,
+  stateName: string,
+  options: UseDurableStateOptions = {},
+): DurableDictionary<K, V> {
+  const instance = instanceOf(ctx);
+  const fieldName = `__tsva_durabledict$${stateName}`;
+  registerDurableField(instance, {
+    fieldName,
+    stateName,
+    kind: "dictionary",
+    ...(options.provider !== undefined ? { provider: options.provider } : {}),
+  });
+  const bound = (): DurableDictionary<K, V> => {
+    const facet = (instance as Record<string, unknown>)[fieldName] as
+      | DurableDictionary<K, V>
+      | undefined;
+    if (facet === undefined) throw new Error(`durable dictionary "${stateName}" not yet bound`);
+    return facet;
+  };
+  return {
+    get size() {
+      return bound().size;
+    },
+    has: (key) => bound().has(key),
+    get: (key) => bound().get(key),
+    entries: () => bound().entries(),
+    keys: () => bound().keys(),
+    values: () => bound().values(),
+    set: (key, value) => bound().set(key, value),
+    delete: (key) => bound().delete(key),
+    clear: () => bound().clear(),
+  };
+}
+
+/**
+ * The functional counterpart of `@durableList` — a journalled ordered list bound
+ * and replayed before `onActivate`.
+ */
+export function useDurableList<T>(
+  ctx: GrainSetup,
+  stateName: string,
+  options: UseDurableStateOptions = {},
+): DurableList<T> {
+  const instance = instanceOf(ctx);
+  const fieldName = `__tsva_durablelist$${stateName}`;
+  registerDurableField(instance, {
+    fieldName,
+    stateName,
+    kind: "list",
+    ...(options.provider !== undefined ? { provider: options.provider } : {}),
+  });
+  const bound = (): DurableList<T> => {
+    const facet = (instance as Record<string, unknown>)[fieldName] as DurableList<T> | undefined;
+    if (facet === undefined) throw new Error(`durable list "${stateName}" not yet bound`);
+    return facet;
+  };
+  return {
+    get length() {
+      return bound().length;
+    },
+    get: (index) => bound().get(index),
+    toArray: () => bound().toArray(),
+    [Symbol.iterator]: () => bound()[Symbol.iterator](),
+    add: (value) => bound().add(value),
+    set: (index, value) => bound().set(index, value),
+    removeAt: (index) => bound().removeAt(index),
+    clear: () => bound().clear(),
   };
 }

--- a/packages/core/src/durable-state-machine.ts
+++ b/packages/core/src/durable-state-machine.ts
@@ -1,0 +1,39 @@
+/**
+ * A registered durable structure, mirroring Orleans' `IDurableStateMachine`.
+ * The manager owns the log; a machine only knows how to (re)build itself from
+ * applied op payloads and how to emit a snapshot of its current state. Payloads
+ * are the machine's private op union — opaque to the manager.
+ */
+export interface DurableStateMachine {
+  /** Name under which this machine is registered on the manager (= `stateName`). */
+  readonly name: string;
+  /** Discard all in-memory state, returning to empty/default (before a replay). */
+  reset(): void;
+  /** Apply one decoded op payload to in-memory state (replay, or after a local append). */
+  apply(payload: unknown): void;
+  /**
+   * Produce a single op payload that, applied to a freshly `reset()` machine,
+   * reconstructs current state in full. Used for compaction.
+   */
+  snapshot(): unknown;
+}
+
+/**
+ * Per-grain owner of one append-only log shared by all the grain's durable
+ * structures, mirroring Orleans' `IStateMachineManager`. Created once per
+ * activation; machines register before the single `replay()`.
+ */
+export interface StateMachineManager {
+  /** Register a machine before `replay()`. Throws on a duplicate name. */
+  register(machine: DurableStateMachine): void;
+  /** Read the log once and dispatch every entry to its owning machine. */
+  replay(): Promise<void>;
+  /**
+   * Append one mutation for `machineName` carrying `payload`: frame it, write it
+   * through storage under the version CAS, and snapshot + truncate when the log
+   * crosses the configured threshold.
+   */
+  append(machineName: string, payload: unknown): Promise<void>;
+  /** Force a snapshot + truncate now. */
+  compact(): Promise<void>;
+}

--- a/packages/core/src/durable-state-metadata.ts
+++ b/packages/core/src/durable-state-metadata.ts
@@ -1,0 +1,29 @@
+/** Which durable structure a journalled field declares. */
+export type DurableKind = "value" | "dictionary" | "list";
+
+/**
+ * A durable-journaling field declared on a grain via the `@durableState` /
+ * `@durableDictionary` / `@durableList` decorators or the `useDurable*` hooks.
+ * The binder builds the matching structure and registers it on the grain's
+ * single state-machine manager (see [ADR 0019](../../docs/adr/0019-durable-journaling.md)).
+ */
+export interface DurableStateField {
+  fieldName: string;
+  /** Name under which this structure registers on the grain's manager. */
+  stateName: string;
+  kind: DurableKind;
+  /** Journal storage provider name; defaults to the silo's default provider. */
+  provider?: string;
+}
+
+const registry = new WeakMap<object, DurableStateField[]>();
+
+export function registerDurableField(instance: object, field: DurableStateField): void {
+  const list = registry.get(instance);
+  if (list === undefined) registry.set(instance, [field]);
+  else list.push(field);
+}
+
+export function getDurableFields(instance: object): readonly DurableStateField[] {
+  return registry.get(instance) ?? [];
+}

--- a/packages/core/src/durable-state.ts
+++ b/packages/core/src/durable-state.ts
@@ -1,0 +1,49 @@
+/**
+ * The grain-facing durable-journaling facets (see
+ * [ADR 0019](../../docs/adr/0019-durable-journaling.md)). Each mutation is
+ * journalled to the grain's append-only log and replayed on activation; reads
+ * are served from memory. Mutators are async because each appends to the log.
+ */
+
+/** A single journalled value cell. Orleans' `IDurableValue<T>`. */
+export interface DurableValue<T> {
+  /** Current value; `undefined` until the first `set`. */
+  readonly value: T | undefined;
+  get(): T | undefined;
+  /** Journal a set and update memory. */
+  set(value: T): Promise<void>;
+  /** Journal a clear back to `undefined`. */
+  clear(): Promise<void>;
+}
+
+/** A journalled scalar-keyed map. Orleans' `IDurableDictionary<K,V>`. */
+export interface DurableDictionary<K, V> {
+  readonly size: number;
+  has(key: K): boolean;
+  get(key: K): V | undefined;
+  entries(): IterableIterator<[K, V]>;
+  keys(): IterableIterator<K>;
+  values(): IterableIterator<V>;
+  /** Journal a set and update memory. */
+  set(key: K, value: V): Promise<void>;
+  /** Journal a delete; resolves to whether the key existed. */
+  delete(key: K): Promise<boolean>;
+  /** Journal a clear of all entries. */
+  clear(): Promise<void>;
+}
+
+/** A journalled ordered list. Orleans' `IDurableList<T>`. */
+export interface DurableList<T> {
+  readonly length: number;
+  get(index: number): T | undefined;
+  toArray(): readonly T[];
+  [Symbol.iterator](): IterableIterator<T>;
+  /** Journal an append and update memory. */
+  add(value: T): Promise<void>;
+  /** Journal a set-at-index and update memory. */
+  set(index: number, value: T): Promise<void>;
+  /** Journal a remove-at-index and update memory. */
+  removeAt(index: number): Promise<void>;
+  /** Journal a clear of all items. */
+  clear(): Promise<void>;
+}

--- a/packages/core/src/journal-storage.ts
+++ b/packages/core/src/journal-storage.ts
@@ -1,0 +1,53 @@
+import type { GrainId } from "./grain-id";
+
+/** One serialized, already-framed log record. Opaque to the storage provider. */
+export type JournalEntry = string;
+
+/** The log as a provider hands it back: ordered entries plus the CAS version. */
+export interface JournalSegment {
+  /** All live entries in append order (a snapshot frame, if any, comes first). */
+  entries: JournalEntry[];
+  /** CAS token: the count of appends + replaces applied. `undefined` = no log yet. */
+  version: number | undefined;
+}
+
+/**
+ * A pluggable append-only journal store, mirroring Orleans' `ILogStorage` /
+ * `IStateMachineStorage`. The provider stores ordered opaque entries plus a
+ * monotonically increasing `version`; the manager owns framing. Appends and
+ * the snapshot replace are conditional on the caller's last-seen `version`
+ * (`undefined` = "no log yet"), carrying `GrainStorage`'s etag optimistic-
+ * concurrency contract over to a log. A losing writer raises
+ * `InconsistentStateError` (see `@tsva/core/errors`).
+ */
+export interface JournalStorage {
+  /** Read the whole log for `(logName, grainId)`. */
+  read(logName: string, grainId: GrainId): Promise<JournalSegment>;
+
+  /**
+   * Append `entries` to the end of the log iff the stored version equals
+   * `expectedVersion` (`undefined` ⇒ the log must not exist yet). Returns the
+   * new version; throws `InconsistentStateError` on mismatch.
+   */
+  append(
+    logName: string,
+    grainId: GrainId,
+    entries: readonly JournalEntry[],
+    expectedVersion: number | undefined,
+  ): Promise<number>;
+
+  /**
+   * Atomically replace the entire log with `entries` (the snapshot frames) iff
+   * the stored version equals `expectedVersion`. Used for snapshot + truncate.
+   * Returns the new version; throws `InconsistentStateError` on mismatch.
+   */
+  replace(
+    logName: string,
+    grainId: GrainId,
+    entries: readonly JournalEntry[],
+    expectedVersion: number | undefined,
+  ): Promise<number>;
+
+  /** Delete the log entirely. */
+  clear(logName: string, grainId: GrainId): Promise<void>;
+}

--- a/packages/hosting/package.json
+++ b/packages/hosting/package.json
@@ -10,6 +10,7 @@
     "@tsva/clustering-k8s": "workspace:*",
     "@tsva/core": "workspace:*",
     "@tsva/directory": "workspace:*",
+    "@tsva/journaling": "workspace:*",
     "@tsva/messaging": "workspace:*",
     "@tsva/observability": "workspace:*",
     "@tsva/persistence": "workspace:*",

--- a/packages/hosting/src/journaling.test.ts
+++ b/packages/hosting/src/journaling.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { durableList, grain } from "@tsva/core/decorators";
+import { defineGrain, useDurableDictionary } from "@tsva/core/define-grain";
+import { Grain } from "@tsva/core/grain";
+import { defineGrainInterface } from "@tsva/core/grain-interface";
+import type { GrainWithStringKey } from "@tsva/core/key-kinds";
+import type { DurableList } from "@tsva/core/durable-state";
+import { SiloAddress } from "@tsva/core/silo-address";
+import { InProcessNetwork } from "@tsva/messaging/in-process-transport";
+import { MemoryJournalStorage } from "@tsva/journaling/memory-journal-storage";
+import { createSilo, type SiloConfig } from "@tsva/hosting/silo-builder";
+
+// A class grain journalling an ordered list.
+interface ICart extends GrainWithStringKey {
+  add(item: string): Promise<number>;
+  list(): Promise<readonly string[]>;
+}
+const ICart = defineGrainInterface<ICart>("ICart", { options: { list: { readOnly: true } } });
+
+@grain()
+class CartGrain extends Grain implements ICart {
+  @durableList("items")
+  private items!: DurableList<string>;
+
+  async add(item: string): Promise<number> {
+    await this.items.add(item);
+    return this.items.length;
+  }
+
+  async list(): Promise<readonly string[]> {
+    return this.items.toArray();
+  }
+}
+
+// A functional grain journalling a dictionary via the hook.
+interface IInventory extends GrainWithStringKey {
+  stock(sku: string, qty: number): Promise<void>;
+  qty(sku: string): Promise<number | undefined>;
+  skus(): Promise<number>;
+}
+const IInventory = defineGrainInterface<IInventory>("IInventory", {
+  options: { qty: { readOnly: true }, skus: { readOnly: true } },
+});
+
+const InventoryGrain = defineGrain<IInventory>("Inventory", (ctx) => {
+  const stock = useDurableDictionary<string, number>(ctx, "stock");
+  return {
+    stock: async (sku, qty) => {
+      await stock.set(sku, qty);
+    },
+    qty: async (sku) => stock.get(sku),
+    skus: async () => stock.size,
+  };
+});
+
+const local = new SiloAddress("silo-0", "uid-0", "silo-0:11111");
+
+function buildSilo(storage: MemoryJournalStorage, config: Partial<SiloConfig> = {}) {
+  return createSilo({ clusterId: "c1", local, ...config })
+    .useStaticMembership([local])
+    .useInProcessTransport(new InProcessNetwork())
+    .useMemoryJournaling(storage)
+    .registerGrain(CartGrain, { interfaces: [ICart] })
+    .registerGrain(InventoryGrain, { interfaces: [IInventory] })
+    .build();
+}
+
+describe("durable journaling end-to-end", () => {
+  it("replays a journalled list across a silo restart (class grain)", async () => {
+    const storage = new MemoryJournalStorage();
+
+    const first = buildSilo(storage);
+    await first.start();
+    await first.getGrain(ICart, "c-1").add("apple");
+    expect(await first.getGrain(ICart, "c-1").add("pear")).toBe(2);
+    await first.stop(); // pod dies
+
+    const restarted = buildSilo(storage); // new pod, same durable store
+    await restarted.start();
+    try {
+      expect(await restarted.getGrain(ICart, "c-1").list()).toEqual(["apple", "pear"]);
+    } finally {
+      await restarted.stop();
+    }
+  });
+
+  it("replays a journalled dictionary across a silo restart (functional grain)", async () => {
+    const storage = new MemoryJournalStorage();
+
+    const first = buildSilo(storage);
+    await first.start();
+    await first.getGrain(IInventory, "warehouse").stock("widget", 5);
+    await first.getGrain(IInventory, "warehouse").stock("gadget", 3);
+    await first.stop();
+
+    const restarted = buildSilo(storage);
+    await restarted.start();
+    try {
+      expect(await restarted.getGrain(IInventory, "warehouse").qty("widget")).toBe(5);
+      expect(await restarted.getGrain(IInventory, "warehouse").skus()).toBe(2);
+    } finally {
+      await restarted.stop();
+    }
+  });
+
+  it("survives a mid-life snapshot compaction and a restart", async () => {
+    const storage = new MemoryJournalStorage();
+
+    const first = buildSilo(storage, { snapshotThreshold: 3 });
+    await first.start();
+    const cart = first.getGrain(ICart, "big");
+    for (const item of ["a", "b", "c", "d", "e"]) await cart.add(item); // crosses threshold
+    await first.stop();
+
+    const restarted = buildSilo(storage, { snapshotThreshold: 3 });
+    await restarted.start();
+    try {
+      expect(await restarted.getGrain(ICart, "big").list()).toEqual(["a", "b", "c", "d", "e"]);
+    } finally {
+      await restarted.stop();
+    }
+  });
+
+  it("keeps separate grain keys independent", async () => {
+    const storage = new MemoryJournalStorage();
+    const silo = buildSilo(storage);
+    await silo.start();
+    try {
+      await silo.getGrain(ICart, "x").add("only-x");
+      expect(await silo.getGrain(ICart, "y").list()).toEqual([]);
+      expect(await silo.getGrain(ICart, "x").list()).toEqual(["only-x"]);
+    } finally {
+      await silo.stop();
+    }
+  });
+});

--- a/packages/hosting/src/silo-builder.ts
+++ b/packages/hosting/src/silo-builder.ts
@@ -37,6 +37,11 @@ import { MemoryTransactionalStorage } from "@tsva/transactions/memory-transactio
 import { RedisTransactionalStorage } from "@tsva/transactions/redis-transactional-storage";
 import { TransactionalStorageRegistry } from "@tsva/transactions/transactional-storage-registry";
 import type { TransactionalStateStorage } from "@tsva/core/transactional-storage";
+import type { JournalStorage } from "@tsva/core/journal-storage";
+import { MemoryJournalStorage } from "@tsva/journaling/memory-journal-storage";
+import { RedisJournalStorage } from "@tsva/journaling/redis-journal-storage";
+import { JournalStorageRegistry } from "@tsva/journaling/journal-storage-registry";
+import { bindDurableStates } from "@tsva/journaling/durable-state-activator";
 import type { StreamProvider } from "@tsva/core/stream";
 import { LocalReminderService } from "@tsva/reminders/local-reminder-service";
 import { MemoryReminderTable } from "@tsva/reminders/memory-reminder-table";
@@ -65,6 +70,8 @@ export interface SiloConfig {
   reminderRefreshSeconds?: number;
   /** Static metadata this silo advertises (e.g. `{ role: "worker" }`), for metadata-aware placement. */
   metadata?: Readonly<Record<string, string>>;
+  /** Durable-journal snapshot threshold: snapshot + truncate past this many log entries (default 100). */
+  snapshotThreshold?: number;
 }
 
 interface Registration {
@@ -79,6 +86,7 @@ export class SiloBuilder {
   private healthPort: number | undefined;
   private storage: StorageRegistry | undefined;
   private transactionalStorage: TransactionalStorageRegistry | undefined;
+  private journalStorage: JournalStorageRegistry | undefined;
   private reminderTable: ReminderTable | undefined;
   private readonly streamProviders = new Map<string, StreamProvider>();
   private readonly incomingCallFilters: IncomingGrainCallFilter[] = [];
@@ -359,6 +367,43 @@ export class SiloBuilder {
     );
   }
 
+  /** Register a named journal-storage provider for durable-journalling facets (ADR 0019). */
+  addJournaling(name: string, provider: JournalStorage): this {
+    (this.journalStorage ??= new JournalStorageRegistry()).add(name, provider);
+    return this;
+  }
+
+  /**
+   * Convenience: register an in-memory "default" journal provider (dev/tests).
+   * Sharing one instance across silo restarts stands in for a durable backend.
+   */
+  useMemoryJournaling(provider: JournalStorage = new MemoryJournalStorage()): this {
+    return this.addJournaling("default", provider);
+  }
+
+  /**
+   * Register a Redis-backed journal provider for durable-journalling facets. The
+   * client connects when the silo starts and disconnects when it stops;
+   * `keyPrefix` namespaces keys (defaults to `"tsva"`).
+   */
+  addRedisJournaling(name: string, options: { url: string; keyPrefix?: string }): this {
+    const client = createClient({ url: options.url });
+    client.on("error", () => {});
+    this.starters.push(async () => {
+      await client.connect();
+    });
+    this.closers.push(async () => {
+      await client.close();
+    });
+    return this.addJournaling(
+      name,
+      new RedisJournalStorage(
+        client,
+        options.keyPrefix !== undefined ? { keyPrefix: options.keyPrefix } : {},
+      ),
+    );
+  }
+
   useStaticMembership(
     silos: readonly SiloAddress[],
     metadata?: (silo: SiloAddress) => Readonly<Record<string, string>> | undefined,
@@ -442,6 +487,8 @@ export class SiloBuilder {
     const transactionalStorage =
       this.transactionalStorage ??
       new TransactionalStorageRegistry().add("default", new MemoryTransactionalStorage());
+    const journalStorage = this.journalStorage;
+    const snapshotThreshold = this.config.snapshotThreshold;
     const time = this.config.time;
     let reminderService: LocalReminderService | undefined;
 
@@ -485,6 +532,14 @@ export class SiloBuilder {
           // persistent facet without reading storage (which would clobber it).
           await bindPersistentStates(instance, grainId, storage, { read: mode !== "rehydrate" });
           await bindReducerStates(instance, grainId, storage);
+        }
+        if (journalStorage !== undefined) {
+          // One manager per grain owns the log; replay rebuilds all durable
+          // structures. On rehydration skip replay (parity with persistent state).
+          await bindDurableStates(instance, grainId, journalStorage, {
+            replay: mode !== "rehydrate",
+            ...(snapshotThreshold !== undefined ? { snapshotThreshold } : {}),
+          });
         }
         await bindTransactionalStates(instance, grainId, transactionalStorage, (manager, txId) =>
           node.resolveTransactionStatus(manager, txId),

--- a/packages/journaling/package.json
+++ b/packages/journaling/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@tsva/journaling",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./*": "./src/*.ts"
+  },
+  "dependencies": {
+    "@tsva/core": "workspace:*",
+    "redis": "^5.12.1"
+  }
+}

--- a/packages/journaling/src/durable-dictionary-impl.test.ts
+++ b/packages/journaling/src/durable-dictionary-impl.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { GrainId } from "@tsva/core/grain-id";
+import { DurableDictionaryImpl } from "@tsva/journaling/durable-dictionary-impl";
+import { MemoryJournalStorage } from "@tsva/journaling/memory-journal-storage";
+import { StateMachineManagerImpl } from "@tsva/journaling/state-machine-manager-impl";
+
+const id = new GrainId("Catalog", "k1");
+
+function makeDict<K, V>(storage: MemoryJournalStorage) {
+  const manager = new StateMachineManagerImpl("journal", id, storage);
+  const dict = new DurableDictionaryImpl<K, V>("d", manager);
+  manager.register(dict);
+  return { manager, dict };
+}
+
+describe("DurableDictionaryImpl", () => {
+  it("tracks set/delete/clear in memory", async () => {
+    const { dict } = makeDict<string, number>(new MemoryJournalStorage());
+    await dict.set("a", 1);
+    await dict.set("b", 2);
+    expect(dict.size).toBe(2);
+    expect(dict.get("a")).toBe(1);
+    expect(await dict.delete("a")).toBe(true);
+    expect(await dict.delete("missing")).toBe(false);
+    expect(dict.has("a")).toBe(false);
+    await dict.clear();
+    expect(dict.size).toBe(0);
+  });
+
+  it("rebuilds from the log on a fresh activation", async () => {
+    const storage = new MemoryJournalStorage();
+    const a = makeDict<string, number>(storage);
+    await a.dict.set("a", 1);
+    await a.dict.set("b", 2);
+    await a.dict.set("a", 10);
+    await a.dict.delete("b");
+
+    const b = makeDict<string, number>(storage);
+    await b.manager.replay();
+    expect([...b.dict.entries()]).toEqual([["a", 10]]);
+  });
+
+  it("replays a clear followed by later sets", async () => {
+    const storage = new MemoryJournalStorage();
+    const a = makeDict<string, number>(storage);
+    await a.dict.set("x", 1);
+    await a.dict.clear();
+    await a.dict.set("y", 2);
+
+    const b = makeDict<string, number>(storage);
+    await b.manager.replay();
+    expect([...b.dict.entries()]).toEqual([["y", 2]]);
+  });
+});

--- a/packages/journaling/src/durable-dictionary-impl.ts
+++ b/packages/journaling/src/durable-dictionary-impl.ts
@@ -1,0 +1,89 @@
+import type { DurableStateMachine, StateMachineManager } from "@tsva/core/durable-state-machine";
+import type { DurableDictionary } from "@tsva/core/durable-state";
+
+type DictOp<K, V> =
+  | { t: "set"; k: K; v: V }
+  | { t: "del"; k: K }
+  | { t: "clear" }
+  | { t: "load"; entries: [K, V][] };
+
+/**
+ * A journalled scalar-keyed map, implemented as a `DurableStateMachine`. Keys
+ * must be JSON-stable scalars (string/number) so they round-trip through the
+ * value-codec on replay. Each mutation is appended to the grain's log and then
+ * applied to memory.
+ */
+export class DurableDictionaryImpl<K, V> implements DurableDictionary<K, V>, DurableStateMachine {
+  private readonly map = new Map<K, V>();
+
+  constructor(
+    readonly name: string,
+    private readonly manager: StateMachineManager,
+  ) {}
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  has(key: K): boolean {
+    return this.map.has(key);
+  }
+
+  get(key: K): V | undefined {
+    return this.map.get(key);
+  }
+
+  entries(): IterableIterator<[K, V]> {
+    return this.map.entries();
+  }
+
+  keys(): IterableIterator<K> {
+    return this.map.keys();
+  }
+
+  values(): IterableIterator<V> {
+    return this.map.values();
+  }
+
+  async set(key: K, value: V): Promise<void> {
+    // The manager applies the op to memory after a successful append.
+    await this.manager.append(this.name, { t: "set", k: key, v: value } satisfies DictOp<K, V>);
+  }
+
+  async delete(key: K): Promise<boolean> {
+    if (!this.map.has(key)) return false;
+    await this.manager.append(this.name, { t: "del", k: key } satisfies DictOp<K, V>);
+    return true;
+  }
+
+  async clear(): Promise<void> {
+    await this.manager.append(this.name, { t: "clear" } satisfies DictOp<K, V>);
+  }
+
+  reset(): void {
+    this.map.clear();
+  }
+
+  apply(payload: unknown): void {
+    const op = payload as DictOp<K, V>;
+    switch (op.t) {
+      case "set":
+        this.map.set(op.k, op.v);
+        break;
+      case "del":
+        this.map.delete(op.k);
+        break;
+      case "clear":
+        this.map.clear();
+        break;
+      case "load":
+        this.map.clear();
+        for (const [k, v] of op.entries) this.map.set(k, v);
+        break;
+    }
+  }
+
+  snapshot(): unknown {
+    return { t: "load", entries: [...this.map.entries()] } satisfies DictOp<K, V>;
+  }
+}

--- a/packages/journaling/src/durable-list-impl.test.ts
+++ b/packages/journaling/src/durable-list-impl.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { GrainId } from "@tsva/core/grain-id";
+import { DurableListImpl } from "@tsva/journaling/durable-list-impl";
+import { MemoryJournalStorage } from "@tsva/journaling/memory-journal-storage";
+import { StateMachineManagerImpl } from "@tsva/journaling/state-machine-manager-impl";
+
+const id = new GrainId("Feed", "f1");
+
+function makeList<T>(storage: MemoryJournalStorage) {
+  const manager = new StateMachineManagerImpl("journal", id, storage);
+  const list = new DurableListImpl<T>("l", manager);
+  manager.register(list);
+  return { manager, list };
+}
+
+describe("DurableListImpl", () => {
+  it("tracks add/set/removeAt/clear in memory", async () => {
+    const { list } = makeList<string>(new MemoryJournalStorage());
+    await list.add("a");
+    await list.add("b");
+    await list.add("c");
+    await list.set(1, "B");
+    await list.removeAt(0);
+    expect(list.toArray()).toEqual(["B", "c"]);
+    expect([...list]).toEqual(["B", "c"]);
+    await list.clear();
+    expect(list.length).toBe(0);
+  });
+
+  it("rebuilds from the log on a fresh activation (index ops replay in order)", async () => {
+    const storage = new MemoryJournalStorage();
+    const a = makeList<number>(storage);
+    await a.list.add(1);
+    await a.list.add(2);
+    await a.list.add(3);
+    await a.list.removeAt(0); // [2,3]
+    await a.list.set(0, 20); // [20,3]
+    await a.list.add(4); // [20,3,4]
+
+    const b = makeList<number>(storage);
+    await b.manager.replay();
+    expect(b.list.toArray()).toEqual([20, 3, 4]);
+  });
+});

--- a/packages/journaling/src/durable-list-impl.ts
+++ b/packages/journaling/src/durable-list-impl.ts
@@ -1,0 +1,86 @@
+import type { DurableStateMachine, StateMachineManager } from "@tsva/core/durable-state-machine";
+import type { DurableList } from "@tsva/core/durable-state";
+
+type ListOp<T> =
+  | { t: "add"; v: T }
+  | { t: "set"; i: number; v: T }
+  | { t: "removeAt"; i: number }
+  | { t: "clear" }
+  | { t: "load"; items: T[] };
+
+/**
+ * A journalled ordered list, implemented as a `DurableStateMachine`. Index-based
+ * ops journal the index at append time; replay reproduces the same indices
+ * because entries are applied in append order. Each mutation is appended to the
+ * grain's log and then applied to memory.
+ */
+export class DurableListImpl<T> implements DurableList<T>, DurableStateMachine {
+  private items: T[] = [];
+
+  constructor(
+    readonly name: string,
+    private readonly manager: StateMachineManager,
+  ) {}
+
+  get length(): number {
+    return this.items.length;
+  }
+
+  get(index: number): T | undefined {
+    return this.items[index];
+  }
+
+  toArray(): readonly T[] {
+    return [...this.items];
+  }
+
+  [Symbol.iterator](): IterableIterator<T> {
+    return this.items[Symbol.iterator]();
+  }
+
+  async add(value: T): Promise<void> {
+    // The manager applies the op to memory after a successful append.
+    await this.manager.append(this.name, { t: "add", v: value } satisfies ListOp<T>);
+  }
+
+  async set(index: number, value: T): Promise<void> {
+    await this.manager.append(this.name, { t: "set", i: index, v: value } satisfies ListOp<T>);
+  }
+
+  async removeAt(index: number): Promise<void> {
+    await this.manager.append(this.name, { t: "removeAt", i: index } satisfies ListOp<T>);
+  }
+
+  async clear(): Promise<void> {
+    await this.manager.append(this.name, { t: "clear" } satisfies ListOp<T>);
+  }
+
+  reset(): void {
+    this.items = [];
+  }
+
+  apply(payload: unknown): void {
+    const op = payload as ListOp<T>;
+    switch (op.t) {
+      case "add":
+        this.items.push(op.v);
+        break;
+      case "set":
+        this.items[op.i] = op.v;
+        break;
+      case "removeAt":
+        this.items.splice(op.i, 1);
+        break;
+      case "clear":
+        this.items = [];
+        break;
+      case "load":
+        this.items = [...op.items];
+        break;
+    }
+  }
+
+  snapshot(): unknown {
+    return { t: "load", items: [...this.items] } satisfies ListOp<T>;
+  }
+}

--- a/packages/journaling/src/durable-state-activator.ts
+++ b/packages/journaling/src/durable-state-activator.ts
@@ -1,0 +1,61 @@
+import type { GrainId } from "@tsva/core/grain-id";
+import type { DurableStateMachine, StateMachineManager } from "@tsva/core/durable-state-machine";
+import { getDurableFields, type DurableKind } from "@tsva/core/durable-state-metadata";
+import { DurableValueImpl } from "@tsva/journaling/durable-value-impl";
+import { DurableDictionaryImpl } from "@tsva/journaling/durable-dictionary-impl";
+import { DurableListImpl } from "@tsva/journaling/durable-list-impl";
+import type { JournalStorageRegistry } from "@tsva/journaling/journal-storage-registry";
+import { StateMachineManagerImpl } from "@tsva/journaling/state-machine-manager-impl";
+
+function makeMachine(
+  kind: DurableKind,
+  stateName: string,
+  manager: StateMachineManager,
+): DurableStateMachine {
+  switch (kind) {
+    case "value":
+      return new DurableValueImpl(stateName, manager);
+    case "dictionary":
+      return new DurableDictionaryImpl(stateName, manager);
+    case "list":
+      return new DurableListImpl(stateName, manager);
+  }
+}
+
+/**
+ * Inject the durable-journaling facets into a grain instance and replay its log,
+ * before `onActivate`. All the grain's `@durableState` / `@durableDictionary` /
+ * `@durableList` fields share ONE `StateMachineManager` (and one log), so this
+ * builds the manager once, registers every structure on it, then replays once.
+ * Wired into the catalog by the hosting layer alongside `bindPersistentStates`.
+ */
+export async function bindDurableStates(
+  instance: object,
+  grainId: GrainId,
+  registry: JournalStorageRegistry,
+  opts: { replay?: boolean; snapshotThreshold?: number } = {},
+): Promise<void> {
+  const fields = getDurableFields(instance);
+  if (fields.length === 0) return;
+
+  // One log per grain: all structures use the same provider; reject a mix.
+  const providerName = fields[0]!.provider;
+  for (const field of fields) {
+    if (field.provider !== providerName) {
+      throw new Error(`durable fields on ${grainId.toString()} must share one journal provider`);
+    }
+  }
+
+  const storage = registry.get(providerName);
+  const manager = new StateMachineManagerImpl("journal", grainId, storage, {
+    ...(opts.snapshotThreshold !== undefined ? { snapshotThreshold: opts.snapshotThreshold } : {}),
+  });
+
+  for (const field of fields) {
+    const machine = makeMachine(field.kind, field.stateName, manager);
+    manager.register(machine);
+    (instance as Record<string, unknown>)[field.fieldName] = machine;
+  }
+
+  if (opts.replay ?? true) await manager.replay();
+}

--- a/packages/journaling/src/durable-value-impl.test.ts
+++ b/packages/journaling/src/durable-value-impl.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { GrainId } from "@tsva/core/grain-id";
+import { DurableValueImpl } from "@tsva/journaling/durable-value-impl";
+import { MemoryJournalStorage } from "@tsva/journaling/memory-journal-storage";
+import { StateMachineManagerImpl } from "@tsva/journaling/state-machine-manager-impl";
+
+const id = new GrainId("Counter", "c1");
+
+function makeValue<T>(storage: MemoryJournalStorage) {
+  const manager = new StateMachineManagerImpl("journal", id, storage);
+  const value = new DurableValueImpl<T>("v", manager);
+  manager.register(value);
+  return { manager, value };
+}
+
+describe("DurableValueImpl", () => {
+  it("starts undefined and tracks set/clear in memory", async () => {
+    const { value } = makeValue<number>(new MemoryJournalStorage());
+    expect(value.value).toBeUndefined();
+    await value.set(7);
+    expect(value.value).toBe(7);
+    await value.clear();
+    expect(value.value).toBeUndefined();
+  });
+
+  it("rebuilds from the log on a fresh activation", async () => {
+    const storage = new MemoryJournalStorage();
+    const a = makeValue<number>(storage);
+    await a.manager.replay();
+    await a.value.set(1);
+    await a.value.set(2);
+    await a.value.set(3);
+
+    const b = makeValue<number>(storage);
+    await b.manager.replay();
+    expect(b.value.value).toBe(3);
+  });
+
+  it("replays a clear as the final state", async () => {
+    const storage = new MemoryJournalStorage();
+    const a = makeValue<number>(storage);
+    await a.value.set(9);
+    await a.value.clear();
+
+    const b = makeValue<number>(storage);
+    await b.manager.replay();
+    expect(b.value.value).toBeUndefined();
+  });
+
+  it("round-trips runtime value types (Date) through the codec", async () => {
+    const storage = new MemoryJournalStorage();
+    const when = new Date("2026-05-27T10:00:00.000Z");
+    const a = makeValue<Date>(storage);
+    await a.value.set(when);
+
+    const b = makeValue<Date>(storage);
+    await b.manager.replay();
+    expect(b.value.value).toBeInstanceOf(Date);
+    expect(b.value.value?.getTime()).toBe(when.getTime());
+  });
+});

--- a/packages/journaling/src/durable-value-impl.ts
+++ b/packages/journaling/src/durable-value-impl.ts
@@ -1,0 +1,58 @@
+import type { DurableStateMachine, StateMachineManager } from "@tsva/core/durable-state-machine";
+import type { DurableValue } from "@tsva/core/durable-state";
+
+type ValueOp<T> = { t: "set"; v: T } | { t: "clear" };
+
+/**
+ * A journalled single value, implemented as a `DurableStateMachine`. Each `set`
+ * / `clear` is appended to the grain's log through the manager and then applied
+ * to memory; replay reconstructs the value from the log.
+ */
+export class DurableValueImpl<T> implements DurableValue<T>, DurableStateMachine {
+  private current: T | undefined;
+  private present = false;
+
+  constructor(
+    readonly name: string,
+    private readonly manager: StateMachineManager,
+  ) {}
+
+  get value(): T | undefined {
+    return this.current;
+  }
+
+  get(): T | undefined {
+    return this.current;
+  }
+
+  async set(value: T): Promise<void> {
+    // The manager applies the op to memory after a successful append.
+    await this.manager.append(this.name, { t: "set", v: value } satisfies ValueOp<T>);
+  }
+
+  async clear(): Promise<void> {
+    await this.manager.append(this.name, { t: "clear" } satisfies ValueOp<T>);
+  }
+
+  reset(): void {
+    this.current = undefined;
+    this.present = false;
+  }
+
+  apply(payload: unknown): void {
+    const op = payload as ValueOp<T>;
+    if (op.t === "set") {
+      this.current = op.v;
+      this.present = true;
+    } else {
+      this.current = undefined;
+      this.present = false;
+    }
+  }
+
+  snapshot(): unknown {
+    return this.present
+      ? ({ t: "set", v: this.current } as ValueOp<T>)
+      : ({ t: "clear" } as ValueOp<T>);
+  }
+}

--- a/packages/journaling/src/journal-storage-registry.ts
+++ b/packages/journaling/src/journal-storage-registry.ts
@@ -1,0 +1,23 @@
+import type { JournalStorage } from "@tsva/core/journal-storage";
+
+export const DEFAULT_JOURNAL_PROVIDER = "default";
+
+/** Named journal-storage providers configured on a silo; resolves a durable field's provider. */
+export class JournalStorageRegistry {
+  private readonly providers = new Map<string, JournalStorage>();
+
+  add(name: string, storage: JournalStorage): this {
+    this.providers.set(name, storage);
+    return this;
+  }
+
+  has(name: string): boolean {
+    return this.providers.has(name);
+  }
+
+  get(name: string = DEFAULT_JOURNAL_PROVIDER): JournalStorage {
+    const storage = this.providers.get(name);
+    if (storage === undefined) throw new Error(`no journal storage provider registered: ${name}`);
+    return storage;
+  }
+}

--- a/packages/journaling/src/memory-journal-storage.ts
+++ b/packages/journaling/src/memory-journal-storage.ts
@@ -1,0 +1,80 @@
+import { InconsistentStateError } from "@tsva/core/errors";
+import type { GrainId } from "@tsva/core/grain-id";
+import type { JournalEntry, JournalSegment, JournalStorage } from "@tsva/core/journal-storage";
+
+interface Log {
+  entries: JournalEntry[];
+  version: number;
+}
+
+const versionStr = (v: number | undefined): string | undefined =>
+  v === undefined ? undefined : String(v);
+
+/**
+ * In-memory journal store for development and tests. Not durable and not shared
+ * across silos; mirrors `MemoryGrainStorage`. The `version` is a per-log op
+ * counter, giving the same optimistic-concurrency behaviour as the Redis
+ * provider (a stale writer loses the CAS and raises `InconsistentStateError`).
+ */
+export class MemoryJournalStorage implements JournalStorage {
+  private readonly logs = new Map<string, Log>();
+
+  async read(logName: string, grainId: GrainId): Promise<JournalSegment> {
+    const log = this.logs.get(this.key(logName, grainId));
+    if (log === undefined) return { entries: [], version: undefined };
+    return { entries: [...log.entries], version: log.version };
+  }
+
+  async append(
+    logName: string,
+    grainId: GrainId,
+    entries: readonly JournalEntry[],
+    expectedVersion: number | undefined,
+  ): Promise<number> {
+    const key = this.key(logName, grainId);
+    const log = this.logs.get(key);
+    this.checkVersion(logName, grainId, log?.version, expectedVersion);
+    const next = log ?? { entries: [], version: 0 };
+    next.entries.push(...entries);
+    next.version += 1;
+    this.logs.set(key, next);
+    return next.version;
+  }
+
+  async replace(
+    logName: string,
+    grainId: GrainId,
+    entries: readonly JournalEntry[],
+    expectedVersion: number | undefined,
+  ): Promise<number> {
+    const key = this.key(logName, grainId);
+    const log = this.logs.get(key);
+    this.checkVersion(logName, grainId, log?.version, expectedVersion);
+    const version = (log?.version ?? 0) + 1;
+    this.logs.set(key, { entries: [...entries], version });
+    return version;
+  }
+
+  async clear(logName: string, grainId: GrainId): Promise<void> {
+    this.logs.delete(this.key(logName, grainId));
+  }
+
+  private checkVersion(
+    logName: string,
+    grainId: GrainId,
+    stored: number | undefined,
+    expected: number | undefined,
+  ): void {
+    if (stored !== expected) {
+      throw new InconsistentStateError(
+        `journal version conflict on ${logName} for ${grainId.toString()}`,
+        versionStr(expected),
+        versionStr(stored),
+      );
+    }
+  }
+
+  private key(logName: string, grainId: GrainId): string {
+    return `${grainId.toString()}/${logName}`;
+  }
+}

--- a/packages/journaling/src/redis-journal-storage.test.ts
+++ b/packages/journaling/src/redis-journal-storage.test.ts
@@ -1,0 +1,113 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createClient } from "redis";
+import { InconsistentStateError } from "@tsva/core/errors";
+import { GrainId } from "@tsva/core/grain-id";
+import { DurableValueImpl } from "@tsva/journaling/durable-value-impl";
+import { RedisJournalStorage } from "@tsva/journaling/redis-journal-storage";
+import { StateMachineManagerImpl } from "@tsva/journaling/state-machine-manager-impl";
+
+const REDIS_URL = process.env.REDIS_URL ?? "redis://localhost:6379";
+
+type Client = ReturnType<typeof createClient>;
+
+/** Probe Redis once at load time so the suite skips cleanly without it. */
+async function reachable(url: string): Promise<Client | undefined> {
+  const probe = createClient({ url });
+  probe.on("error", () => {});
+  try {
+    await probe.connect();
+    await probe.ping();
+    return probe;
+  } catch {
+    try {
+      await probe.destroy();
+    } catch {
+      /* never connected */
+    }
+    return undefined;
+  }
+}
+
+const client = await reachable(REDIS_URL);
+const prefix = `tsva-test:journal:${randomUUID()}`;
+
+const id = new GrainId("Agg", "g1");
+const makeStorage = () => new RedisJournalStorage(client!, { keyPrefix: prefix });
+
+async function deleteAll(c: Client, match: string): Promise<void> {
+  for await (const keys of c.scanIterator({ MATCH: match })) {
+    if (keys.length > 0) await c.del(keys);
+  }
+}
+
+afterAll(async () => {
+  if (client === undefined) return;
+  await deleteAll(client, `${prefix}*`);
+  await client.destroy();
+});
+
+describe.skipIf(client === undefined)("RedisJournalStorage", () => {
+  beforeEach(async () => {
+    await deleteAll(client!, `${prefix}*`);
+  });
+
+  it("reads an empty log as no version", async () => {
+    const segment = await makeStorage().read("journal", id);
+    expect(segment.entries).toEqual([]);
+    expect(segment.version).toBeUndefined();
+  });
+
+  it("appends and round-trips through a fresh client", async () => {
+    const v1 = await makeStorage().append("journal", id, ["a", "b"], undefined);
+    expect(v1).toBe(1);
+    const v2 = await makeStorage().append("journal", id, ["c"], 1);
+    expect(v2).toBe(2);
+
+    const segment = await makeStorage().read("journal", id);
+    expect(segment.entries).toEqual(["a", "b", "c"]);
+    expect(segment.version).toBe(2);
+  });
+
+  it("raises InconsistentStateError on a stale append", async () => {
+    await makeStorage().append("journal", id, ["a"], undefined);
+    await expect(makeStorage().append("journal", id, ["b"], undefined)).rejects.toBeInstanceOf(
+      InconsistentStateError,
+    );
+    await expect(makeStorage().append("journal", id, ["b"], 5)).rejects.toBeInstanceOf(
+      InconsistentStateError,
+    );
+  });
+
+  it("replace truncates the log and bumps the version", async () => {
+    await makeStorage().append("journal", id, ["a", "b", "c"], undefined);
+    const v = await makeStorage().replace("journal", id, ["snap"], 1);
+    expect(v).toBe(2);
+    const segment = await makeStorage().read("journal", id);
+    expect(segment.entries).toEqual(["snap"]);
+    expect(segment.version).toBe(2);
+  });
+
+  it("clears both keys", async () => {
+    await makeStorage().append("journal", id, ["a"], undefined);
+    await makeStorage().clear("journal", id);
+    const segment = await makeStorage().read("journal", id);
+    expect(segment.entries).toEqual([]);
+    expect(segment.version).toBeUndefined();
+  });
+
+  it("round-trips a full manager + structure through Redis", async () => {
+    const a = new StateMachineManagerImpl("journal", id, makeStorage());
+    const av = new DurableValueImpl<number>("v", a);
+    a.register(av);
+    await a.replay();
+    await av.set(1);
+    await av.set(2);
+
+    const b = new StateMachineManagerImpl("journal", id, makeStorage());
+    const bv = new DurableValueImpl<number>("v", b);
+    b.register(bv);
+    await b.replay();
+    expect(bv.value).toBe(2);
+  });
+});

--- a/packages/journaling/src/redis-journal-storage.ts
+++ b/packages/journaling/src/redis-journal-storage.ts
@@ -1,0 +1,139 @@
+import type { createClient } from "redis";
+import { InconsistentStateError } from "@tsva/core/errors";
+import type { GrainId } from "@tsva/core/grain-id";
+import type { JournalEntry, JournalSegment, JournalStorage } from "@tsva/core/journal-storage";
+
+/** A connected node-redis client (the subset this provider drives). */
+export type RedisClient = ReturnType<typeof createClient>;
+
+export interface RedisJournalStorageOptions {
+  /** Namespace for keys in the shared Redis (defaults to `"tsva"`). */
+  keyPrefix?: string;
+}
+
+const CONFLICT = "TSVA_ETAG_CONFLICT";
+
+// Conditional append: the caller's expected version (ARGV[1], '' = "no log yet")
+// must match the stored version, then push the new entries (ARGV[2..]) and bump
+// the version. Atomic on the server, so two silos racing to append produce one
+// winner and one conflict — the optimistic-concurrency contract of GrainStorage,
+// carried over to an append-only log.
+const APPEND = `
+local cur = redis.call('GET', KEYS[2])
+if ARGV[1] == '' then
+  if cur then return redis.error_reply('${CONFLICT} ' .. cur) end
+elseif (not cur) or (cur ~= ARGV[1]) then
+  return redis.error_reply('${CONFLICT} ' .. (cur or ''))
+end
+for i = 2, #ARGV do
+  redis.call('RPUSH', KEYS[1], ARGV[i])
+end
+return redis.call('INCR', KEYS[2])`;
+
+// Conditional snapshot replace: same version guard, then drop the whole log and
+// write the snapshot frames in its place. Atomic, so a compaction racing a
+// stale incarnation's append still leaves exactly one winner.
+const REPLACE = `
+local cur = redis.call('GET', KEYS[2])
+if ARGV[1] == '' then
+  if cur then return redis.error_reply('${CONFLICT} ' .. cur) end
+elseif (not cur) or (cur ~= ARGV[1]) then
+  return redis.error_reply('${CONFLICT} ' .. (cur or ''))
+end
+redis.call('DEL', KEYS[1])
+for i = 2, #ARGV do
+  redis.call('RPUSH', KEYS[1], ARGV[i])
+end
+return redis.call('INCR', KEYS[2])`;
+
+/**
+ * Durable, cluster-shared journal store backed by Redis. The log is a Redis list
+ * of entry strings (`…:journal:{grain}/{log}`) alongside a version counter
+ * (`…:journalver:{grain}/{log}`); appends and snapshot replaces run as
+ * conditional Lua scripts so optimistic concurrency holds across silos. Reuses
+ * the `RedisGrainStorage` Lua/CAS pattern and is interchangeable with
+ * `MemoryJournalStorage`.
+ */
+export class RedisJournalStorage implements JournalStorage {
+  private readonly keyPrefix: string;
+
+  constructor(
+    private readonly client: RedisClient,
+    options: RedisJournalStorageOptions = {},
+  ) {
+    this.keyPrefix = options.keyPrefix ?? "tsva";
+  }
+
+  async read(logName: string, grainId: GrainId): Promise<JournalSegment> {
+    const versionRaw = await this.client.get(this.versionKey(logName, grainId));
+    if (versionRaw === null) return { entries: [], version: undefined };
+    const entries = await this.client.lRange(this.entriesKey(logName, grainId), 0, -1);
+    return { entries, version: Number(versionRaw) };
+  }
+
+  async append(
+    logName: string,
+    grainId: GrainId,
+    entries: readonly JournalEntry[],
+    expectedVersion: number | undefined,
+  ): Promise<number> {
+    return this.eval(APPEND, logName, grainId, entries, expectedVersion);
+  }
+
+  async replace(
+    logName: string,
+    grainId: GrainId,
+    entries: readonly JournalEntry[],
+    expectedVersion: number | undefined,
+  ): Promise<number> {
+    return this.eval(REPLACE, logName, grainId, entries, expectedVersion);
+  }
+
+  async clear(logName: string, grainId: GrainId): Promise<void> {
+    await this.client.del([this.entriesKey(logName, grainId), this.versionKey(logName, grainId)]);
+  }
+
+  private async eval(
+    script: string,
+    logName: string,
+    grainId: GrainId,
+    entries: readonly JournalEntry[],
+    expectedVersion: number | undefined,
+  ): Promise<number> {
+    try {
+      const result = await this.client.eval(script, {
+        keys: [this.entriesKey(logName, grainId), this.versionKey(logName, grainId)],
+        arguments: [expectedVersion === undefined ? "" : String(expectedVersion), ...entries],
+      });
+      return Number(result);
+    } catch (err) {
+      this.rethrowConflict(err, logName, grainId, expectedVersion);
+    }
+  }
+
+  private rethrowConflict(
+    err: unknown,
+    logName: string,
+    grainId: GrainId,
+    expected: number | undefined,
+  ): never {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.startsWith(CONFLICT)) {
+      const stored = message.slice(CONFLICT.length).trim() || undefined;
+      throw new InconsistentStateError(
+        `journal version conflict on ${logName} for ${grainId.toString()}`,
+        expected === undefined ? undefined : String(expected),
+        stored,
+      );
+    }
+    throw err;
+  }
+
+  private entriesKey(logName: string, grainId: GrainId): string {
+    return `${this.keyPrefix}:journal:${grainId.toString()}/${logName}`;
+  }
+
+  private versionKey(logName: string, grainId: GrainId): string {
+    return `${this.keyPrefix}:journalver:${grainId.toString()}/${logName}`;
+  }
+}

--- a/packages/journaling/src/state-machine-manager-impl.test.ts
+++ b/packages/journaling/src/state-machine-manager-impl.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { InconsistentStateError } from "@tsva/core/errors";
+import { GrainId } from "@tsva/core/grain-id";
+import { DurableValueImpl } from "@tsva/journaling/durable-value-impl";
+import { DurableDictionaryImpl } from "@tsva/journaling/durable-dictionary-impl";
+import { DurableListImpl } from "@tsva/journaling/durable-list-impl";
+import { MemoryJournalStorage } from "@tsva/journaling/memory-journal-storage";
+import { StateMachineManagerImpl } from "@tsva/journaling/state-machine-manager-impl";
+
+const id = new GrainId("Agg", "g1");
+
+async function frameKinds(storage: MemoryJournalStorage): Promise<string[]> {
+  const segment = await storage.read("journal", id);
+  return segment.entries.map((e) => JSON.parse(e).k as string);
+}
+
+describe("StateMachineManagerImpl", () => {
+  it("rejects a duplicate machine name", () => {
+    const manager = new StateMachineManagerImpl("journal", id, new MemoryJournalStorage());
+    manager.register(new DurableValueImpl("dup", manager));
+    expect(() => manager.register(new DurableValueImpl("dup", manager))).toThrow(/duplicate/);
+  });
+
+  it("snapshots and truncates the log past the threshold, and replays correctly", async () => {
+    const storage = new MemoryJournalStorage();
+    const manager = new StateMachineManagerImpl("journal", id, storage, { snapshotThreshold: 4 });
+    const value = new DurableValueImpl<number>("v", manager);
+    manager.register(value);
+    await manager.replay();
+
+    // 4 appends crosses the threshold and triggers a compaction.
+    await value.set(1);
+    await value.set(2);
+    await value.set(3);
+    await value.set(4);
+
+    const kinds = await frameKinds(storage);
+    expect(kinds).toEqual(["snap"]); // log truncated to one snapshot frame
+    const { version } = await storage.read("journal", id);
+    expect(version).toBe(5); // 4 appends + 1 replace
+
+    // Further mutations after the snapshot, then a fresh activation replays it all.
+    await value.set(5);
+    const fresh = new StateMachineManagerImpl("journal", id, storage, { snapshotThreshold: 4 });
+    const replayed = new DurableValueImpl<number>("v", fresh);
+    fresh.register(replayed);
+    await fresh.replay();
+    expect(replayed.value).toBe(5);
+  });
+
+  it("shares one log across multiple structures and replays each", async () => {
+    const storage = new MemoryJournalStorage();
+    const manager = new StateMachineManagerImpl("journal", id, storage, {
+      snapshotThreshold: 1000,
+    });
+    const value = new DurableValueImpl<string>("v", manager);
+    const dict = new DurableDictionaryImpl<string, number>("d", manager);
+    const list = new DurableListImpl<number>("l", manager);
+    manager.register(value);
+    manager.register(dict);
+    manager.register(list);
+    await manager.replay();
+
+    await value.set("hello");
+    await dict.set("a", 1);
+    await list.add(10);
+    await dict.set("b", 2);
+    await list.add(20);
+
+    // All five mutations live in the single shared log.
+    expect((await storage.read("journal", id)).entries).toHaveLength(5);
+
+    const fresh = new StateMachineManagerImpl("journal", id, storage, { snapshotThreshold: 1000 });
+    const v2 = new DurableValueImpl<string>("v", fresh);
+    const d2 = new DurableDictionaryImpl<string, number>("d", fresh);
+    const l2 = new DurableListImpl<number>("l", fresh);
+    fresh.register(v2);
+    fresh.register(d2);
+    fresh.register(l2);
+    await fresh.replay();
+
+    expect(v2.value).toBe("hello");
+    expect([...d2.entries()]).toEqual([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    expect(l2.toArray()).toEqual([10, 20]);
+  });
+
+  it("fences out a stale incarnation via the version CAS, leaving its memory untouched", async () => {
+    const storage = new MemoryJournalStorage();
+    const a = new StateMachineManagerImpl("journal", id, storage);
+    const av = new DurableValueImpl<number>("v", a);
+    a.register(av);
+    await a.replay();
+
+    const b = new StateMachineManagerImpl("journal", id, storage);
+    const bv = new DurableValueImpl<number>("v", b);
+    b.register(bv);
+    await b.replay(); // both at the empty version
+
+    await av.set(1); // A wins the append
+
+    await expect(bv.set(99)).rejects.toBeInstanceOf(InconsistentStateError);
+    expect(bv.value).toBeUndefined(); // append-before-apply: B's memory unchanged
+  });
+});

--- a/packages/journaling/src/state-machine-manager-impl.ts
+++ b/packages/journaling/src/state-machine-manager-impl.ts
@@ -1,0 +1,94 @@
+import type { GrainId } from "@tsva/core/grain-id";
+import type { JournalStorage } from "@tsva/core/journal-storage";
+import type { DurableStateMachine, StateMachineManager } from "@tsva/core/durable-state-machine";
+import { deserializeValue, serializeValue } from "@tsva/core/value-codec";
+
+/** A framed log record: which machine, whether it is an op or a snapshot, and the payload. */
+interface LogEnvelope {
+  /** Owning machine name (= `stateName`). */
+  m: string;
+  /** Frame kind: `"op"` = incremental mutation, `"snap"` = full-state snapshot. */
+  k: "op" | "snap";
+  /** Machine-specific payload (op or snapshot), opaque to the manager. */
+  p: unknown;
+}
+
+export interface StateMachineManagerOptions {
+  /** Snapshot + truncate once the live log reaches this many entries (default 100). */
+  snapshotThreshold?: number;
+}
+
+/**
+ * Per-grain owner of one append-only log shared by all the grain's durable
+ * structures (see [ADR 0019](../../docs/adr/0019-durable-journaling.md)). It
+ * frames mutations, persists them through a `JournalStorage` under version CAS,
+ * replays the log on activation, and snapshots + truncates past a threshold.
+ * Within an activation everything runs on serialized turns, so no in-process
+ * locking is needed; the only concurrency is a cross-silo incarnation, which the
+ * storage version CAS fences out.
+ */
+export class StateMachineManagerImpl implements StateMachineManager {
+  private readonly machines = new Map<string, DurableStateMachine>();
+  private readonly snapshotThreshold: number;
+  private version: number | undefined;
+  private liveEntryCount = 0;
+
+  constructor(
+    private readonly logName: string,
+    private readonly grainId: GrainId,
+    private readonly storage: JournalStorage,
+    options: StateMachineManagerOptions = {},
+  ) {
+    this.snapshotThreshold = options.snapshotThreshold ?? 100;
+  }
+
+  register(machine: DurableStateMachine): void {
+    if (this.machines.has(machine.name)) {
+      throw new Error(
+        `duplicate durable state machine "${machine.name}" on ${this.grainId.toString()}`,
+      );
+    }
+    this.machines.set(machine.name, machine);
+  }
+
+  async replay(): Promise<void> {
+    const segment = await this.storage.read(this.logName, this.grainId);
+    this.version = segment.version;
+    this.liveEntryCount = segment.entries.length;
+    for (const machine of this.machines.values()) machine.reset();
+    for (const entry of segment.entries) {
+      const env = deserializeValue<LogEnvelope>(entry);
+      const machine = this.machines.get(env.m);
+      // A structure removed from the grain across deploys: drop its orphan
+      // entries (they vanish at the next compaction) rather than crash activation.
+      if (machine === undefined) continue;
+      machine.apply(env.p);
+    }
+  }
+
+  async append(machineName: string, payload: unknown): Promise<void> {
+    const machine = this.machines.get(machineName);
+    if (machine === undefined) throw new Error(`unknown durable state machine "${machineName}"`);
+    const entry = serializeValue({ m: machineName, k: "op", p: payload } satisfies LogEnvelope);
+    // Persist first; only on success apply to memory (a conflicting write leaves
+    // the structure untouched and fails the call). The manager owns the apply so
+    // that an in-turn compaction below snapshots up-to-date in-memory state.
+    this.version = await this.storage.append(this.logName, this.grainId, [entry], this.version);
+    machine.apply(payload);
+    this.liveEntryCount += 1;
+    if (this.liveEntryCount >= this.threshold()) await this.compact();
+  }
+
+  async compact(): Promise<void> {
+    const frames = [...this.machines.values()].map((machine) =>
+      serializeValue({ m: machine.name, k: "snap", p: machine.snapshot() } satisfies LogEnvelope),
+    );
+    this.version = await this.storage.replace(this.logName, this.grainId, frames, this.version);
+    this.liveEntryCount = frames.length;
+  }
+
+  /** Keep the threshold above the machine count so we don't recompact on every append. */
+  private threshold(): number {
+    return Math.max(this.snapshotThreshold, this.machines.size + 1);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       '@tsva/directory':
         specifier: workspace:*
         version: link:../directory
+      '@tsva/journaling':
+        specifier: workspace:*
+        version: link:../journaling
       '@tsva/messaging':
         specifier: workspace:*
         version: link:../messaging
@@ -229,6 +232,15 @@ importers:
       pg:
         specifier: ^8.21.0
         version: 8.21.0
+      redis:
+        specifier: ^5.12.1
+        version: 5.12.1(@opentelemetry/api@1.9.1)
+
+  packages/journaling:
+    dependencies:
+      '@tsva/core':
+        specifier: workspace:*
+        version: link:../core
       redis:
         specifier: ^5.12.1
         version: 5.12.1(@opentelemetry/api@1.9.1)

--- a/todo.md
+++ b/todo.md
@@ -11,8 +11,9 @@ routing, the DHT directory with versioned range handoff, placement (strategies +
 version-aware), Kubernetes hosting, persistence and reminders (memory / Redis / Postgres), event
 streams (memory / Redis) with implicit subscriptions, cross-grain ACID transactions, grain call
 filters, observability, grain migration, grain-interface versioning, broadcast channels, the external
-client (gateway discovery + failover), and reducer / functional-first authoring. Worked examples
-double as acceptance tests.
+client (gateway discovery + failover), durable journaling (`DurableGrain`,
+[ADR 0019](docs/adr/0019-durable-journaling.md)), and reducer / functional-first authoring. Worked
+examples double as acceptance tests.
 
 ## Remaining
 
@@ -23,8 +24,6 @@ double as acceptance tests.
       surface, a `RebalancingReport` + suspend/resume, and a convergence e2e over a running cluster.
 - [ ] **Durable jobs** — implement [ADR 0018](docs/adr/0018-durable-jobs.md) (`@tsva/durable-jobs`): a
       sharded, durable, at-least-once scheduled-execution engine. Design only so far.
-- [ ] **Durable journaling (`DurableGrain`)** — Orleans 10 `Orleans.Journaling`; needs an ADR
-      (overlaps the reducer/persistent-state model) then implementation.
 
 ## Beyond parity
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,6 +30,7 @@
       "@tsva/hosting/*": ["./packages/hosting/src/*"],
       "@tsva/persistence/*": ["./packages/persistence/src/*"],
       "@tsva/transactions/*": ["./packages/transactions/src/*"],
+      "@tsva/journaling/*": ["./packages/journaling/src/*"],
       "@tsva/observability/*": ["./packages/observability/src/*"],
       "@tsva/reminders/*": ["./packages/reminders/src/*"],
       "@tsva/streams/*": ["./packages/streams/src/*"],


### PR DESCRIPTION
Port Orleans 10 Orleans.Journaling as @tsva/journaling: a per-grain
StateMachineManager owns one append-only log; DurableValue/DurableDictionary/
DurableList register as DurableStateMachines, journal each mutation, and replay
on activation, with snapshot + truncate past a threshold. A new JournalStorage
seam (memory + Redis, reusing the redis-grain-storage Lua/CAS pattern) stays
separate from the reducer snapshot facet (ADR 0006) and PersistentState — the
durable, journalled path those left out. Adds useDurableState/useDurableDictionary/
useDurableList hooks + @durableState/@durableDictionary/@durableList decorators,
and builder useMemoryJournaling()/addRedisJournaling(name, { url, keyPrefix? }),
wired in only at the existing stateBinder seam.

https://claude.ai/code/session_01SRxwdcsLqSjHF3apsNhyET