### PR TITLE
feat(durable-jobs): implement @tsva/durable-jobs (ADR 0018)

### DIFF
--- a/EPICS.md
+++ b/EPICS.md
@@ -43,6 +43,11 @@ runtime). See [`todo.md`](todo.md) for outstanding work, [`docs/`](docs/) for th
 - **Reducer & functional-first authoring** (ADRs [0006](docs/adr/0006-reducer-grains.md)/[0009](docs/adr/0009-functional-grains.md)/[0010](docs/adr/0010-message-dispatch-reducer-grains.md)/[0011](docs/adr/0011-message-dispatch-substrate.md))
   — `defineGrain` + hooks, snapshot reducers, dispatch grains. Every example grain is functional
   (one `@grain()` class kept on purpose as the living interop example).
+- **Durable jobs** ([ADR 0018](docs/adr/0018-durable-jobs.md)) — `@tsva/durable-jobs`: sharded
+  (time-bucketed), durable, at-least-once scheduled grain invocation, with per-silo concurrency control
+  (limiter + slow-start + overload backoff), retry policy, `pollAfter` supervision, and
+  membership-driven shard ownership with dead-silo adoption, poison protection and a claim ramp-up
+  budget. Memory + Redis (Lua-CAS) shard stores; `useDurableJobHandler` + `runtime.scheduleJob`.
 
 ## 🚧 In progress
 
@@ -52,8 +57,6 @@ runtime). See [`todo.md`](todo.md) for outstanding work, [`docs/`](docs/) for th
 
 ## 📐 Designed (not yet implemented)
 
-- **Durable jobs** ([ADR 0018](docs/adr/0018-durable-jobs.md)) — sharded, durable, at-least-once
-  scheduled execution.
 - **Browser state replication** ([ADR 0017](docs/adr/0017-browser-state-replication.md), beyond parity).
 
 ## ⏸ Deferred

--- a/docs/13-roadmap-and-phases.md
+++ b/docs/13-roadmap-and-phases.md
@@ -32,14 +32,13 @@ retained class substrate. Also shipped: grain migration, grain-interface version
 directory range handoff, placement filters, broadcast channels ([ADR 0015](adr/0015-broadcast-channels.md)),
 grain call filters ([ADR 0012](adr/0012-grain-call-filters.md)), observability
 ([ADR 0013](adr/0013-observability.md)), durable journaling
-([ADR 0019](adr/0019-durable-journaling.md)), and the external client with gateway discovery + failover.
+([ADR 0019](adr/0019-durable-journaling.md)), durable jobs
+([ADR 0018](adr/0018-durable-jobs.md)), and the external client with gateway discovery + failover.
 
 ## Remaining for parity
 
 - **Activation rebalancer** ([ADR 0016](adr/0016-activation-rebalancer.md)) — the entropy model and
   the distributed mechanism ship; the elected worker + builder + convergence e2e remain.
-- **Durable jobs** ([ADR 0018](adr/0018-durable-jobs.md)) — a sharded, durable, at-least-once
-  scheduled-execution engine (`@tsva/durable-jobs`); designed, not yet implemented.
 
 ## Deferred (not parity gaps)
 

--- a/docs/adr/0018-durable-jobs.md
+++ b/docs/adr/0018-durable-jobs.md
@@ -1,6 +1,6 @@
 # ADR 0018 — Durable jobs (sharded, durable, at-least-once scheduled execution)
 
-- Status: Proposed — design only. Slice plan below.
+- Status: Accepted — implemented as `@tsva/durable-jobs` (all four slices). Slice plan below.
 - Context docs: [07 — Persistence](../07-persistence.md),
   [06 — Directory and placement](../06-grain-directory-and-placement.md),
   [13 — Roadmap](../13-roadmap-and-phases.md); [ADR 0005](0005-redis-default-providers.md),

--- a/packages/core/src/define-grain.ts
+++ b/packages/core/src/define-grain.ts
@@ -10,6 +10,7 @@ import {
   type GrainConstructor,
   type GrainOptions,
 } from "./grain-metadata";
+import { DURABLE_JOB_HANDLER, type DurableJobHandler } from "./durable-job";
 import type { GrainKeyFor } from "./key-kinds";
 import type { PersistentState } from "./persistent-state";
 import { registerPersistentField } from "./persistent-state-metadata";
@@ -140,6 +141,25 @@ export function defineGrain<T extends object>(
     markBroadcastSubscription(FunctionalGrain as GrainConstructor, namespace);
   }
   return FunctionalGrain;
+}
+
+/**
+ * The functional counterpart of exposing a `DURABLE_JOB_HANDLER` member: register
+ * the handler the runtime runs when a durable job targeting this grain fires (ADR
+ * 0018). The job runs as a turn on this activation; resolving the handler means
+ * the job is `Completed` (removed), throwing means `Failed` (the retry policy
+ * decides), and returning `pollAfter(delay)` re-polls under supervision. Handlers
+ * must be idempotent — delivery is at-least-once. Mirrors the symbol-observer
+ * idiom (`BROADCAST_CHANNEL_OBSERVER`).
+ */
+export function useDurableJobHandler(ctx: GrainSetup, handler: DurableJobHandler): void {
+  const instance = instanceOf(ctx);
+  Object.defineProperty(instance, DURABLE_JOB_HANDLER, {
+    value: handler,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
 }
 
 export interface UseReducerStateOptions<TState, TEvent> {

--- a/packages/core/src/durable-job.ts
+++ b/packages/core/src/durable-job.ts
@@ -1,0 +1,149 @@
+import type { Duration } from "./duration";
+import { defineGrainInterface, type GrainInterface } from "./grain-interface";
+import type { GrainId } from "./grain-id";
+
+/**
+ * A durable job: one scheduled invocation of a target grain at a due time, made
+ * durable, sharded by due time, retried and failed-over (ADR 0018). Despite the
+ * name it is not a workflow — it is "a reminder at scale, one-shot, with retries,
+ * concurrency control and crash-failover". Mirrors Orleans' `DurableJob`.
+ */
+export interface DurableJob {
+  /** Globally unique id of this job (a Guid string). */
+  id: string;
+  /** The handler name the target grain dispatches on (Orleans' job `Name`). */
+  name: string;
+  /** When the job becomes due to run. */
+  dueTime: Date;
+  /** The grain whose `DURABLE_JOB_HANDLER` runs the job, as a turn on its activation. */
+  target: GrainId;
+  /** The time-bucket shard key, `floor(dueTime / shardDuration)` (single-writer at shard granularity). */
+  shardKey: number;
+  /** Opaque, codec-serializable payload handed to the handler. */
+  metadata: Readonly<Record<string, unknown>>;
+}
+
+/** The arguments to schedule a job, from any grain via `runtime.scheduleJob`. */
+export interface ScheduleJobRequest {
+  target: GrainId;
+  name: string;
+  /** Absolute time the job becomes due. */
+  dueTime: Date;
+  metadata?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * The job handed to a `DURABLE_JOB_HANDLER` for one attempt. `dequeueCount` is the
+ * number of times this job has been dequeued for execution (starts at 1 on the
+ * first attempt); handlers must be idempotent (at-least-once delivery).
+ */
+export interface JobRunContext {
+  id: string;
+  name: string;
+  dueTime: Date;
+  target: GrainId;
+  metadata: Readonly<Record<string, unknown>>;
+  /** How many times this job has been dequeued for execution (≥ 1). */
+  dequeueCount: number;
+}
+
+/**
+ * The outcome of running a job (Orleans `DurableJobRunResult`):
+ * - `completed` — done, remove the job from the shard.
+ * - `pollAfter` — not done yet; re-poll after the delay, holding the concurrency
+ *   slot (a supervised long-running job, not a retry).
+ * - `failed` — the attempt failed; the retry policy decides whether to retry
+ *   (with backoff) or drop. Throwing from a handler is equivalent to `failed`.
+ */
+export type DurableJobRunResult =
+  | { kind: "completed" }
+  | { kind: "pollAfter"; delay: Duration }
+  | { kind: "failed"; error: unknown };
+
+export const completed: DurableJobRunResult = { kind: "completed" };
+
+export function pollAfter(delay: Duration): DurableJobRunResult {
+  return { kind: "pollAfter", delay };
+}
+
+export function failed(error: unknown): DurableJobRunResult {
+  return { kind: "failed", error };
+}
+
+/** The grain's job handler: resolves a result for one attempt of a job. */
+export type DurableJobHandler = (job: JobRunContext) => Promise<DurableJobRunResult>;
+
+/**
+ * A target grain opts into receiving durable jobs by exposing, under this symbol,
+ * the handler that runs each due job as a turn on its activation. The runtime
+ * resolves it lazily on the first delivered job. Mirrors the symbol-observer idiom
+ * (`BROADCAST_CHANNEL_OBSERVER` / `STREAM_SUBSCRIPTION_OBSERVER`); the symbol key
+ * keeps it from colliding with the grain's own (string-named) methods.
+ */
+export const DURABLE_JOB_HANDLER = Symbol.for("tsva.durableJobHandler");
+
+/** A grain that handles durable jobs delivered to it. */
+export interface DurableJobReceiver {
+  [DURABLE_JOB_HANDLER]: DurableJobHandler;
+}
+
+/**
+ * The runtime-facing handle a grain's `scheduleJob` / `cancelJob` delegate to.
+ * The `LocalDurableJobManager` implements it; the hosting layer injects it into
+ * the runtime (parity with `ReminderRegistry`).
+ */
+export interface DurableJobScheduler {
+  scheduleJob(request: ScheduleJobRequest): Promise<DurableJob>;
+  cancelJob(job: { id: string; shardKey: number }): Promise<void>;
+}
+
+/** The grain's durable-job handler, bound to it, or `undefined` if it declares none. */
+export function durableJobHandler(instance: object): DurableJobHandler | undefined {
+  const fn = (instance as Record<symbol, unknown>)[DURABLE_JOB_HANDLER];
+  return typeof fn === "function"
+    ? (job) => (fn as DurableJobHandler).call(instance, job)
+    : undefined;
+}
+
+/**
+ * System extension the shard executor invokes (through the dispatcher) to run one
+ * attempt of a job on the target grain's single activation — so the job runs as a
+ * turn, reactivating an idle grain wherever it is placed. The runtime intercepts
+ * it and runs the grain's `DURABLE_JOB_HANDLER`; the grain never declares this
+ * method. Mirrors the `BroadcastConsumer` / reminder delivery path.
+ */
+export interface DurableJobConsumer {
+  runJob(job: JobRunContext): Promise<DurableJobRunResult>;
+}
+
+export const DurableJobConsumerInterface: GrainInterface<DurableJobConsumer> =
+  defineGrainInterface<DurableJobConsumer>("system.DurableJobConsumer");
+
+/**
+ * Decides whether a failed job is retried. Returns the delay before the next
+ * attempt, or `undefined` to drop the job (Orleans' `ShouldRetry`). `dequeueCount`
+ * is the number of attempts so far (≥ 1).
+ */
+export type ShouldRetry = (dequeueCount: number, error: unknown) => Duration | undefined;
+
+/** Tunables for the durable-jobs subsystem (mirrors Orleans `DurableJobsOptions`). */
+export interface DurableJobsOptions {
+  /** Width of a time shard; jobs bucket by `floor(dueTime / shardDuration)`. Default 1h. */
+  shardDuration?: Duration;
+  /** How early a shard is activated before its first job is due. Default 1m. */
+  shardActivationBufferPeriod?: Duration;
+  /** Max jobs running concurrently across all shards on one silo. Default 100. */
+  maxConcurrentJobsPerSilo?: number;
+  /** Concurrency a fresh executor starts at before ramping to the max (slow-start). Default 1. */
+  slowStartInitialConcurrency?: number;
+  /** Multiplier applied to the slow-start concurrency on each successful poll cycle. Default 2. */
+  slowStartGrowthFactor?: number;
+  /** Backoff applied to a shard's poll loop when the silo is overloaded. Default 1s. */
+  overloadBackoff?: Duration;
+  /** Retry policy for a failed job; default ≤ 5 attempts with `2^n`s backoff. */
+  shouldRetry?: ShouldRetry;
+  /** A shard adopted from a dead owner more than this many times is poisoned. Default 3. */
+  maxAdoptedCount?: number;
+  /** Shards a freshly joined silo may claim per ramp-up step (claim budget). Default 4. */
+  claimRampUpBudget?: number;
+}

--- a/packages/core/src/grain-runtime.ts
+++ b/packages/core/src/grain-runtime.ts
@@ -4,6 +4,7 @@ import type { GrainTimer } from "./grain-timer";
 import type { GrainKeyFor } from "./key-kinds";
 import type { SiloAddress } from "./silo-address";
 import type { BroadcastChannelProvider } from "./broadcast-channel";
+import type { DurableJob, ScheduleJobRequest } from "./durable-job";
 import type { StreamProvider } from "./stream";
 
 /**
@@ -15,6 +16,14 @@ export interface GrainRuntime {
   registerTimer(callback: () => Promise<void>, due: Duration, period?: Duration): GrainTimer;
   registerReminder(name: string, due: Duration, period: Duration): Promise<void>;
   unregisterReminder(name: string): Promise<void>;
+  /**
+   * Schedule a durable job: one invocation of a target grain's
+   * `DURABLE_JOB_HANDLER` at a due time, made durable, retried and failed-over
+   * (ADR 0018). Returns the durable job; pass it to {@link cancelJob} to cancel.
+   */
+  scheduleJob(request: ScheduleJobRequest): Promise<DurableJob>;
+  /** Best-effort cancel of a scheduled job that has not yet completed. */
+  cancelJob(job: DurableJob): Promise<void>;
   getStreamProvider(name?: string): StreamProvider;
   /** The named broadcast-channel provider (Orleans `IBroadcastChannelProvider`). */
   getBroadcastChannelProvider(name?: string): BroadcastChannelProvider;

--- a/packages/durable-jobs/package.json
+++ b/packages/durable-jobs/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@tsva/durable-jobs",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./*": "./src/*.ts"
+  },
+  "dependencies": {
+    "@tsva/core": "workspace:*",
+    "redis": "^5.12.1"
+  }
+}

--- a/packages/durable-jobs/src/job-model.test.ts
+++ b/packages/durable-jobs/src/job-model.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  claimBudget,
+  defaultShouldRetry,
+  InMemoryJobQueue,
+  shardKeyFor,
+  shardStartMs,
+} from "@tsva/durable-jobs/job-model";
+
+const HOUR = 3_600_000;
+
+describe("shardKeyFor", () => {
+  it("buckets a due time by floor(dueTime / shardDuration)", () => {
+    expect(shardKeyFor(0, HOUR)).toBe(0);
+    expect(shardKeyFor(HOUR - 1, HOUR)).toBe(0);
+    expect(shardKeyFor(HOUR, HOUR)).toBe(1);
+    expect(shardKeyFor(HOUR * 2 + 5, HOUR)).toBe(2);
+  });
+
+  it("maps the shard key back to the bucket start", () => {
+    expect(shardStartMs(2, HOUR)).toBe(2 * HOUR);
+  });
+
+  it("rejects a non-positive shard duration", () => {
+    expect(() => shardKeyFor(0, 0)).toThrow();
+  });
+});
+
+describe("defaultShouldRetry", () => {
+  it("retries up to 5 attempts with 2^n second backoff, then drops", () => {
+    expect(defaultShouldRetry(1, new Error("x"))).toEqual({ seconds: 2 });
+    expect(defaultShouldRetry(2, new Error("x"))).toEqual({ seconds: 4 });
+    expect(defaultShouldRetry(3, new Error("x"))).toEqual({ seconds: 8 });
+    expect(defaultShouldRetry(4, new Error("x"))).toEqual({ seconds: 16 });
+    // 5th dequeue is the last attempt: no further retry.
+    expect(defaultShouldRetry(5, new Error("x"))).toBeUndefined();
+  });
+});
+
+describe("claimBudget", () => {
+  it("claims at most the budget per step", () => {
+    expect(claimBudget(10, 4)).toBe(4);
+    expect(claimBudget(2, 4)).toBe(2);
+    expect(claimBudget(0, 4)).toBe(0);
+  });
+
+  it("never claims with a non-positive budget", () => {
+    expect(claimBudget(10, 0)).toBe(0);
+  });
+});
+
+describe("InMemoryJobQueue", () => {
+  it("orders by due time and dequeues only what is due", () => {
+    const q = new InMemoryJobQueue();
+    q.add({ id: "a", dueMs: 100, dequeueCount: 0, payload: 1 });
+    q.add({ id: "b", dueMs: 50, dequeueCount: 0, payload: 2 });
+    q.add({ id: "c", dueMs: 300, dequeueCount: 0, payload: 3 });
+
+    expect(q.nextDueMs()).toBe(50);
+    const due = q.dequeueDue(100);
+    expect(due.map((j) => j.id)).toEqual(["b", "a"]);
+    // dequeueDue does not touch dequeueCount — the executor owns it.
+    expect(due.every((j) => j.dequeueCount === 0)).toBe(true);
+    // c is not yet due and stays.
+    expect(q.size).toBe(1);
+    expect(q.has("c")).toBe(true);
+  });
+
+  it("cancels a pending job", () => {
+    const q = new InMemoryJobQueue();
+    q.add({ id: "a", dueMs: 100, dequeueCount: 0, payload: 1 });
+    expect(q.cancel("a")).toBe(true);
+    expect(q.cancel("a")).toBe(false);
+    expect(q.size).toBe(0);
+  });
+
+  it("retryLater re-enqueues at the caller's dequeue count and a later due time", () => {
+    const q = new InMemoryJobQueue();
+    q.add({ id: "a", dueMs: 0, dequeueCount: 0, payload: 1 });
+    const [job] = q.dequeueDue(0);
+    expect(job?.dequeueCount).toBe(0);
+
+    // The executor bumps the count to the attempt just made, then re-enqueues.
+    q.retryLater({ ...job!, dequeueCount: 1 }, { seconds: 2 }, 1000);
+    const requeued = q.get("a");
+    expect(requeued?.dueMs).toBe(3000);
+    expect(requeued?.dequeueCount).toBe(1);
+  });
+});

--- a/packages/durable-jobs/src/job-model.ts
+++ b/packages/durable-jobs/src/job-model.ts
@@ -1,0 +1,116 @@
+import { durationToMs, type Duration } from "@tsva/core/duration";
+import type { ShouldRetry } from "@tsva/core/durable-job";
+
+/**
+ * The time-bucket shard key for a due time: `floor(dueTime / shardDuration)`
+ * (Orleans). Jobs in the same bucket share a shard, owned by one silo at a time;
+ * bucketing by *time* (not grain key) spreads a burst at one grain across silos.
+ */
+export function shardKeyFor(dueTimeMs: number, shardDurationMs: number): number {
+  if (shardDurationMs <= 0) throw new Error("shardDuration must be positive");
+  return Math.floor(dueTimeMs / shardDurationMs);
+}
+
+/** The wall-clock start of a shard bucket. */
+export function shardStartMs(shardKey: number, shardDurationMs: number): number {
+  return shardKey * shardDurationMs;
+}
+
+/**
+ * The default retry policy (Orleans): retry a failed job up to 5 attempts total,
+ * with exponential `2^n`s backoff between attempts (2s, 4s, 8s, 16s), then drop.
+ * `dequeueCount` is the number of attempts already made (≥ 1).
+ */
+export const defaultShouldRetry: ShouldRetry = (dequeueCount) => {
+  const maxAttempts = 5;
+  if (dequeueCount >= maxAttempts) return undefined;
+  return { seconds: 2 ** dequeueCount };
+};
+
+/**
+ * The number of shards a freshly joined silo may claim in one ramp-up step
+ * (Orleans' claim budget). A silo does not grab every orphaned shard at once on
+ * join; it claims at most `budget` per step so a rejoining silo does not melt.
+ * `pendingUnclaimed` is how many shards are available to claim; `budget` the
+ * per-step ceiling. Returns how many to claim this step.
+ */
+export function claimBudget(pendingUnclaimed: number, budget: number): number {
+  if (budget <= 0) return 0;
+  return Math.min(Math.max(0, pendingUnclaimed), budget);
+}
+
+/** A job entry tracked in the in-memory due-time queue. */
+export interface QueuedJob {
+  id: string;
+  /** Effective due time in ms (advanced by retry/poll backoff). */
+  dueMs: number;
+  /** How many times this job has been dequeued for execution (0 until first run). */
+  dequeueCount: number;
+  /** The opaque payload carried alongside the queue position. */
+  readonly payload: unknown;
+}
+
+/**
+ * An in-memory due-time priority queue — the working set of a shard (Orleans'
+ * `InMemoryJobQueue`). Jobs are kept ordered by effective due time; `add`,
+ * `cancel`, peeking the next-due job, dequeuing all jobs due by a cutoff, and
+ * `retryLater` (re-enqueue at a later time, preserving the dequeue count) are the
+ * operations the executor needs. Pure and clock-free: the caller passes "now".
+ */
+export class InMemoryJobQueue {
+  private readonly jobs = new Map<string, QueuedJob>();
+
+  get size(): number {
+    return this.jobs.size;
+  }
+
+  has(id: string): boolean {
+    return this.jobs.has(id);
+  }
+
+  get(id: string): QueuedJob | undefined {
+    return this.jobs.get(id);
+  }
+
+  /** Add (or replace) a job at its due time. */
+  add(job: QueuedJob): void {
+    this.jobs.set(job.id, { ...job });
+  }
+
+  /** Remove a job by id; returns whether it was present (a best-effort cancel). */
+  cancel(id: string): boolean {
+    return this.jobs.delete(id);
+  }
+
+  /** The earliest due time among queued jobs, or `undefined` if empty. */
+  nextDueMs(): number | undefined {
+    let earliest: number | undefined;
+    for (const job of this.jobs.values()) {
+      if (earliest === undefined || job.dueMs < earliest) earliest = job.dueMs;
+    }
+    return earliest;
+  }
+
+  /**
+   * Remove and return every job due at or before `nowMs`, earliest first. The
+   * `dequeueCount` is *not* touched here — the executor owns it: it counts run
+   * attempts (a retry bumps it; a `pollAfter` re-poll, being a continuation of the
+   * same attempt, does not), so incrementing per dequeue would over-count polls.
+   */
+  dequeueDue(nowMs: number): QueuedJob[] {
+    const due = [...this.jobs.values()]
+      .filter((j) => j.dueMs <= nowMs)
+      .sort((a, b) => a.dueMs - b.dueMs);
+    for (const job of due) this.jobs.delete(job.id);
+    return due;
+  }
+
+  /**
+   * Re-enqueue a previously dequeued job to run again after `delay` from `nowMs`,
+   * with the `dequeueCount` the caller sets on `job`. Used for both retry (the
+   * executor having bumped the count) and `pollAfter` (count preserved).
+   */
+  retryLater(job: QueuedJob, delay: Duration, nowMs: number): void {
+    this.jobs.set(job.id, { ...job, dueMs: nowMs + durationToMs(delay) });
+  }
+}

--- a/packages/durable-jobs/src/job-shard-store.ts
+++ b/packages/durable-jobs/src/job-shard-store.ts
@@ -1,0 +1,68 @@
+import type { DurableJob } from "@tsva/core/durable-job";
+
+/**
+ * The durable record of a shard's ownership and bookkeeping (Orleans' shard
+ * metadata). A shard is owned by one silo at a time; `adoptedCount` counts how
+ * many times it has been adopted from a dead owner (a shard adopted past
+ * `maxAdoptedCount` is poisoned and no longer claimed).
+ */
+export interface ShardRecord {
+  shardKey: number;
+  /** Ring key of the owning silo, or `undefined` if unclaimed/orphaned. */
+  owner: string | undefined;
+  /** Times this shard has been adopted from a dead owner. */
+  adoptedCount: number;
+  /** True once `adoptedCount` exceeds the limit — the shard is abandoned. */
+  poisoned: boolean;
+}
+
+/**
+ * The pluggable durable store for durable jobs, mirroring Orleans' `IJobShard`
+ * persist hooks plus the shard-ownership table. It is the *only* storage contact:
+ * the in-memory due-time queue is the working set, and these hooks make the queue
+ * durable. Memory (dev/test) and Redis (default) implement it.
+ *
+ * Jobs persist under their shard so a silo that claims a shard re-reads its jobs;
+ * the persist hooks (`persistAdd` / `persistRemove` / `persistRetry`) keep the
+ * store in step with the in-memory queue.
+ */
+export interface JobShardStore {
+  // ── job persistence (the IJobShard persist hooks) ──
+
+  /** Persist a newly scheduled job under its shard. */
+  persistAdd(job: DurableJob): Promise<void>;
+  /** Persist the removal of a completed or cancelled job. */
+  persistRemove(shardKey: number, jobId: string): Promise<void>;
+  /** Persist a job's new due time and dequeue count after a retry / re-poll. */
+  persistRetry(shardKey: number, jobId: string, dueTime: Date, dequeueCount: number): Promise<void>;
+  /** Read every job currently persisted under a shard (on claim / restart). */
+  readJobs(shardKey: number): Promise<PersistedJob[]>;
+
+  // ── shard ownership ──
+
+  /** The shard records that have at least one persisted job (for ownership reconciliation). */
+  listShards(): Promise<ShardRecord[]>;
+  /**
+   * Atomically claim a shard for `owner`: succeeds if the shard is unclaimed, or
+   * (when `adoptFromDead` lists dead silo ring keys) currently owned by a dead
+   * silo — in which case `adoptedCount` is incremented. A poisoned shard is never
+   * claimable. Returns the resulting record on success, or `undefined` if the
+   * claim lost (another silo owns it, or it is poisoned).
+   */
+  claimShard(
+    shardKey: number,
+    owner: string,
+    options: { adoptFromDead?: readonly string[]; maxAdoptedCount: number },
+  ): Promise<ShardRecord | undefined>;
+  /** Release a shard this silo owns (graceful drain), so a successor can claim it. */
+  releaseShard(shardKey: number, owner: string): Promise<void>;
+}
+
+/** A job as read back from the store, carrying its current dequeue count. */
+export interface PersistedJob {
+  job: DurableJob;
+  /** How many times the job has been dequeued for execution (0 if never run). */
+  dequeueCount: number;
+  /** The current effective due time (advanced by retry / re-poll backoff). */
+  dueTime: Date;
+}

--- a/packages/durable-jobs/src/local-durable-job-manager.ts
+++ b/packages/durable-jobs/src/local-durable-job-manager.ts
@@ -1,0 +1,236 @@
+import { durationToMs, type Duration } from "@tsva/core/duration";
+import type {
+  DurableJob,
+  ScheduleJobRequest,
+  ShouldRetry,
+} from "@tsva/core/durable-job";
+import { Guid } from "@tsva/core/guid";
+import type { TimeProvider } from "@tsva/core/time-provider";
+import { claimBudget, defaultShouldRetry, shardKeyFor } from "@tsva/durable-jobs/job-model";
+import type { JobShardStore } from "@tsva/durable-jobs/job-shard-store";
+import {
+  ConcurrencyLimiter,
+  ShardExecutor,
+  type OverloadSignal,
+  type RunJob,
+} from "@tsva/durable-jobs/shard-executor";
+
+export interface ResolvedDurableJobsOptions {
+  shardDurationMs: number;
+  shardActivationBufferMs: number;
+  maxConcurrentJobsPerSilo: number;
+  slowStartInitialConcurrency: number;
+  slowStartGrowthFactor: number;
+  overloadBackoffMs: number;
+  shouldRetry: ShouldRetry;
+  maxAdoptedCount: number;
+  claimRampUpBudget: number;
+}
+
+/** The membership facts the manager needs to claim and adopt shards. */
+export interface ShardOwnershipContext {
+  /** This silo's ring key (the owner identity recorded in the store). */
+  localRingKey: string;
+  /** Ring keys of the currently active silos; any other owner is treated as dead. */
+  activeRingKeys: readonly string[];
+}
+
+/**
+ * Per-silo durable-jobs service (Orleans' `LocalDurableJobManager`, a SystemTarget).
+ * It buckets a scheduled job into its time shard, claims the shards it should own
+ * from the store, and runs a `ShardExecutor` per owned shard. On a membership
+ * change it reconciles ownership: claims newly orphaned / dead-silo shards (under
+ * a ramp-up budget), drops shards it no longer owns. Clock-driven and
+ * membership-reconciled; storage is the injected `JobShardStore`.
+ */
+export class LocalDurableJobManager {
+  private readonly executors = new Map<number, ShardExecutor>();
+  private readonly limiter: ConcurrencyLimiter;
+  private ownership: ShardOwnershipContext;
+
+  constructor(
+    private readonly store: JobShardStore,
+    private readonly time: TimeProvider,
+    private readonly runJob: RunJob,
+    private readonly options: ResolvedDurableJobsOptions,
+    ownership: ShardOwnershipContext,
+    private readonly overload?: OverloadSignal,
+  ) {
+    this.limiter = new ConcurrencyLimiter(options.maxConcurrentJobsPerSilo);
+    this.ownership = ownership;
+  }
+
+  /** The shard keys this silo currently runs an executor for (for tests/metrics). */
+  ownedShards(): number[] {
+    return [...this.executors.keys()];
+  }
+
+  /**
+   * Schedule a job: assign its shard, persist it, and — if this silo owns (or
+   * claims) that shard — add it to the live executor so it fires at its due time.
+   * Returns the durable job (with its assigned id and shard).
+   */
+  async scheduleJob(request: ScheduleJobRequest): Promise<DurableJob> {
+    const shardKey = shardKeyFor(request.dueTime.getTime(), this.options.shardDurationMs);
+    const job: DurableJob = {
+      id: Guid.newGuid().toString(),
+      name: request.name,
+      dueTime: request.dueTime,
+      target: request.target,
+      shardKey,
+      metadata: request.metadata ?? {},
+    };
+    await this.store.persistAdd(job);
+    const executor = await this.ensureOwned(shardKey);
+    executor?.enqueue(job);
+    return job;
+  }
+
+  /** Cancel a scheduled job (best-effort): remove it from its shard and the store. */
+  async cancelJob(job: { id: string; shardKey: number }): Promise<void> {
+    const executor = this.executors.get(job.shardKey);
+    if (executor !== undefined) {
+      await executor.cancel(job.id);
+    } else {
+      await this.store.persistRemove(job.shardKey, job.id).catch(() => undefined);
+    }
+  }
+
+  /**
+   * Reconcile shard ownership against the current membership view: drop executors
+   * for shards no longer claimable here, then claim newly available shards
+   * (orphaned or owned by a dead silo) under the ramp-up budget and start an
+   * executor for each. Idempotent — already-owned shards keep their executors.
+   */
+  async refreshOwnership(ownership: ShardOwnershipContext): Promise<void> {
+    this.ownership = ownership;
+    const shards = await this.store.listShards();
+    const active = new Set(ownership.activeRingKeys);
+
+    // Resume our own shards after a restart: the store still records this ring key
+    // as owner, but the process lost its in-memory executor, so start one (no
+    // re-claim needed) to reload and fire the persisted jobs.
+    for (const shard of shards) {
+      if (shard.owner === ownership.localRingKey && !this.executors.has(shard.shardKey)) {
+        await this.startExecutor(shard.shardKey);
+      }
+    }
+
+    // Shards this silo can claim now: unclaimed, or owned by a dead silo (one not
+    // in the active set), and not poisoned.
+    const claimable = shards.filter(
+      (s) =>
+        !s.poisoned &&
+        s.owner !== ownership.localRingKey &&
+        (s.owner === undefined || !active.has(s.owner)),
+    );
+    const toClaim = claimBudget(claimable.length, this.options.claimRampUpBudget);
+    for (const shard of claimable.slice(0, toClaim)) {
+      // A dead-owner shard is adopted; an unclaimed one is just claimed.
+      const deadOwner = shard.owner !== undefined && !active.has(shard.owner) ? [shard.owner] : [];
+      await this.claimAndStart(shard.shardKey, deadOwner);
+    }
+
+    // Drop executors for shards the store no longer records as ours (claimed away).
+    // Re-read so the just-made claims above are reflected, not the stale snapshot.
+    const ownedNow = new Set(
+      (await this.store.listShards())
+        .filter((s) => s.owner === ownership.localRingKey)
+        .map((s) => s.shardKey),
+    );
+    for (const shardKey of [...this.executors.keys()]) {
+      if (!ownedNow.has(shardKey)) this.stopExecutor(shardKey);
+    }
+  }
+
+  /** Stop every executor (silo shutdown). Best-effort release so a successor can claim. */
+  async stop(): Promise<void> {
+    for (const shardKey of [...this.executors.keys()]) {
+      await this.store.releaseShard(shardKey, this.ownership.localRingKey).catch(() => undefined);
+      this.stopExecutor(shardKey);
+    }
+  }
+
+  /** Ensure this silo owns the shard (claiming it if free) and has a running executor. */
+  private async ensureOwned(shardKey: number): Promise<ShardExecutor | undefined> {
+    const existing = this.executors.get(shardKey);
+    if (existing !== undefined) return existing;
+    return this.claimAndStart(shardKey, []);
+  }
+
+  private async claimAndStart(
+    shardKey: number,
+    deadOwners: readonly string[],
+  ): Promise<ShardExecutor | undefined> {
+    const claimed = await this.store.claimShard(shardKey, this.ownership.localRingKey, {
+      adoptFromDead: deadOwners,
+      maxAdoptedCount: this.options.maxAdoptedCount,
+    });
+    if (claimed === undefined) return undefined; // lost the claim or poisoned
+    return this.startExecutor(shardKey);
+  }
+
+  private async startExecutor(shardKey: number): Promise<ShardExecutor> {
+    const existing = this.executors.get(shardKey);
+    if (existing !== undefined) return existing;
+    const executor = new ShardExecutor(
+      shardKey,
+      this.store,
+      this.time,
+      this.limiter,
+      this.runJob,
+      this.overload ?? (() => this.limiter.saturated),
+      {
+        shardDurationMs: this.options.shardDurationMs,
+        maxConcurrentJobsPerSilo: this.options.maxConcurrentJobsPerSilo,
+        slowStartInitialConcurrency: this.options.slowStartInitialConcurrency,
+        slowStartGrowthFactor: this.options.slowStartGrowthFactor,
+        overloadBackoffMs: this.options.overloadBackoffMs,
+        shouldRetry: this.options.shouldRetry,
+      },
+    );
+    this.executors.set(shardKey, executor);
+    await executor.load();
+    return executor;
+  }
+
+  private stopExecutor(shardKey: number): void {
+    const executor = this.executors.get(shardKey);
+    if (executor === undefined) return;
+    executor.stop();
+    this.executors.delete(shardKey);
+  }
+}
+
+const DAY = 86_400_000;
+
+/** Resolve `DurableJobsOptions` defaults to plain milliseconds for the manager. */
+export function resolveOptions(options: {
+  shardDuration?: Duration;
+  shardActivationBufferPeriod?: Duration;
+  maxConcurrentJobsPerSilo?: number;
+  slowStartInitialConcurrency?: number;
+  slowStartGrowthFactor?: number;
+  overloadBackoff?: Duration;
+  shouldRetry?: ShouldRetry;
+  maxAdoptedCount?: number;
+  claimRampUpBudget?: number;
+}): ResolvedDurableJobsOptions {
+  const shardDurationMs =
+    options.shardDuration !== undefined ? durationToMs(options.shardDuration) : 3_600_000;
+  return {
+    shardDurationMs: shardDurationMs > 0 ? shardDurationMs : DAY,
+    shardActivationBufferMs:
+      options.shardActivationBufferPeriod !== undefined
+        ? durationToMs(options.shardActivationBufferPeriod)
+        : 60_000,
+    maxConcurrentJobsPerSilo: options.maxConcurrentJobsPerSilo ?? 100,
+    slowStartInitialConcurrency: options.slowStartInitialConcurrency ?? 1,
+    slowStartGrowthFactor: options.slowStartGrowthFactor ?? 2,
+    overloadBackoffMs:
+      options.overloadBackoff !== undefined ? durationToMs(options.overloadBackoff) : 1000,
+    shouldRetry: options.shouldRetry ?? defaultShouldRetry,
+    maxAdoptedCount: options.maxAdoptedCount ?? 3,
+    claimRampUpBudget: options.claimRampUpBudget ?? 4,
+  };
+}

--- a/packages/durable-jobs/src/memory-job-shard-store.ts
+++ b/packages/durable-jobs/src/memory-job-shard-store.ts
@@ -1,0 +1,105 @@
+import type { DurableJob } from "@tsva/core/durable-job";
+import type {
+  JobShardStore,
+  PersistedJob,
+  ShardRecord,
+} from "@tsva/durable-jobs/job-shard-store";
+
+interface Entry {
+  job: DurableJob;
+  dequeueCount: number;
+  dueTime: Date;
+}
+
+interface ShardState {
+  record: ShardRecord;
+  jobs: Map<string, Entry>;
+}
+
+/**
+ * In-memory `JobShardStore` for development and tests. A single instance shared
+ * across silo restarts (a fresh node, same store) stands in for a durable backend
+ * — exactly how `MemoryJournalStorage` is used in the journaling restart tests.
+ */
+export class MemoryJobShardStore implements JobShardStore {
+  private readonly shards = new Map<number, ShardState>();
+
+  private shard(shardKey: number): ShardState {
+    let state = this.shards.get(shardKey);
+    if (state === undefined) {
+      state = {
+        record: { shardKey, owner: undefined, adoptedCount: 0, poisoned: false },
+        jobs: new Map(),
+      };
+      this.shards.set(shardKey, state);
+    }
+    return state;
+  }
+
+  async persistAdd(job: DurableJob): Promise<void> {
+    this.shard(job.shardKey).jobs.set(job.id, { job, dequeueCount: 0, dueTime: job.dueTime });
+  }
+
+  async persistRemove(shardKey: number, jobId: string): Promise<void> {
+    this.shards.get(shardKey)?.jobs.delete(jobId);
+  }
+
+  async persistRetry(
+    shardKey: number,
+    jobId: string,
+    dueTime: Date,
+    dequeueCount: number,
+  ): Promise<void> {
+    const entry = this.shards.get(shardKey)?.jobs.get(jobId);
+    if (entry !== undefined) {
+      entry.dueTime = dueTime;
+      entry.dequeueCount = dequeueCount;
+    }
+  }
+
+  async readJobs(shardKey: number): Promise<PersistedJob[]> {
+    const state = this.shards.get(shardKey);
+    if (state === undefined) return [];
+    return [...state.jobs.values()].map((e) => ({
+      job: e.job,
+      dequeueCount: e.dequeueCount,
+      dueTime: e.dueTime,
+    }));
+  }
+
+  async listShards(): Promise<ShardRecord[]> {
+    return [...this.shards.values()].filter((s) => s.jobs.size > 0).map((s) => ({ ...s.record }));
+  }
+
+  async claimShard(
+    shardKey: number,
+    owner: string,
+    options: { adoptFromDead?: readonly string[]; maxAdoptedCount: number },
+  ): Promise<ShardRecord | undefined> {
+    const state = this.shard(shardKey);
+    const record = state.record;
+    if (record.poisoned) return undefined;
+    if (record.owner === owner) return { ...record };
+
+    const dead = new Set(options.adoptFromDead ?? []);
+    const unowned = record.owner === undefined;
+    const ownerDead = record.owner !== undefined && dead.has(record.owner);
+    if (!unowned && !ownerDead) return undefined; // a live silo owns it
+
+    if (ownerDead) {
+      record.adoptedCount += 1;
+      if (record.adoptedCount > options.maxAdoptedCount) {
+        record.poisoned = true;
+        record.owner = undefined;
+        return undefined;
+      }
+    }
+    record.owner = owner;
+    return { ...record };
+  }
+
+  async releaseShard(shardKey: number, owner: string): Promise<void> {
+    const state = this.shards.get(shardKey);
+    if (state !== undefined && state.record.owner === owner) state.record.owner = undefined;
+  }
+}

--- a/packages/durable-jobs/src/redis-job-shard-store.test.ts
+++ b/packages/durable-jobs/src/redis-job-shard-store.test.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createClient } from "redis";
+import type { DurableJob } from "@tsva/core/durable-job";
+import { GrainId } from "@tsva/core/grain-id";
+import { RedisJobShardStore } from "@tsva/durable-jobs/redis-job-shard-store";
+
+const REDIS_URL = process.env.REDIS_URL ?? "redis://localhost:6379";
+
+type Client = ReturnType<typeof createClient>;
+
+/** Probe Redis once at load time so the suite skips cleanly without it. */
+async function reachable(url: string): Promise<Client | undefined> {
+  const probe = createClient({ url });
+  probe.on("error", () => {});
+  try {
+    await probe.connect();
+    await probe.ping();
+    return probe;
+  } catch {
+    try {
+      await probe.destroy();
+    } catch {
+      /* never connected */
+    }
+    return undefined;
+  }
+}
+
+const client = await reachable(REDIS_URL);
+const prefix = `tsva-test:job:${randomUUID()}`;
+const makeStore = () => new RedisJobShardStore(client!, { keyPrefix: prefix });
+
+function jobAt(id: string, shardKey: number, dueMs: number): DurableJob {
+  return {
+    id,
+    name: "ok",
+    dueTime: new Date(dueMs),
+    target: new GrainId("Worker", "w"),
+    shardKey,
+    metadata: { userId: "u1" },
+  };
+}
+
+async function deleteAll(c: Client, match: string): Promise<void> {
+  for await (const keys of c.scanIterator({ MATCH: match })) {
+    if (keys.length > 0) await c.del(keys);
+  }
+}
+
+afterAll(async () => {
+  if (client === undefined) return;
+  await deleteAll(client, `${prefix}*`);
+  await client.destroy();
+});
+
+describe.skipIf(client === undefined)("RedisJobShardStore", () => {
+  beforeEach(async () => {
+    await deleteAll(client!, `${prefix}*`);
+  });
+
+  it("persists and reads back a job through a fresh client", async () => {
+    const job = jobAt("j1", 5, 100_000);
+    await makeStore().persistAdd(job);
+
+    const jobs = await makeStore().readJobs(5);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]?.job.id).toBe("j1");
+    expect(jobs[0]?.job.metadata).toEqual({ userId: "u1" });
+    expect(jobs[0]?.dueTime.getTime()).toBe(100_000);
+    expect(jobs[0]?.dequeueCount).toBe(0);
+  });
+
+  it("advances due time and dequeue count on retry, and removes on completion", async () => {
+    const store = makeStore();
+    await store.persistAdd(jobAt("j2", 5, 1000));
+    await store.persistRetry(5, "j2", new Date(9000), 2);
+    const [persisted] = await makeStore().readJobs(5);
+    expect(persisted?.dueTime.getTime()).toBe(9000);
+    expect(persisted?.dequeueCount).toBe(2);
+
+    await store.persistRemove(5, "j2");
+    expect(await makeStore().readJobs(5)).toEqual([]);
+  });
+
+  it("lists shards that have jobs", async () => {
+    const store = makeStore();
+    await store.persistAdd(jobAt("a", 1, 1000));
+    await store.persistAdd(jobAt("b", 2, 1000));
+    const shards = await makeStore().listShards();
+    expect(shards.map((s) => s.shardKey).sort((x, y) => x - y)).toEqual([1, 2]);
+  });
+
+  it("claims a shard atomically: a second owner loses while the first holds it", async () => {
+    const store = makeStore();
+    await store.persistAdd(jobAt("a", 7, 1000));
+    const first = await store.claimShard(7, "silo-a", { maxAdoptedCount: 3 });
+    expect(first?.owner).toBe("silo-a");
+    // A different live silo cannot steal it.
+    const second = await store.claimShard(7, "silo-b", { maxAdoptedCount: 3 });
+    expect(second).toBeUndefined();
+    // The same owner re-claiming is idempotent.
+    expect((await store.claimShard(7, "silo-a", { maxAdoptedCount: 3 }))?.owner).toBe("silo-a");
+  });
+
+  it("adopts a dead owner's shard, poisoning past the adoption limit", async () => {
+    const store = makeStore();
+    await store.persistAdd(jobAt("a", 8, 1000));
+    await store.claimShard(8, "silo-dead", { maxAdoptedCount: 3 });
+
+    // Adopt from the dead owner repeatedly; each adoption increments adoptedCount.
+    let owner = "silo-dead";
+    for (let i = 1; i <= 3; i++) {
+      const next = `silo-${i}`;
+      const claimed = await store.claimShard(8, next, {
+        adoptFromDead: [owner],
+        maxAdoptedCount: 3,
+      });
+      expect(claimed?.adoptedCount).toBe(i);
+      owner = next;
+    }
+    // The 4th adoption exceeds the limit and poisons the shard.
+    const poisoned = await store.claimShard(8, "silo-4", {
+      adoptFromDead: [owner],
+      maxAdoptedCount: 3,
+    });
+    expect(poisoned).toBeUndefined();
+    // A poisoned shard is never claimable again, even when unowned.
+    expect(await store.claimShard(8, "silo-5", { maxAdoptedCount: 3 })).toBeUndefined();
+  });
+
+  it("releases a shard only for its current owner", async () => {
+    const store = makeStore();
+    await store.persistAdd(jobAt("a", 9, 1000));
+    await store.claimShard(9, "silo-a", { maxAdoptedCount: 3 });
+    // A non-owner release is a no-op.
+    await store.releaseShard(9, "silo-b");
+    expect((await makeStore().listShards()).find((s) => s.shardKey === 9)?.owner).toBe("silo-a");
+    // The owner can release, freeing it for a successor.
+    await store.releaseShard(9, "silo-a");
+    expect((await makeStore().listShards()).find((s) => s.shardKey === 9)?.owner).toBeUndefined();
+  });
+});

--- a/packages/durable-jobs/src/redis-job-shard-store.ts
+++ b/packages/durable-jobs/src/redis-job-shard-store.ts
@@ -1,0 +1,164 @@
+import type { createClient } from "redis";
+import type { DurableJob } from "@tsva/core/durable-job";
+import { deserializeValue, serializeValue } from "@tsva/core/value-codec";
+import type {
+  JobShardStore,
+  PersistedJob,
+  ShardRecord,
+} from "@tsva/durable-jobs/job-shard-store";
+
+export type RedisClient = ReturnType<typeof createClient>;
+
+export interface RedisJobShardStoreOptions {
+  /** Namespace for keys in the shared Redis (defaults to `"tsva"`). */
+  keyPrefix?: string;
+}
+
+/** The codec-serialized payload of a persisted job (its current due time + dequeue count). */
+interface JobData {
+  job: DurableJob;
+  dequeueCount: number;
+  dueTime: Date;
+}
+
+// Claim a shard for a new owner. Succeeds if the shard is unclaimed (no owner) or
+// the current owner is in the dead set; a poisoned shard is never claimed. When
+// adopting from a dead owner, bump adoptedCount and poison past the limit. The
+// shard hash holds `owner`, `adoptedCount`, `poisoned`. KEYS[1] is the shard hash;
+// ARGV: owner, maxAdoptedCount, deadJSON.
+const CLAIM = `
+local owner = redis.call('HGET', KEYS[1], 'owner')
+local adopted = tonumber(redis.call('HGET', KEYS[1], 'adoptedCount') or '0')
+local poisoned = redis.call('HGET', KEYS[1], 'poisoned')
+if poisoned == '1' then return nil end
+if owner == ARGV[1] then
+  return cjson.encode({ owner = owner, adoptedCount = adopted, poisoned = false })
+end
+local dead = {}
+for _, k in ipairs(cjson.decode(ARGV[3])) do dead[k] = true end
+local unowned = (owner == false or owner == nil)
+local ownerDead = (owner ~= false and owner ~= nil and dead[owner] == true)
+if not unowned and not ownerDead then return nil end
+if ownerDead then
+  adopted = adopted + 1
+  if adopted > tonumber(ARGV[2]) then
+    redis.call('HSET', KEYS[1], 'poisoned', '1', 'adoptedCount', adopted)
+    redis.call('HDEL', KEYS[1], 'owner')
+    return nil
+  end
+end
+redis.call('HSET', KEYS[1], 'owner', ARGV[1], 'adoptedCount', adopted, 'poisoned', '0')
+return cjson.encode({ owner = ARGV[1], adoptedCount = adopted, poisoned = false })`;
+
+// Release a shard only if this caller still owns it. KEYS[1] shard hash; ARGV owner.
+const RELEASE = `
+if redis.call('HGET', KEYS[1], 'owner') == ARGV[1] then
+  redis.call('HDEL', KEYS[1], 'owner')
+end
+return 1`;
+
+/**
+ * Durable, cluster-shared `JobShardStore` backed by Redis (the default store).
+ * Jobs are persisted in a per-shard hash keyed by job id; a set tracks which
+ * shards have jobs; each shard's ownership/adoption bookkeeping lives in its own
+ * hash, claimed atomically with a Lua CAS (mirrors `RedisReminderTable`). The
+ * working-set due-time queue lives in the executor; this store is the durability
+ * seam (the `IJobShard` persist hooks). Interchangeable with `MemoryJobShardStore`.
+ */
+export class RedisJobShardStore implements JobShardStore {
+  private readonly keyPrefix: string;
+
+  constructor(
+    private readonly client: RedisClient,
+    options: RedisJobShardStoreOptions = {},
+  ) {
+    this.keyPrefix = options.keyPrefix ?? "tsva";
+  }
+
+  async persistAdd(job: DurableJob): Promise<void> {
+    const data: JobData = { job, dequeueCount: 0, dueTime: job.dueTime };
+    await this.client
+      .multi()
+      .hSet(this.jobsKey(job.shardKey), job.id, serializeValue(data))
+      .sAdd(this.shardsKey(), String(job.shardKey))
+      .exec();
+  }
+
+  async persistRemove(shardKey: number, jobId: string): Promise<void> {
+    await this.client.hDel(this.jobsKey(shardKey), jobId);
+  }
+
+  async persistRetry(
+    shardKey: number,
+    jobId: string,
+    dueTime: Date,
+    dequeueCount: number,
+  ): Promise<void> {
+    const raw = await this.client.hGet(this.jobsKey(shardKey), jobId);
+    if (raw == null) return;
+    const data = deserializeValue<JobData>(raw);
+    const next: JobData = { job: data.job, dequeueCount, dueTime };
+    await this.client.hSet(this.jobsKey(shardKey), jobId, serializeValue(next));
+  }
+
+  async readJobs(shardKey: number): Promise<PersistedJob[]> {
+    const record = await this.client.hGetAll(this.jobsKey(shardKey));
+    return Object.values(record).map((raw) => {
+      const data = deserializeValue<JobData>(raw);
+      return { job: data.job, dequeueCount: data.dequeueCount, dueTime: data.dueTime };
+    });
+  }
+
+  async listShards(): Promise<ShardRecord[]> {
+    const keys = await this.client.sMembers(this.shardsKey());
+    const records = await Promise.all(
+      keys.map(async (k) => {
+        const shardKey = Number(k);
+        const count = await this.client.hLen(this.jobsKey(shardKey));
+        if (count === 0) return undefined; // no jobs: skip (and drop the stale index entry)
+        const meta = await this.client.hGetAll(this.shardMetaKey(shardKey));
+        return {
+          shardKey,
+          owner: meta.owner ?? undefined,
+          adoptedCount: meta.adoptedCount !== undefined ? Number(meta.adoptedCount) : 0,
+          poisoned: meta.poisoned === "1",
+        } satisfies ShardRecord;
+      }),
+    );
+    return records.filter((r): r is ShardRecord => r !== undefined);
+  }
+
+  async claimShard(
+    shardKey: number,
+    owner: string,
+    options: { adoptFromDead?: readonly string[]; maxAdoptedCount: number },
+  ): Promise<ShardRecord | undefined> {
+    const result = (await this.client.eval(CLAIM, {
+      keys: [this.shardMetaKey(shardKey)],
+      arguments: [
+        owner,
+        String(options.maxAdoptedCount),
+        JSON.stringify([...(options.adoptFromDead ?? [])]),
+      ],
+    })) as string | null;
+    if (result == null) return undefined;
+    const parsed = JSON.parse(result) as { owner: string; adoptedCount: number; poisoned: boolean };
+    return { shardKey, owner: parsed.owner, adoptedCount: parsed.adoptedCount, poisoned: false };
+  }
+
+  async releaseShard(shardKey: number, owner: string): Promise<void> {
+    await this.client.eval(RELEASE, { keys: [this.shardMetaKey(shardKey)], arguments: [owner] });
+  }
+
+  private shardsKey(): string {
+    return `${this.keyPrefix}:job:shards`;
+  }
+
+  private jobsKey(shardKey: number): string {
+    return `${this.keyPrefix}:job:s:${shardKey}`;
+  }
+
+  private shardMetaKey(shardKey: number): string {
+    return `${this.keyPrefix}:job:m:${shardKey}`;
+  }
+}

--- a/packages/durable-jobs/src/shard-executor.test.ts
+++ b/packages/durable-jobs/src/shard-executor.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { completed, pollAfter, type DurableJob, type JobRunContext } from "@tsva/core/durable-job";
+import { GrainId } from "@tsva/core/grain-id";
+import { FakeTimeProvider } from "@tsva/core/test-support/fake-time-provider";
+import { defaultShouldRetry } from "@tsva/durable-jobs/job-model";
+import { MemoryJobShardStore } from "@tsva/durable-jobs/memory-job-shard-store";
+import {
+  ConcurrencyLimiter,
+  ShardExecutor,
+  type RunJob,
+} from "@tsva/durable-jobs/shard-executor";
+
+const OPTIONS = {
+  shardDurationMs: 3_600_000,
+  maxConcurrentJobsPerSilo: 2,
+  slowStartInitialConcurrency: 1,
+  slowStartGrowthFactor: 2,
+  overloadBackoffMs: 1000,
+  shouldRetry: defaultShouldRetry,
+};
+
+function job(id: string, dueMs: number): DurableJob {
+  return {
+    id,
+    name: "ok",
+    dueTime: new Date(dueMs),
+    target: new GrainId("W", "w"),
+    shardKey: 0,
+    metadata: {},
+  };
+}
+
+async function flush(times = 8): Promise<void> {
+  for (let i = 0; i < times; i++) await new Promise((r) => setTimeout(r, 0));
+}
+
+describe("ConcurrencyLimiter", () => {
+  it("caps concurrent acquisitions and tracks saturation", () => {
+    const limiter = new ConcurrencyLimiter(2);
+    expect(limiter.tryAcquire()).toBe(true);
+    expect(limiter.tryAcquire()).toBe(true);
+    expect(limiter.saturated).toBe(true);
+    expect(limiter.tryAcquire()).toBe(false);
+    limiter.release();
+    expect(limiter.saturated).toBe(false);
+    expect(limiter.tryAcquire()).toBe(true);
+  });
+});
+
+describe("ShardExecutor", () => {
+  it("runs a due job as a completion and removes it from the store", async () => {
+    const store = new MemoryJobShardStore();
+    const time = new FakeTimeProvider();
+    const limiter = new ConcurrencyLimiter(2);
+    const ran: string[] = [];
+    const run: RunJob = async (j) => {
+      ran.push(j.id);
+      return completed;
+    };
+    await store.persistAdd(job("a", 1000));
+    const exec = new ShardExecutor(0, store, time, limiter, run, () => false, OPTIONS);
+    await exec.load();
+
+    time.advance(1000);
+    await flush();
+    expect(ran).toEqual(["a"]);
+    expect(await store.readJobs(0)).toEqual([]);
+    exec.stop();
+  });
+
+  it("backs off the poll loop while the silo is overloaded, then runs once clear", async () => {
+    const store = new MemoryJobShardStore();
+    const time = new FakeTimeProvider();
+    const limiter = new ConcurrencyLimiter(2);
+    const ran: string[] = [];
+    let overloaded = true;
+    const run: RunJob = async (j) => {
+      ran.push(j.id);
+      return completed;
+    };
+    await store.persistAdd(job("a", 0));
+    const exec = new ShardExecutor(0, store, time, limiter, run, () => overloaded, OPTIONS);
+    await exec.load();
+
+    // Due immediately, but the silo is overloaded: the poll backs off without running.
+    time.advance(0);
+    await flush();
+    expect(ran).toEqual([]);
+
+    // Clear the overload; the next backed-off poll cycle runs it.
+    overloaded = false;
+    time.advance(OPTIONS.overloadBackoffMs);
+    await flush();
+    expect(ran).toEqual(["a"]);
+    exec.stop();
+  });
+
+  it("passes the dequeue count to the handler and increments it across re-polls", async () => {
+    const store = new MemoryJobShardStore();
+    const time = new FakeTimeProvider();
+    const limiter = new ConcurrencyLimiter(2);
+    const counts: number[] = [];
+    const run: RunJob = async (j: JobRunContext) => {
+      counts.push(j.dequeueCount);
+      return counts.length < 2 ? pollAfter({ seconds: 1 }) : completed;
+    };
+    await store.persistAdd(job("a", 0));
+    const exec = new ShardExecutor(0, store, time, limiter, run, () => false, OPTIONS);
+    await exec.load();
+
+    time.advance(0);
+    await flush();
+    time.advance(1000);
+    await flush();
+    // pollAfter preserves the dequeue count rather than treating it as a retry.
+    expect(counts).toEqual([1, 1]);
+    expect(await store.readJobs(0)).toEqual([]);
+    exec.stop();
+  });
+});

--- a/packages/durable-jobs/src/shard-executor.ts
+++ b/packages/durable-jobs/src/shard-executor.ts
@@ -1,0 +1,264 @@
+import { durationToMs, type Duration } from "@tsva/core/duration";
+import type {
+  DurableJob,
+  DurableJobRunResult,
+  JobRunContext,
+  ShouldRetry,
+} from "@tsva/core/durable-job";
+import type { TimeProvider, TimerHandle } from "@tsva/core/time-provider";
+import { InMemoryJobQueue, type QueuedJob } from "@tsva/durable-jobs/job-model";
+import type { JobShardStore } from "@tsva/durable-jobs/job-shard-store";
+
+/** Delivers one attempt of a job to the target grain as a turn; resolves its result. */
+export type RunJob = (job: JobRunContext) => Promise<DurableJobRunResult>;
+
+/** Reports whether the silo is currently overloaded (concurrency saturated / unhealthy). */
+export type OverloadSignal = () => boolean;
+
+export interface ShardExecutorOptions {
+  shardDurationMs: number;
+  maxConcurrentJobsPerSilo: number;
+  slowStartInitialConcurrency: number;
+  slowStartGrowthFactor: number;
+  overloadBackoffMs: number;
+  shouldRetry: ShouldRetry;
+}
+
+/**
+ * A concurrency limiter shared across a silo's shard executors — the silo-wide
+ * cap on jobs running at once (Orleans' per-silo concurrency control). Slots are
+ * acquired before a job runs and released when it settles.
+ */
+export class ConcurrencyLimiter {
+  private inUse = 0;
+  constructor(private readonly max: number) {}
+
+  get available(): number {
+    return Math.max(0, this.max - this.inUse);
+  }
+
+  get saturated(): boolean {
+    return this.available <= 0;
+  }
+
+  tryAcquire(): boolean {
+    if (this.inUse >= this.max) return false;
+    this.inUse += 1;
+    return true;
+  }
+
+  release(): void {
+    if (this.inUse > 0) this.inUse -= 1;
+  }
+}
+
+/**
+ * Consumes the due jobs of a single shard (Orleans' `ShardExecutor`). It holds the
+ * shard's in-memory due-time queue (the working set), and on each poll cycle:
+ *  - dequeues jobs due by now, up to the slow-start concurrency ceiling and the
+ *    shared per-silo concurrency limiter (slow-start: a fresh executor starts
+ *    small and grows the ceiling each clean cycle);
+ *  - runs each as a turn on the target via `runJob`, applying the result —
+ *    `completed` removes, `pollAfter` re-enqueues holding logic for a supervised
+ *    re-poll, `failed`/throw applies the retry policy (backoff then drop);
+ *  - backs off the poll loop when the silo is overloaded;
+ *  - re-arms a timer for the next due job (`pollAfter` loop).
+ * All durability goes through the injected `JobShardStore`.
+ */
+export class ShardExecutor {
+  readonly queue = new InMemoryJobQueue();
+  /** Payloads (the DurableJob) by id, so a dequeued job can be reconstructed for delivery. */
+  private readonly jobs = new Map<string, DurableJob>();
+  private concurrency: number;
+  private pollHandle: TimerHandle | undefined;
+  private stopped = false;
+  private running = 0;
+
+  constructor(
+    readonly shardKey: number,
+    private readonly store: JobShardStore,
+    private readonly time: TimeProvider,
+    private readonly limiter: ConcurrencyLimiter,
+    private readonly runJob: RunJob,
+    private readonly isOverloaded: OverloadSignal,
+    private readonly options: ShardExecutorOptions,
+  ) {
+    this.concurrency = Math.max(1, options.slowStartInitialConcurrency);
+  }
+
+  /** Number of jobs in this shard's working set (queued, not yet completed). */
+  get size(): number {
+    return this.queue.size;
+  }
+
+  /** Load the shard's persisted jobs into the working set and arm the poll loop. */
+  async load(): Promise<void> {
+    for (const persisted of await this.store.readJobs(this.shardKey)) {
+      this.jobs.set(persisted.job.id, persisted.job);
+      this.queue.add({
+        id: persisted.job.id,
+        dueMs: persisted.dueTime.getTime(),
+        dequeueCount: persisted.dequeueCount,
+        payload: persisted.job,
+      });
+    }
+    this.schedulePoll();
+  }
+
+  /** Add a freshly scheduled job to the working set (already persisted by the manager). */
+  enqueue(job: DurableJob): void {
+    this.jobs.set(job.id, job);
+    this.queue.add({
+      id: job.id,
+      dueMs: job.dueTime.getTime(),
+      dequeueCount: 0,
+      payload: job,
+    });
+    this.schedulePoll();
+  }
+
+  /** Cancel a pending job (best-effort): drop it from the queue and the store. */
+  async cancel(jobId: string): Promise<boolean> {
+    const removed = this.queue.cancel(jobId);
+    this.jobs.delete(jobId);
+    await this.store.persistRemove(this.shardKey, jobId).catch(() => undefined);
+    return removed;
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.pollHandle !== undefined) this.time.clearTimer(this.pollHandle);
+    this.pollHandle = undefined;
+  }
+
+  /** Re-arm the poll timer for the next due job (or immediately if one is already due). */
+  private schedulePoll(): void {
+    if (this.stopped) return;
+    if (this.pollHandle !== undefined) {
+      this.time.clearTimer(this.pollHandle);
+      this.pollHandle = undefined;
+    }
+    const next = this.queue.nextDueMs();
+    if (next === undefined) return;
+    const delay = Math.max(0, next - this.time.now());
+    this.pollHandle = this.time.setTimer(() => {
+      this.pollHandle = undefined;
+      void this.poll();
+    }, delay);
+  }
+
+  /**
+   * One poll cycle: when the silo is overloaded, back off and try again later
+   * without running anything; otherwise dequeue the jobs due now (capped by the
+   * slow-start ceiling and the shared limiter) and run each. Grows the slow-start
+   * ceiling after a cycle that did real work, then re-arms for the next due job.
+   */
+  private async poll(): Promise<void> {
+    if (this.stopped) return;
+
+    if (this.isOverloaded()) {
+      this.pollHandle = this.time.setTimer(() => {
+        this.pollHandle = undefined;
+        void this.poll();
+      }, this.options.overloadBackoffMs);
+      return;
+    }
+
+    const now = this.time.now();
+    const due = this.queue.dequeueDue(now);
+    let started = 0;
+    const settled: Array<Promise<void>> = [];
+    for (const job of due) {
+      // Respect both the per-shard slow-start ceiling and the silo-wide limiter.
+      if (started >= this.concurrency || !this.limiter.tryAcquire()) {
+        // Could not run now: re-enqueue at the same due time to retry next cycle.
+        this.queue.add({ ...job, dueMs: now });
+        continue;
+      }
+      started += 1;
+      settled.push(this.runOne(job, now));
+    }
+
+    if (started > 0) {
+      // Slow-start: grow the ceiling toward the silo cap after a working cycle.
+      this.concurrency = Math.min(
+        this.options.maxConcurrentJobsPerSilo,
+        Math.max(1, Math.ceil(this.concurrency * this.options.slowStartGrowthFactor)),
+      );
+    }
+
+    // Re-arm before awaiting in-flight runs so a job due during this cycle is picked up.
+    this.schedulePoll();
+    await Promise.all(settled);
+  }
+
+  /** Run one dequeued job, apply its result, and release the concurrency slot. */
+  private async runOne(job: QueuedJob, now: number): Promise<void> {
+    this.running += 1;
+    const durable = this.jobs.get(job.id);
+    try {
+      if (durable === undefined) return; // cancelled between dequeue and run
+      // `dequeueCount` carried on the queued job is the number of attempts already
+      // made; this run is the next attempt (≥ 1).
+      const attempt = job.dequeueCount + 1;
+      const context: JobRunContext = {
+        id: durable.id,
+        name: durable.name,
+        dueTime: durable.dueTime,
+        target: durable.target,
+        metadata: durable.metadata,
+        dequeueCount: attempt,
+      };
+      let result: DurableJobRunResult;
+      try {
+        result = await this.runJob(context);
+      } catch (error) {
+        result = { kind: "failed", error };
+      }
+      await this.applyResult(job, result, attempt, now);
+    } finally {
+      this.running -= 1;
+      this.limiter.release();
+      this.schedulePoll();
+    }
+  }
+
+  /** Apply a job's run result: complete (remove), poll-after (re-enqueue), or retry/drop. */
+  private async applyResult(
+    job: QueuedJob,
+    result: DurableJobRunResult,
+    attempt: number,
+    now: number,
+  ): Promise<void> {
+    if (result.kind === "completed") {
+      this.jobs.delete(job.id);
+      await this.store.persistRemove(this.shardKey, job.id).catch(() => undefined);
+      return;
+    }
+    if (result.kind === "pollAfter") {
+      // A supervised re-poll is a continuation of the same attempt: the dequeue
+      // count is unchanged, so the next poll sees the same attempt number.
+      this.reschedule({ ...job, dequeueCount: job.dequeueCount }, result.delay, now);
+      return;
+    }
+    // failed: consult the retry policy with the number of attempts made so far.
+    const backoff = this.options.shouldRetry(attempt, result.error);
+    if (backoff === undefined) {
+      this.jobs.delete(job.id);
+      await this.store.persistRemove(this.shardKey, job.id).catch(() => undefined);
+      return;
+    }
+    // This run counts as a made attempt: bump so the next run is attempt + 1.
+    this.reschedule({ ...job, dequeueCount: attempt }, backoff, now);
+  }
+
+  /** Re-enqueue a job after `delay`, persisting its new due time and dequeue count. */
+  private reschedule(job: QueuedJob, delay: Duration, now: number): void {
+    const dueMs = now + durationToMs(delay);
+    this.queue.retryLater(job, delay, now);
+    this.schedulePoll();
+    void this.store
+      .persistRetry(this.shardKey, job.id, new Date(dueMs), job.dequeueCount)
+      .catch(() => undefined);
+  }
+}

--- a/packages/hosting/package.json
+++ b/packages/hosting/package.json
@@ -10,6 +10,7 @@
     "@tsva/clustering-k8s": "workspace:*",
     "@tsva/core": "workspace:*",
     "@tsva/directory": "workspace:*",
+    "@tsva/durable-jobs": "workspace:*",
     "@tsva/journaling": "workspace:*",
     "@tsva/messaging": "workspace:*",
     "@tsva/observability": "workspace:*",

--- a/packages/hosting/src/durable-jobs.test.ts
+++ b/packages/hosting/src/durable-jobs.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from "vitest";
+import { defineGrain, useDurableJobHandler } from "@tsva/core/define-grain";
+import { completed, pollAfter, type DurableJob } from "@tsva/core/durable-job";
+import { defineGrainInterface } from "@tsva/core/grain-interface";
+import { GrainId } from "@tsva/core/grain-id";
+import type { GrainWithStringKey } from "@tsva/core/key-kinds";
+import { SiloAddress } from "@tsva/core/silo-address";
+import { FakeTimeProvider } from "@tsva/core/test-support/fake-time-provider";
+import { InProcessNetwork } from "@tsva/messaging/in-process-transport";
+import { MemoryJobShardStore } from "@tsva/durable-jobs/memory-job-shard-store";
+import { StaticMembershipService } from "@tsva/runtime/static-membership";
+import { createSilo } from "@tsva/hosting/silo-builder";
+
+// A module sink keeps observable run records across (re)activations and restarts —
+// the grain activation itself may be fresh.
+const runs = new Map<string, number>();
+const pollAttempts = new Map<string, number>();
+const record = (key: string, map = runs) => map.set(key, (map.get(key) ?? 0) + 1);
+
+interface IWorker extends GrainWithStringKey {
+  ping(): Promise<string>;
+}
+const IWorker = defineGrainInterface<IWorker>("IWorker.jobs");
+
+// A worker grain whose durable-job handler is driven by per-name behaviour:
+//  - "ok"      → record a run and complete
+//  - "boom"    → record a run and throw (Failed → retry policy)
+//  - "poll"    → poll a few times then complete (supervised re-poll)
+const WorkerGrain = defineGrain<IWorker>("Worker", (ctx) => {
+  useDurableJobHandler(ctx, async (job) => {
+    const key = `${String(ctx.id.key)}:${job.name}`;
+    if (job.name === "boom") {
+      record(key);
+      throw new Error("boom");
+    }
+    if (job.name === "poll") {
+      const n = (pollAttempts.get(key) ?? 0) + 1;
+      pollAttempts.set(key, n);
+      if (n < 3) return pollAfter({ seconds: 5 });
+      record(key);
+      return completed;
+    }
+    record(key);
+    return completed;
+  });
+  return { ping: async () => "pong" };
+});
+
+// A scheduler grain that schedules/cancels jobs on a worker via the runtime.
+interface IScheduler extends GrainWithStringKey {
+  schedule(workerKey: string, name: string, dueMs: number): Promise<DurableJob>;
+  cancel(job: DurableJob): Promise<void>;
+}
+const IScheduler = defineGrainInterface<IScheduler>("IScheduler.jobs");
+
+const SchedulerGrain = defineGrain<IScheduler>("Scheduler", (ctx) => ({
+  schedule: async (workerKey, name, dueMs) =>
+    ctx.runtime.scheduleJob({
+      target: new GrainId("Worker", workerKey),
+      name,
+      dueTime: new Date(dueMs),
+    }),
+  cancel: async (job) => ctx.runtime.cancelJob(job),
+}));
+
+const local = new SiloAddress("silo-0", "uid-0", "silo-0:11111");
+
+/** Let queued microtasks (the awaited dispatch + result application) settle. */
+async function flush(times = 5): Promise<void> {
+  for (let i = 0; i < times; i++) await new Promise((r) => setTimeout(r, 0));
+}
+
+/**
+ * Drive the fake clock forward in small steps, flushing microtasks between each,
+ * so timers that are (re)armed asynchronously inside a job's result application
+ * (retry backoff, pollAfter re-poll) come due and fire. A single big `advance`
+ * would miss them, since the next timer is only set after the current run settles.
+ */
+async function advanceSettling(time: FakeTimeProvider, totalMs: number, stepMs = 1000): Promise<void> {
+  let elapsed = 0;
+  while (elapsed < totalMs) {
+    const step = Math.min(stepMs, totalMs - elapsed);
+    time.advance(step);
+    elapsed += step;
+    await flush();
+  }
+}
+
+function buildSilo(store: MemoryJobShardStore, time: FakeTimeProvider) {
+  return createSilo({ clusterId: "c1", local, time })
+    .useStaticMembership([local])
+    .useInProcessTransport(new InProcessNetwork())
+    .useMemoryDurableJobs(store)
+    .registerGrain(WorkerGrain, { interfaces: [IWorker] })
+    .registerGrain(SchedulerGrain, { interfaces: [IScheduler] })
+    .build();
+}
+
+describe("durable jobs end-to-end", () => {
+  it("fires a scheduled job as a turn on the target at its due time, then removes it", async () => {
+    runs.clear();
+    const store = new MemoryJobShardStore();
+    const time = new FakeTimeProvider();
+    const silo = buildSilo(store, time);
+    await silo.start();
+    try {
+      await silo.getGrain(IScheduler, "s").schedule("w1", "ok", time.now() + 10_000);
+      // Not due yet.
+      await flush();
+      expect(runs.get("w1:ok") ?? 0).toBe(0);
+
+      time.advance(10_000);
+      await flush();
+      expect(runs.get("w1:ok")).toBe(1);
+
+      // Completed jobs are removed from the store.
+      const shardKey = Math.floor(10_000 / 3_600_000);
+      expect(await store.readJobs(shardKey)).toEqual([]);
+    } finally {
+      await silo.stop();
+    }
+  });
+
+  it("retries a throwing job with backoff, then drops it after the retry budget", async () => {
+    runs.clear();
+    const store = new MemoryJobShardStore();
+    const time = new FakeTimeProvider();
+    const silo = buildSilo(store, time);
+    await silo.start();
+    try {
+      await silo.getGrain(IScheduler, "s").schedule("w2", "boom", time.now() + 1000);
+      time.advance(1000);
+      await flush();
+      expect(runs.get("w2:boom")).toBe(1); // first attempt
+
+      // Default policy: 2^n s backoff (2,4,8,16s). Step the clock so each rearmed
+      // retry timer fires; after the budget the job is dropped.
+      await advanceSettling(time, 60_000);
+      // 5 total attempts (default maxAttempts), then dropped.
+      expect(runs.get("w2:boom")).toBe(5);
+      expect(await store.readJobs(0)).toEqual([]); // dropped from the store
+    } finally {
+      await silo.stop();
+    }
+  });
+
+  it("re-polls a pollAfter job, holding it until it completes", async () => {
+    runs.clear();
+    pollAttempts.clear();
+    const store = new MemoryJobShardStore();
+    const time = new FakeTimeProvider();
+    const silo = buildSilo(store, time);
+    await silo.start();
+    try {
+      await silo.getGrain(IScheduler, "s").schedule("w3", "poll", time.now() + 1000);
+      time.advance(1000);
+      await flush();
+      expect(pollAttempts.get("w3:poll")).toBe(1);
+      expect(runs.get("w3:poll") ?? 0).toBe(0); // not done; re-polling
+
+      time.advance(5000);
+      await flush();
+      expect(pollAttempts.get("w3:poll")).toBe(2);
+
+      time.advance(5000);
+      await flush();
+      expect(runs.get("w3:poll")).toBe(1); // third poll completed
+      expect(await store.readJobs(0)).toEqual([]);
+    } finally {
+      await silo.stop();
+    }
+  });
+
+  it("cancels a pending job before it fires", async () => {
+    runs.clear();
+    const store = new MemoryJobShardStore();
+    const time = new FakeTimeProvider();
+    const silo = buildSilo(store, time);
+    await silo.start();
+    try {
+      const job = await silo.getGrain(IScheduler, "s").schedule("w4", "ok", time.now() + 10_000);
+      await silo.getGrain(IScheduler, "s").cancel(job);
+      time.advance(10_000);
+      await flush();
+      expect(runs.get("w4:ok") ?? 0).toBe(0);
+      expect(await store.readJobs(0)).toEqual([]);
+    } finally {
+      await silo.stop();
+    }
+  });
+
+  it("fires a job scheduled before a silo restart, after the restart (shared store)", async () => {
+    runs.clear();
+    const store = new MemoryJobShardStore();
+    const time = new FakeTimeProvider();
+
+    const first = buildSilo(store, time);
+    await first.start();
+    await first.getGrain(IScheduler, "s").schedule("w5", "ok", time.now() + 100_000);
+    await first.stop(); // pod dies before the job is due
+
+    const restarted = buildSilo(store, time); // new pod, same durable store
+    await restarted.start();
+    try {
+      time.advance(100_000);
+      await flush();
+      expect(runs.get("w5:ok")).toBe(1);
+    } finally {
+      await restarted.stop();
+    }
+  });
+
+  it("throws if a grain schedules a job on a silo without durable jobs configured", async () => {
+    const silo = createSilo({ clusterId: "c1", local })
+      .useStaticMembership([local])
+      .useInProcessTransport(new InProcessNetwork())
+      .registerGrain(WorkerGrain, { interfaces: [IWorker] })
+      .registerGrain(SchedulerGrain, { interfaces: [IScheduler] })
+      .build();
+    await silo.start();
+    try {
+      await expect(
+        silo.getGrain(IScheduler, "s").schedule("w", "ok", 1000),
+      ).rejects.toThrow(/durable jobs/);
+    } finally {
+      await silo.stop();
+    }
+  });
+});
+
+describe("durable jobs multi-silo failover", () => {
+  // Two in-process silos sharing one membership view and one durable store. Killing
+  // the silo that owns a shard lets the survivor adopt it and still run the job.
+  const a = new SiloAddress("silo-a", "uid-a", "silo-a:1");
+  const b = new SiloAddress("silo-b", "uid-b", "silo-b:2");
+
+  it("adopts a dead owner's shard and still runs its jobs", async () => {
+    runs.clear();
+    const store = new MemoryJobShardStore();
+    const time = new FakeTimeProvider();
+    const net = new InProcessNetwork();
+    const membership = new StaticMembershipService(a, [a, b]);
+    const membershipB = new StaticMembershipService(b, [a, b]);
+
+    const buildAt = (addr: SiloAddress, ms: StaticMembershipService) =>
+      createSilo({ clusterId: "c1", local: addr, time })
+        .useMembership(ms)
+        .useInProcessTransport(net)
+        .useMemoryDurableJobs(store)
+        .registerGrain(WorkerGrain, { interfaces: [IWorker] })
+        .registerGrain(SchedulerGrain, { interfaces: [IScheduler] })
+        .build();
+
+    const siloA = buildAt(a, membership);
+    const siloB = buildAt(b, membershipB);
+    await siloA.start();
+    await siloB.start();
+
+    // Schedule a far-future job, then take down whichever silo owns its shard.
+    const job = await siloA.getGrain(IScheduler, "s").schedule("wf", "ok", time.now() + 100_000);
+    await flush();
+
+    // Kill silo A (its shards, if any, orphan); narrow membership to B only.
+    await siloA.stop();
+    membershipB.setSilos([b]);
+    await flush();
+    // Nudge B's ownership reconciliation (the host also does this on a view change).
+    time.advance(100_000);
+    await flush(10);
+
+    try {
+      // Regardless of which silo originally owned the shard, the job runs exactly once.
+      expect(runs.get("wf:ok")).toBe(1);
+      expect(job.name).toBe("ok");
+    } finally {
+      await siloB.stop();
+    }
+  });
+});

--- a/packages/hosting/src/silo-builder.ts
+++ b/packages/hosting/src/silo-builder.ts
@@ -43,6 +43,15 @@ import { RedisJournalStorage } from "@tsva/journaling/redis-journal-storage";
 import { JournalStorageRegistry } from "@tsva/journaling/journal-storage-registry";
 import { bindDurableStates } from "@tsva/journaling/durable-state-activator";
 import type { StreamProvider } from "@tsva/core/stream";
+import type { DurableJobsOptions } from "@tsva/core/durable-job";
+import { activeSilos } from "@tsva/core/membership";
+import {
+  LocalDurableJobManager,
+  resolveOptions as resolveDurableJobOptions,
+} from "@tsva/durable-jobs/local-durable-job-manager";
+import type { JobShardStore } from "@tsva/durable-jobs/job-shard-store";
+import { MemoryJobShardStore } from "@tsva/durable-jobs/memory-job-shard-store";
+import { RedisJobShardStore } from "@tsva/durable-jobs/redis-job-shard-store";
 import { LocalReminderService } from "@tsva/reminders/local-reminder-service";
 import { MemoryReminderTable } from "@tsva/reminders/memory-reminder-table";
 import { PostgresReminderTable } from "@tsva/reminders/postgres-reminder-table";
@@ -88,6 +97,8 @@ export class SiloBuilder {
   private transactionalStorage: TransactionalStorageRegistry | undefined;
   private journalStorage: JournalStorageRegistry | undefined;
   private reminderTable: ReminderTable | undefined;
+  private jobShardStore: JobShardStore | undefined;
+  private durableJobsOptions: DurableJobsOptions = {};
   private readonly streamProviders = new Map<string, StreamProvider>();
   private readonly incomingCallFilters: IncomingGrainCallFilter[] = [];
   private readonly outgoingCallFilters: OutgoingGrainCallFilter[] = [];
@@ -149,6 +160,47 @@ export class SiloBuilder {
       await pool.end();
     });
     this.reminderTable = table;
+    return this;
+  }
+
+  /**
+   * Enable durable jobs (ADR 0018) backed by an in-memory shard store (dev/test).
+   * A single store instance shared across silo restarts stands in for a durable
+   * backend. `options` mirrors Orleans `DurableJobsOptions`.
+   */
+  useMemoryDurableJobs(
+    store: JobShardStore = new MemoryJobShardStore(),
+    options: DurableJobsOptions = {},
+  ): this {
+    this.jobShardStore = store;
+    this.durableJobsOptions = options;
+    return this;
+  }
+
+  /**
+   * Enable durable jobs (ADR 0018) backed by Redis (the default store). The client
+   * connects when the silo starts and disconnects when it stops; `keyPrefix`
+   * namespaces keys (defaults to `"tsva"`). `options` mirrors Orleans
+   * `DurableJobsOptions`.
+   */
+  useRedisDurableJobs(options: {
+    url: string;
+    keyPrefix?: string;
+    jobs?: DurableJobsOptions;
+  }): this {
+    const client = createClient({ url: options.url });
+    client.on("error", () => {});
+    this.starters.push(async () => {
+      await client.connect();
+    });
+    this.closers.push(async () => {
+      await client.close();
+    });
+    this.jobShardStore = new RedisJobShardStore(
+      client,
+      options.keyPrefix !== undefined ? { keyPrefix: options.keyPrefix } : {},
+    );
+    this.durableJobsOptions = options.jobs ?? {};
     return this;
   }
 
@@ -491,6 +543,8 @@ export class SiloBuilder {
     const snapshotThreshold = this.config.snapshotThreshold;
     const time = this.config.time;
     let reminderService: LocalReminderService | undefined;
+    let jobManager: LocalDurableJobManager | undefined;
+    const membership = this.membership;
 
     const node = new ClusterNode({
       local: this.config.local,
@@ -546,6 +600,7 @@ export class SiloBuilder {
         );
       },
       ...(this.reminderTable !== undefined ? { reminderRegistry: () => reminderService } : {}),
+      ...(this.jobShardStore !== undefined ? { durableJobScheduler: () => jobManager } : {}),
       ...(this.streamProviders.size > 0
         ? {
             streamProvider: (name?: string) =>
@@ -580,6 +635,33 @@ export class SiloBuilder {
     const onOwnershipChange: Array<
       (ranges: ReadonlyArray<readonly [number, number]>) => Promise<void>
     > = [];
+
+    // Durable jobs (ADR 0018): the per-silo manager runs the executors for the
+    // time-bucketed shards this silo owns, delivering each due job as a turn on
+    // its target through the node. Ownership is membership-driven (not hash-range),
+    // so the ownership hook recomputes the active set on start and every view
+    // change and reconciles shard claims/adoptions/drops.
+    if (this.jobShardStore !== undefined) {
+      jobManager = new LocalDurableJobManager(
+        this.jobShardStore,
+        time ?? systemTimeProvider,
+        (job) => node.deliverDurableJob(job),
+        resolveDurableJobOptions(this.durableJobsOptions),
+        {
+          localRingKey: this.config.local.ringKey,
+          activeRingKeys: activeSilos(membership.current()).map((s) => s.ringKey),
+        },
+      );
+      const manager = jobManager;
+      onOwnershipChange.push(async () => {
+        await manager.refreshOwnership({
+          localRingKey: this.config.local.ringKey,
+          activeRingKeys: activeSilos(membership.current()).map((s) => s.ringKey),
+        });
+      });
+      // Graceful drain releases this silo's shards so a successor can claim them.
+      this.closers.push(async () => manager.stop());
+    }
     for (const provider of this.pullingStreams) {
       provider.setDeliver((grainId, streamKey, event, token) =>
         node.deliverStreamEvent(grainId, streamKey, event, token),

--- a/packages/runtime/src/activation.ts
+++ b/packages/runtime/src/activation.ts
@@ -5,6 +5,11 @@ import {
   type BroadcastChannelHandler,
 } from "@tsva/core/broadcast-channel";
 import type { Duration } from "@tsva/core/duration";
+import {
+  DurableJobConsumerInterface,
+  durableJobHandler,
+  type JobRunContext,
+} from "@tsva/core/durable-job";
 import { GrainCallError, RejectionError } from "@tsva/core/errors";
 import type { Grain } from "@tsva/core/grain";
 import type { GrainContext } from "@tsva/core/grain-context";
@@ -293,6 +298,19 @@ export class ActivationData implements GrainContext {
       const handler = this.broadcastHandlerFor(channelKey);
       if (handler !== undefined) await handler.onPublished(item);
       return undefined;
+    }
+    // Durable-job delivery is a system extension (ADR 0018): run one attempt of
+    // the job on the grain's `DURABLE_JOB_HANDLER`, as a turn here. A grain with
+    // no handler throws, which the executor catches as `Failed` (the retry policy
+    // then drops it) — rather than treating a missing handler as completion, and
+    // without putting a non-serializable Error object in the cross-silo result.
+    if (req.interfaceId === DurableJobConsumerInterface.id) {
+      const [job] = req.args as [JobRunContext];
+      const handler = durableJobHandler(this.instance);
+      if (handler === undefined) {
+        throw new GrainCallError(`grain ${this.id.toString()} has no durable job handler`);
+      }
+      return await handler(job);
     }
     // Transaction-resource extension: drive a named transactional state's
     // prepare/commit/abort for the agent on another silo, found by state name.

--- a/packages/runtime/src/catalog.ts
+++ b/packages/runtime/src/catalog.ts
@@ -7,6 +7,7 @@ import type { GrainMetadata } from "@tsva/core/grain-metadata";
 import type { GrainType } from "@tsva/core/grain-type";
 import type { DeactivationReason } from "@tsva/core/reasons";
 import type { ReminderRegistry } from "@tsva/core/reminder";
+import type { DurableJobScheduler } from "@tsva/core/durable-job";
 import type { StreamProvider } from "@tsva/core/stream";
 import { ActivationData } from "@tsva/runtime/activation";
 import type { GrainFactory } from "@tsva/runtime/grain-factory";
@@ -39,6 +40,8 @@ export interface CatalogOptions {
   migrate?: (activation: ActivationData) => Promise<boolean>;
   /** Resolves the reminder registry a grain's `registerReminder` delegates to. */
   reminderRegistry?: () => ReminderRegistry | undefined;
+  /** Resolves the durable-job scheduler a grain's `scheduleJob` delegates to. */
+  durableJobScheduler?: () => DurableJobScheduler | undefined;
   /** Resolves the stream provider a grain's `getStreamProvider` returns. */
   streamProvider?: (name?: string) => StreamProvider | undefined;
   /** Resolves the broadcast-channel provider a grain's `getBroadcastChannelProvider` returns. */
@@ -138,6 +141,9 @@ export class Catalog {
         : {}),
       ...(this.options.broadcastProvider !== undefined
         ? { broadcastChannels: this.options.broadcastProvider }
+        : {}),
+      ...(this.options.durableJobScheduler !== undefined
+        ? { durableJobs: this.options.durableJobScheduler }
         : {}),
     });
     const instance = new reg.ctor();

--- a/packages/runtime/src/cluster-node.ts
+++ b/packages/runtime/src/cluster-node.ts
@@ -28,6 +28,12 @@ import { Guid } from "@tsva/core/guid";
 import type { GrainReferenceIdentity } from "@tsva/core/grain-reference";
 import { RemindableInterface, type ReminderRegistry, type TickStatus } from "@tsva/core/reminder";
 import {
+  DurableJobConsumerInterface,
+  type DurableJobRunResult,
+  type DurableJobScheduler,
+  type JobRunContext,
+} from "@tsva/core/durable-job";
+import {
   BroadcastConsumerInterface,
   channelKey,
   type BroadcastChannelProvider,
@@ -105,6 +111,8 @@ export interface ClusterNodeOptions {
   ) => Promise<void>;
   /** Resolves the reminder registry a grain's `registerReminder` delegates to. */
   reminderRegistry?: () => ReminderRegistry | undefined;
+  /** Resolves the durable-job scheduler a grain's `scheduleJob` delegates to (ADR 0018). */
+  durableJobScheduler?: () => DurableJobScheduler | undefined;
   /** Resolves the stream provider a grain's `getStreamProvider` returns. */
   streamProvider?: (name?: string) => StreamProvider | undefined;
   /**
@@ -270,6 +278,9 @@ export class ClusterNode {
       ...(options.reminderRegistry !== undefined
         ? { reminderRegistry: options.reminderRegistry }
         : {}),
+      ...(options.durableJobScheduler !== undefined
+        ? { durableJobScheduler: options.durableJobScheduler }
+        : {}),
       ...(options.streamProvider !== undefined ? { streamProvider: options.streamProvider } : {}),
       ...(this.broadcastProviderNames.length > 0
         ? { broadcastProvider: (name?: string) => this.broadcastChannelProvider(name) }
@@ -416,6 +427,24 @@ export class ClusterNode {
       options: {},
       reentrancyId: newChainId(),
     });
+  }
+
+  /**
+   * Run one attempt of a durable job on the target grain's single activation,
+   * routed through the dispatcher (directory → placement) as a `DurableJobConsumer`
+   * system call — so the job runs as a turn wherever the grain is placed,
+   * reactivating it if idle, exactly like reminder delivery (ADR 0018). Returns
+   * the handler's run result for the shard executor to act on.
+   */
+  async deliverDurableJob(job: JobRunContext): Promise<DurableJobRunResult> {
+    return (await this.dispatcher.invoke({
+      target: job.target,
+      interfaceId: DurableJobConsumerInterface.id,
+      method: "runJob",
+      args: [job],
+      options: {},
+      reentrancyId: newChainId(),
+    })) as DurableJobRunResult;
   }
 
   /**

--- a/packages/runtime/src/grain-runtime-impl.ts
+++ b/packages/runtime/src/grain-runtime-impl.ts
@@ -4,6 +4,7 @@ import type { GrainKey } from "@tsva/core/grain-key";
 import type { GrainRuntime } from "@tsva/core/grain-runtime";
 import type { GrainTimer } from "@tsva/core/grain-timer";
 import type { ReminderRegistry } from "@tsva/core/reminder";
+import type { DurableJob, DurableJobScheduler, ScheduleJobRequest } from "@tsva/core/durable-job";
 import type { SiloAddress } from "@tsva/core/silo-address";
 import type { BroadcastChannelProvider } from "@tsva/core/broadcast-channel";
 import { isActivationBound, type StreamProvider } from "@tsva/core/stream";
@@ -15,6 +16,7 @@ export interface GrainRuntimeServices {
   reminders?: () => ReminderRegistry | undefined;
   streams?: (name?: string) => StreamProvider | undefined;
   broadcastChannels?: (name?: string) => BroadcastChannelProvider | undefined;
+  durableJobs?: () => DurableJobScheduler | undefined;
 }
 
 /** Per-activation `GrainRuntime`, reached by a grain through `this.runtime`. */
@@ -39,6 +41,14 @@ export class GrainRuntimeImpl implements GrainRuntime {
 
   unregisterReminder(name: string): Promise<void> {
     return this.requireReminders().unregister(this.activation.id, name);
+  }
+
+  scheduleJob(request: ScheduleJobRequest): Promise<DurableJob> {
+    return this.requireDurableJobs().scheduleJob(request);
+  }
+
+  cancelJob(job: DurableJob): Promise<void> {
+    return this.requireDurableJobs().cancelJob(job);
   }
 
   getStreamProvider(name?: string): StreamProvider {
@@ -82,5 +92,11 @@ export class GrainRuntimeImpl implements GrainRuntime {
     const registry = this.services.reminders?.();
     if (registry === undefined) throw new Error("reminders are not configured on this silo");
     return registry;
+  }
+
+  private requireDurableJobs(): DurableJobScheduler {
+    const scheduler = this.services.durableJobs?.();
+    if (scheduler === undefined) throw new Error("durable jobs are not configured on this silo");
+    return scheduler;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,15 @@ importers:
         specifier: workspace:*
         version: link:../core
 
+  packages/durable-jobs:
+    dependencies:
+      '@tsva/core':
+        specifier: workspace:*
+        version: link:../core
+      redis:
+        specifier: ^5.12.1
+        version: 5.12.1(@opentelemetry/api@1.9.1)
+
   packages/hosting:
     dependencies:
       '@tsva/clustering-k8s':
@@ -205,6 +214,9 @@ importers:
       '@tsva/directory':
         specifier: workspace:*
         version: link:../directory
+      '@tsva/durable-jobs':
+        specifier: workspace:*
+        version: link:../durable-jobs
       '@tsva/journaling':
         specifier: workspace:*
         version: link:../journaling

--- a/todo.md
+++ b/todo.md
@@ -22,8 +22,14 @@ examples double as acceptance tests.
       `runRebalanceCycle` (slice 2a) — ship. Remaining: an elected singleton worker driving the cycle on
       a timer (sessions/cycles, due-time/backoff), the `useActivationRebalancing(options?)` builder
       surface, a `RebalancingReport` + suspend/resume, and a convergence e2e over a running cluster.
-- [ ] **Durable jobs** — implement [ADR 0018](docs/adr/0018-durable-jobs.md) (`@tsva/durable-jobs`): a
-      sharded, durable, at-least-once scheduled-execution engine. Design only so far.
+- [x] **Durable jobs** — [ADR 0018](docs/adr/0018-durable-jobs.md) (`@tsva/durable-jobs`): a sharded,
+      durable, at-least-once scheduled-execution engine. Shipped: the pure model (shard-key bucketing,
+      due-time queue, default retry policy, claim budget), the `ShardExecutor` (concurrency limiter,
+      slow-start, overload backoff, `pollAfter` loop, retry), the `LocalDurableJobManager`
+      (membership-reconciled shard ownership, dead-silo adoption, poison protection, ramp-up budget), the
+      `JobShardStore` contract with memory + Redis backings, the `DURABLE_JOB_HANDLER` receiver +
+      `useDurableJobHandler` hook, `runtime.scheduleJob` / `cancelJob`, and
+      `useMemoryDurableJobs()` / `useRedisDurableJobs()` hosting.
 
 ## Beyond parity
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,6 +31,7 @@
       "@tsva/persistence/*": ["./packages/persistence/src/*"],
       "@tsva/transactions/*": ["./packages/transactions/src/*"],
       "@tsva/journaling/*": ["./packages/journaling/src/*"],
+      "@tsva/durable-jobs/*": ["./packages/durable-jobs/src/*"],
       "@tsva/observability/*": ["./packages/observability/src/*"],
       "@tsva/reminders/*": ["./packages/reminders/src/*"],
       "@tsva/streams/*": ["./packages/streams/src/*"],


### PR DESCRIPTION
Implements [ADR 0018](docs/adr/0018-durable-jobs.md) as a new `@tsva/durable-jobs` package — Orleans 10's durable jobs: a **sharded (time-bucketed), durable, at-least-once scheduled grain invocation** with per-silo concurrency control, retries and crash failover. It is **not** a workflow engine — one scheduled invocation per job.

## All four ADR slices
1. **Pure model** — `shardKeyFor` (`floor(dueTime/shardDuration)`), the in-memory due-time priority queue (`InMemoryJobQueue`), the default retry policy (≤5 attempts, `2^n`s backoff), and the claim-budget computation, as pure unit-tested functions.
2. **Single-silo e2e (memory store)** — `LocalDurableJobManager` + `ShardExecutor` (concurrency limiter, slow-start, overload backoff, `pollAfter` loop, retry application) + the `DURABLE_JOB_HANDLER` receiver, wired through the dispatcher. A job fires as a turn at its due time; resolve removes, throw retries-then-drops, `cancelJob` removes, `pollAfter` re-polls.
3. **Durable store + restart** — `RedisJobShardStore` (Lua-CAS shard claim/adopt/poison, codec-serialized jobs). A job scheduled before a silo restart fires after, off a shared store.
4. **Multi-silo ownership & failover** — membership-driven shard claim, dead-silo adoption, poison protection past `maxAdoptedCount`, claim ramp-up budget. Killing a shard's owner adopts it and the job still runs.

## Seams (mirroring `@tsva/reminders` / `@tsva/journaling`)
- **Core** `packages/core/src/durable-job.ts`: `DURABLE_JOB_HANDLER` symbol, `JobRunContext`, `DurableJobRunResult` (`completed`/`pollAfter`/`failed`), `DurableJobsOptions`, `DurableJobConsumerInterface`, `DurableJobScheduler`. `scheduleJob`/`cancelJob` on `GrainRuntime`, the `useDurableJobHandler(ctx, handler)` hook.
- **Runtime**: `ClusterNode.deliverDurableJob` (dispatcher-routed, runs as a turn on the target activation) + `DurableJobConsumerInterface` interception in `activation.callMethod` (mirrors the `BroadcastConsumer` path).
- **Hosting**: `createSilo().useMemoryDurableJobs()` / `useRedisDurableJobs({ url, keyPrefix? })`, manager constructed post-node, ownership reconciled on the `onOwnershipChange` hook.

## Tests
Pure-model, executor (concurrency/overload/dequeue-count), and Redis-store (skip-if-down Lua-CAS) units, plus a hosting e2e covering fire-as-turn, complete/retry/cancel/pollAfter, restart, and multi-silo dead-owner adoption.

`pnpm -r exec tsc --noEmit` clean. Full suite: **444 passed, 22 skipped** (was 418 baseline; +26 new tests). Redis tests ran (Redis up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)