### PR TITLE
feat(journaling): add DurableQueue and DurableSet

### DIFF
--- a/EPICS.md
+++ b/EPICS.md
@@ -23,7 +23,8 @@ for how the design differs from Orleans.
   locking, optimistic two-phase commit (TM elected from writers), durable storage, cross-silo
   participants, in-doubt recovery.
 - **Durable journaling (`DurableGrain`)** — a per-grain `StateMachineManager` over
-  `DurableValue`/`DurableDictionary`/`DurableList` that journals each mutation to an append-only log
+  `DurableValue`/`DurableDictionary`/`DurableList`/`DurableQueue`/`DurableSet` that journals each
+  mutation to an append-only log
   and replays it on activation, with snapshot/compaction; a `JournalStorage` seam (memory + Redis),
   `useDurable*` hooks + `@durable*` decorators, and `useMemoryJournaling()`/`addRedisJournaling()`.
   Separate from the reducer snapshot facet and `PersistentState`.

--- a/packages/core/src/decorators.ts
+++ b/packages/core/src/decorators.ts
@@ -186,3 +186,13 @@ export function durableDictionary(stateName: string, options: DurableStateOption
 export function durableList(stateName: string, options: DurableStateOptions = {}) {
   return durableField("list", stateName, options);
 }
+
+/** Injects a `DurableQueue<T>` journalled facet into a grain field. */
+export function durableQueue(stateName: string, options: DurableStateOptions = {}) {
+  return durableField("queue", stateName, options);
+}
+
+/** Injects a `DurableSet<T>` journalled facet into a grain field. */
+export function durableSet(stateName: string, options: DurableStateOptions = {}) {
+  return durableField("set", stateName, options);
+}

--- a/packages/core/src/define-grain.ts
+++ b/packages/core/src/define-grain.ts
@@ -14,7 +14,13 @@ import { DURABLE_JOB_HANDLER, type DurableJobHandler } from "./durable-job";
 import type { GrainKeyFor } from "./key-kinds";
 import type { PersistentState } from "./persistent-state";
 import { registerPersistentField } from "./persistent-state-metadata";
-import type { DurableDictionary, DurableList, DurableValue } from "./durable-state";
+import type {
+  DurableDictionary,
+  DurableList,
+  DurableQueue,
+  DurableSet,
+  DurableValue,
+} from "./durable-state";
 import { registerDurableField } from "./durable-state-metadata";
 import type { Reducer, ReducerState } from "./reducer-state";
 import { registerReducerField } from "./reducer-state-metadata";
@@ -410,6 +416,76 @@ export function useDurableList<T>(
     add: (value) => bound().add(value),
     set: (index, value) => bound().set(index, value),
     removeAt: (index) => bound().removeAt(index),
+    clear: () => bound().clear(),
+  };
+}
+
+/**
+ * The functional counterpart of `@durableQueue` — a journalled FIFO queue bound
+ * and replayed before `onActivate`.
+ */
+export function useDurableQueue<T>(
+  ctx: GrainSetup,
+  stateName: string,
+  options: UseDurableStateOptions = {},
+): DurableQueue<T> {
+  const instance = instanceOf(ctx);
+  const fieldName = `__tsva_durablequeue$${stateName}`;
+  registerDurableField(instance, {
+    fieldName,
+    stateName,
+    kind: "queue",
+    ...(options.provider !== undefined ? { provider: options.provider } : {}),
+  });
+  const bound = (): DurableQueue<T> => {
+    const facet = (instance as Record<string, unknown>)[fieldName] as DurableQueue<T> | undefined;
+    if (facet === undefined) throw new Error(`durable queue "${stateName}" not yet bound`);
+    return facet;
+  };
+  return {
+    get size() {
+      return bound().size;
+    },
+    peek: () => bound().peek(),
+    toArray: () => bound().toArray(),
+    [Symbol.iterator]: () => bound()[Symbol.iterator](),
+    enqueue: (value) => bound().enqueue(value),
+    dequeue: () => bound().dequeue(),
+    clear: () => bound().clear(),
+  };
+}
+
+/**
+ * The functional counterpart of `@durableSet` — a journalled set of scalar
+ * values bound and replayed before `onActivate`.
+ */
+export function useDurableSet<T>(
+  ctx: GrainSetup,
+  stateName: string,
+  options: UseDurableStateOptions = {},
+): DurableSet<T> {
+  const instance = instanceOf(ctx);
+  const fieldName = `__tsva_durableset$${stateName}`;
+  registerDurableField(instance, {
+    fieldName,
+    stateName,
+    kind: "set",
+    ...(options.provider !== undefined ? { provider: options.provider } : {}),
+  });
+  const bound = (): DurableSet<T> => {
+    const facet = (instance as Record<string, unknown>)[fieldName] as DurableSet<T> | undefined;
+    if (facet === undefined) throw new Error(`durable set "${stateName}" not yet bound`);
+    return facet;
+  };
+  return {
+    get size() {
+      return bound().size;
+    },
+    has: (value) => bound().has(value),
+    values: () => bound().values(),
+    [Symbol.iterator]: () => bound()[Symbol.iterator](),
+    add: (value) => bound().add(value),
+    delete: (value) => bound().delete(value),
     clear: () => bound().clear(),
   };
 }

--- a/packages/core/src/durable-state-metadata.ts
+++ b/packages/core/src/durable-state-metadata.ts
@@ -1,5 +1,5 @@
 /** Which durable structure a journalled field declares. */
-export type DurableKind = "value" | "dictionary" | "list";
+export type DurableKind = "value" | "dictionary" | "list" | "queue" | "set";
 
 /**
  * A durable-journaling field declared on a grain via the `@durableState` /

--- a/packages/core/src/durable-state.ts
+++ b/packages/core/src/durable-state.ts
@@ -46,3 +46,36 @@ export interface DurableList<T> {
   /** Journal a clear of all items. */
   clear(): Promise<void>;
 }
+
+/** A journalled FIFO queue. Orleans' `IDurableQueue<T>`. */
+export interface DurableQueue<T> {
+  readonly size: number;
+  /** The element at the front without removing it; `undefined` when empty. */
+  peek(): T | undefined;
+  toArray(): readonly T[];
+  [Symbol.iterator](): IterableIterator<T>;
+  /** Journal an enqueue at the back and update memory. */
+  enqueue(value: T): Promise<void>;
+  /** Journal a dequeue from the front; resolves to the removed element, or `undefined` when empty. */
+  dequeue(): Promise<T | undefined>;
+  /** Journal a clear of all elements. */
+  clear(): Promise<void>;
+}
+
+/**
+ * A journalled set of scalar values. Orleans' `IDurableSet<T>`. Values must be
+ * JSON-stable scalars (string/number/boolean) so they round-trip through the
+ * value-codec on replay and compare by value rather than reference.
+ */
+export interface DurableSet<T> {
+  readonly size: number;
+  has(value: T): boolean;
+  values(): IterableIterator<T>;
+  [Symbol.iterator](): IterableIterator<T>;
+  /** Journal an add; resolves to whether the value was newly added. */
+  add(value: T): Promise<boolean>;
+  /** Journal a delete; resolves to whether the value was present. */
+  delete(value: T): Promise<boolean>;
+  /** Journal a clear of all values. */
+  clear(): Promise<void>;
+}

--- a/packages/journaling/src/durable-queue-impl.test.ts
+++ b/packages/journaling/src/durable-queue-impl.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { GrainId } from "@tsva/core/grain-id";
+import { DurableQueueImpl } from "@tsva/journaling/durable-queue-impl";
+import { MemoryJournalStorage } from "@tsva/journaling/memory-journal-storage";
+import { StateMachineManagerImpl } from "@tsva/journaling/state-machine-manager-impl";
+
+const id = new GrainId("Inbox", "i1");
+
+function makeQueue<T>(storage: MemoryJournalStorage) {
+  const manager = new StateMachineManagerImpl("journal", id, storage);
+  const queue = new DurableQueueImpl<T>("q", manager);
+  manager.register(queue);
+  return { manager, queue };
+}
+
+describe("DurableQueueImpl", () => {
+  it("tracks enqueue/dequeue/peek/clear in FIFO order", async () => {
+    const { queue } = makeQueue<string>(new MemoryJournalStorage());
+    await queue.enqueue("a");
+    await queue.enqueue("b");
+    await queue.enqueue("c");
+    expect(queue.size).toBe(3);
+    expect(queue.peek()).toBe("a");
+    expect(queue.toArray()).toEqual(["a", "b", "c"]);
+    expect([...queue]).toEqual(["a", "b", "c"]);
+
+    expect(await queue.dequeue()).toBe("a");
+    expect(await queue.dequeue()).toBe("b");
+    expect(queue.peek()).toBe("c");
+    expect(queue.size).toBe(1);
+
+    await queue.clear();
+    expect(queue.size).toBe(0);
+  });
+
+  it("dequeue on an empty queue resolves to undefined without journaling", async () => {
+    const storage = new MemoryJournalStorage();
+    const { queue } = makeQueue<number>(storage);
+    expect(await queue.dequeue()).toBeUndefined();
+    // A no-op dequeue must not have written a log entry.
+    const replayed = makeQueue<number>(storage);
+    await replayed.manager.replay();
+    expect(replayed.queue.size).toBe(0);
+  });
+
+  it("rebuilds from the log on a fresh activation", async () => {
+    const storage = new MemoryJournalStorage();
+    const a = makeQueue<number>(storage);
+    await a.queue.enqueue(1);
+    await a.queue.enqueue(2);
+    await a.queue.enqueue(3);
+    await a.queue.dequeue(); // [2,3]
+    await a.queue.enqueue(4); // [2,3,4]
+
+    const b = makeQueue<number>(storage);
+    await b.manager.replay();
+    expect(b.queue.toArray()).toEqual([2, 3, 4]);
+  });
+});

--- a/packages/journaling/src/durable-queue-impl.ts
+++ b/packages/journaling/src/durable-queue-impl.ts
@@ -1,0 +1,78 @@
+import type { DurableStateMachine, StateMachineManager } from "@tsva/core/durable-state-machine";
+import type { DurableQueue } from "@tsva/core/durable-state";
+
+type QueueOp<T> = { t: "enq"; v: T } | { t: "deq" } | { t: "clear" } | { t: "load"; items: T[] };
+
+/**
+ * A journalled FIFO queue, implemented as a `DurableStateMachine`. Enqueues
+ * append to the back and dequeues remove from the front; both replay in append
+ * order, so a fresh activation reproduces the same ordering. Each mutation is
+ * appended to the grain's log and then applied to memory.
+ */
+export class DurableQueueImpl<T> implements DurableQueue<T>, DurableStateMachine {
+  private items: T[] = [];
+
+  constructor(
+    readonly name: string,
+    private readonly manager: StateMachineManager,
+  ) {}
+
+  get size(): number {
+    return this.items.length;
+  }
+
+  peek(): T | undefined {
+    return this.items[0];
+  }
+
+  toArray(): readonly T[] {
+    return [...this.items];
+  }
+
+  [Symbol.iterator](): IterableIterator<T> {
+    return this.items[Symbol.iterator]();
+  }
+
+  async enqueue(value: T): Promise<void> {
+    // The manager applies the op to memory after a successful append.
+    await this.manager.append(this.name, { t: "enq", v: value } satisfies QueueOp<T>);
+  }
+
+  async dequeue(): Promise<T | undefined> {
+    // An empty dequeue is a no-op: nothing to journal, nothing to return.
+    if (this.items.length === 0) return undefined;
+    const head = this.items[0];
+    await this.manager.append(this.name, { t: "deq" } satisfies QueueOp<T>);
+    return head;
+  }
+
+  async clear(): Promise<void> {
+    await this.manager.append(this.name, { t: "clear" } satisfies QueueOp<T>);
+  }
+
+  reset(): void {
+    this.items = [];
+  }
+
+  apply(payload: unknown): void {
+    const op = payload as QueueOp<T>;
+    switch (op.t) {
+      case "enq":
+        this.items.push(op.v);
+        break;
+      case "deq":
+        this.items.shift();
+        break;
+      case "clear":
+        this.items = [];
+        break;
+      case "load":
+        this.items = [...op.items];
+        break;
+    }
+  }
+
+  snapshot(): unknown {
+    return { t: "load", items: [...this.items] } satisfies QueueOp<T>;
+  }
+}

--- a/packages/journaling/src/durable-set-impl.test.ts
+++ b/packages/journaling/src/durable-set-impl.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { GrainId } from "@tsva/core/grain-id";
+import { DurableSetImpl } from "@tsva/journaling/durable-set-impl";
+import { MemoryJournalStorage } from "@tsva/journaling/memory-journal-storage";
+import { StateMachineManagerImpl } from "@tsva/journaling/state-machine-manager-impl";
+
+const id = new GrainId("Tags", "t1");
+
+function makeSet<T>(storage: MemoryJournalStorage) {
+  const manager = new StateMachineManagerImpl("journal", id, storage);
+  const set = new DurableSetImpl<T>("s", manager);
+  manager.register(set);
+  return { manager, set };
+}
+
+describe("DurableSetImpl", () => {
+  it("tracks add/has/delete/clear in memory", async () => {
+    const { set } = makeSet<string>(new MemoryJournalStorage());
+    expect(await set.add("a")).toBe(true);
+    expect(await set.add("b")).toBe(true);
+    expect(await set.add("a")).toBe(false); // already present
+    expect(set.size).toBe(2);
+    expect(set.has("a")).toBe(true);
+    expect([...set].sort()).toEqual(["a", "b"]);
+
+    expect(await set.delete("a")).toBe(true);
+    expect(await set.delete("a")).toBe(false); // already gone
+    expect(set.has("a")).toBe(false);
+    expect(set.size).toBe(1);
+
+    await set.clear();
+    expect(set.size).toBe(0);
+  });
+
+  it("does not journal a redundant add or a missing delete", async () => {
+    const storage = new MemoryJournalStorage();
+    const a = makeSet<number>(storage);
+    await a.set.add(1);
+    await a.set.add(1); // redundant
+    await a.set.delete(2); // missing
+
+    const b = makeSet<number>(storage);
+    await b.manager.replay();
+    expect([...b.set.values()]).toEqual([1]);
+  });
+
+  it("rebuilds from the log on a fresh activation", async () => {
+    const storage = new MemoryJournalStorage();
+    const a = makeSet<number>(storage);
+    await a.set.add(1);
+    await a.set.add(2);
+    await a.set.add(3);
+    await a.set.delete(2);
+
+    const b = makeSet<number>(storage);
+    await b.manager.replay();
+    expect([...b.set.values()].sort()).toEqual([1, 3]);
+  });
+});

--- a/packages/journaling/src/durable-set-impl.ts
+++ b/packages/journaling/src/durable-set-impl.ts
@@ -1,0 +1,84 @@
+import type { DurableStateMachine, StateMachineManager } from "@tsva/core/durable-state-machine";
+import type { DurableSet } from "@tsva/core/durable-state";
+
+type SetOp<T> =
+  | { t: "add"; v: T }
+  | { t: "del"; v: T }
+  | { t: "clear" }
+  | { t: "load"; values: T[] };
+
+/**
+ * A journalled set of scalar values, implemented as a `DurableStateMachine`.
+ * Values must be JSON-stable scalars (string/number/boolean) so they round-trip
+ * through the value-codec on replay and compare by value. Redundant adds and
+ * deletes of absent values are no-ops and journal nothing. Each mutation is
+ * appended to the grain's log and then applied to memory.
+ */
+export class DurableSetImpl<T> implements DurableSet<T>, DurableStateMachine {
+  private readonly set = new Set<T>();
+
+  constructor(
+    readonly name: string,
+    private readonly manager: StateMachineManager,
+  ) {}
+
+  get size(): number {
+    return this.set.size;
+  }
+
+  has(value: T): boolean {
+    return this.set.has(value);
+  }
+
+  values(): IterableIterator<T> {
+    return this.set.values();
+  }
+
+  [Symbol.iterator](): IterableIterator<T> {
+    return this.set[Symbol.iterator]();
+  }
+
+  async add(value: T): Promise<boolean> {
+    if (this.set.has(value)) return false;
+    // The manager applies the op to memory after a successful append.
+    await this.manager.append(this.name, { t: "add", v: value } satisfies SetOp<T>);
+    return true;
+  }
+
+  async delete(value: T): Promise<boolean> {
+    if (!this.set.has(value)) return false;
+    await this.manager.append(this.name, { t: "del", v: value } satisfies SetOp<T>);
+    return true;
+  }
+
+  async clear(): Promise<void> {
+    await this.manager.append(this.name, { t: "clear" } satisfies SetOp<T>);
+  }
+
+  reset(): void {
+    this.set.clear();
+  }
+
+  apply(payload: unknown): void {
+    const op = payload as SetOp<T>;
+    switch (op.t) {
+      case "add":
+        this.set.add(op.v);
+        break;
+      case "del":
+        this.set.delete(op.v);
+        break;
+      case "clear":
+        this.set.clear();
+        break;
+      case "load":
+        this.set.clear();
+        for (const v of op.values) this.set.add(v);
+        break;
+    }
+  }
+
+  snapshot(): unknown {
+    return { t: "load", values: [...this.set] } satisfies SetOp<T>;
+  }
+}

--- a/packages/journaling/src/durable-state-activator.ts
+++ b/packages/journaling/src/durable-state-activator.ts
@@ -4,6 +4,8 @@ import { getDurableFields, type DurableKind } from "@tsva/core/durable-state-met
 import { DurableValueImpl } from "@tsva/journaling/durable-value-impl";
 import { DurableDictionaryImpl } from "@tsva/journaling/durable-dictionary-impl";
 import { DurableListImpl } from "@tsva/journaling/durable-list-impl";
+import { DurableQueueImpl } from "@tsva/journaling/durable-queue-impl";
+import { DurableSetImpl } from "@tsva/journaling/durable-set-impl";
 import type { JournalStorageRegistry } from "@tsva/journaling/journal-storage-registry";
 import { StateMachineManagerImpl } from "@tsva/journaling/state-machine-manager-impl";
 
@@ -19,6 +21,10 @@ function makeMachine(
       return new DurableDictionaryImpl(stateName, manager);
     case "list":
       return new DurableListImpl(stateName, manager);
+    case "queue":
+      return new DurableQueueImpl(stateName, manager);
+    case "set":
+      return new DurableSetImpl(stateName, manager);
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `DurableQueue<T>` (FIFO `enqueue`/`dequeue`/`peek`/`clear`) and `DurableSet<T>` (`add`/`delete`/`has`/`clear`) to `@tsva/journaling`, completing the Orleans.Journaling collection set alongside the existing `DurableValue`/`DurableDictionary`/`DurableList`.
- Each new type is a `DurableStateMachine`: every mutation appends to the grain's log and replays on activation, with snapshot/compaction via the shared `StateMachineManager`. Empty `dequeue`, redundant `add`, and missing `delete` are no-ops that journal nothing.
- Fully wired through the public surface: `@durableQueue` / `@durableSet` decorators, `useDurableQueue` / `useDurableSet` hooks, and the activator's `makeMachine`. `DurableKind` extended to `"queue" | "set"`.

## Test plan
- [x] 6 new unit tests cover FIFO ordering, dedup/no-op semantics, no-op-no-journal, and log replay on a fresh activation
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] Full suite: 477 passed / 22 skipped (the skipped are the pre-existing Redis/Postgres integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)