### PR TITLE
ci: run the suites on a self-hosted runner with the backing services up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,128 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  # Self-hosted macOS runners inherit a bare launchd PATH, so Homebrew-installed
+  # node/pnpm/docker are not on it unless we say so.
+  PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+
+concurrency:
+  group: ci-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref }}
+  # Superseded PR runs are safe to cancel. `main` runs are not cancelled: there
+  # is one runner, and a half-finished run on main leaves an ambiguous record of
+  # whether that commit was ever green.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # Fast fail. Types and lint catch most of what breaks, in well under a minute,
+  # so there is no point paying for the service containers to find out.
+  check:
+    runs-on: self-hosted
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Preflight
+        run: |
+          command -v node >/dev/null || { echo "node is not on PATH for the runner"; exit 1; }
+          corepack enable >/dev/null 2>&1 || true
+          command -v pnpm >/dev/null || { echo "pnpm is not on PATH (corepack enable failed?)"; exit 1; }
+          echo "node $(node --version), pnpm $(pnpm --version)"
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+  # The suites that need Redis, Postgres or Kafka probe the service at load time
+  # and skip themselves when it is unreachable. That makes a serviceless run look
+  # green while silently covering far less, which is the specific gap this job
+  # exists to close -- so it asserts the services are up rather than letting the
+  # skips pass unnoticed.
+  test:
+    needs: check
+    runs-on: self-hosted
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Preflight
+        run: corepack enable >/dev/null 2>&1 || true
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      # Publishes the service URLs into the job env. The services listen on
+      # non-default ports so they cannot collide with, or silently borrow, any
+      # other project's Redis/Postgres/Kafka on the same runner.
+      - name: Ensure backing services
+        run: |
+          ./scripts/ensure-services.sh
+          ./scripts/ensure-services.sh --env | sed 's/^export //; s/'"'"'//g' >> "$GITHUB_ENV"
+
+      - name: Unit tests
+        run: set -o pipefail; pnpm test 2>&1 | tee unit.log
+
+      # Parity does not touch the backing services: its skips are deliberate
+      # `orleansTest.excluded` backlog entries, and that count IS the parity
+      # metric. It should move when the backlog moves, never because of CI.
+      - name: Parity tests
+        run: set -o pipefail; pnpm test:parity 2>&1 | tee parity.log
+
+      - name: Parity scorecard
+        run: set -o pipefail; pnpm parity:scorecard 2>&1 | tee scorecard.log
+
+      # A rising skip count is how coverage silently rots here: a service that
+      # stops coming up turns into skipped suites, not a red build. Surface the
+      # counts on every run so the trend is visible in the run summary.
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Unit"
+            echo '```'
+            tail -n 12 unit.log 2>/dev/null || echo "(no output)"
+            echo '```'
+            echo "## Parity"
+            echo '```'
+            tail -n 12 parity.log 2>/dev/null || echo "(no output)"
+            echo '```'
+            echo "## Parity scorecard"
+            echo '```'
+            tail -n 25 scorecard.log 2>/dev/null || echo "(no output)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # A provider suite skips itself when its service is unreachable, so a
+      # service that quietly stops coming up shows as a green run with less
+      # coverage rather than a red one. With all three services up exactly one
+      # unit file skips; more than that means something did not start, and the
+      # build should fail rather than report a hollow pass.
+      - name: Assert the provider suites actually ran
+        run: |
+          skipped=$(grep -oE '[0-9]+ skipped \(' unit.log | grep -oE '^[0-9]+' | head -1)
+          echo "Unit test files skipped: ${skipped:-unknown}"
+          if [ -z "$skipped" ]; then
+            echo "could not parse the skip count from unit.log" >&2
+            exit 1
+          fi
+          if [ "$skipped" -gt 1 ]; then
+            echo "::error::${skipped} unit test files skipped, expected at most 1." \
+                 "A backing service probably failed to start, so the Redis/Postgres/Kafka" \
+                 "suites silently did not run."
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -73,6 +73,43 @@ pnpm typecheck    # type-check every package
 pnpm lint         # ESLint + Prettier
 ```
 
+### Backing services
+
+The Redis, Postgres and Kafka suites probe their service when the file loads and
+skip themselves when it is unreachable, so `pnpm test` passes without any of
+them — it just covers less. Bringing them up is what turns those suites on:
+
+```sh
+./scripts/ensure-services.sh          # start Redis, Postgres and Kafka in Docker
+eval "$(./scripts/ensure-services.sh --env)"   # point the suites at them
+pnpm test
+./scripts/ensure-services.sh --down   # stop them again
+```
+
+With all three up, exactly one unit test file should skip; without them, twelve
+do. They listen on **non-default ports** (6390, 5433, 9192) so they cannot
+collide with — or silently borrow — another project's services on the same
+machine. Borrowing is the dangerous case: a foreign Postgres on 5432 answers the
+probe, fails to be usable, and the suite skips itself, so the run stays green
+while testing nothing.
+
+### CI
+
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs typecheck and lint,
+then the unit and parity suites with the backing services up, on a **self-hosted
+runner**. It fails the build if more than one unit file skips, so a service that
+stops starting shows up as a red build rather than as quietly reduced coverage.
+
+To install the runner on the Mac mini (idempotent; needs `gh` logged in with
+admin on the repo, and the mini reachable over SSH):
+
+```sh
+./scripts/setup-ci-runner.sh
+```
+
+Parity's skips are unrelated to CI: they are deliberate `orleansTest.excluded`
+backlog entries, and that count is the parity metric itself.
+
 ### Examples
 
 Each example runs end-to-end over in-memory providers and the in-process transport, and is also

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,76 @@
+# Backing services for the provider-backed test suites.
+#
+# Every suite that needs one of these probes it at load time and calls
+# `describe.skipIf(...)` when it is unreachable, so the whole file is optional:
+# without it `pnpm test` still passes, it just silently covers less. Bring these
+# up (`./scripts/ensure-services.sh`) to run the Redis, Postgres and Kafka
+# suites locally, which is what CI does.
+#
+# Ports are the defaults the suites assume (REDIS_URL, PG_URL, KAFKA_BROKERS
+# override them). Nothing here is seeded: each suite creates its own uniquely
+# named table or topic and drops it again, so the containers stay disposable.
+
+name: thresh
+
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: thresh-redis
+    ports:
+      - "6390:6379"
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: thresh-postgres
+    ports:
+      - "5433:5432"
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_DB: postgres
+    # Test data is disposable; keeping it off disk makes a cold start faster and
+    # stops a wedged run from poisoning the next one.
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+
+  # Apache Kafka in KRaft mode (no ZooKeeper). Redpanda was tried first for its
+  # faster start, but the pulling-stream and queue suites hang against it, so the
+  # real broker it is. Auto-topic-creation stays off: the suites create their own
+  # topics and a silent auto-create would mask a bug in that path.
+  kafka:
+    image: apache/kafka:3.9.0
+    container_name: thresh-kafka
+    ports:
+      - "9192:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9192
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1",
+        ]
+      interval: 3s
+      timeout: 10s
+      retries: 30

--- a/scripts/ensure-services.sh
+++ b/scripts/ensure-services.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Ensure the backing services the provider-backed suites need (Redis, Postgres,
+# Kafka) are up and healthy, and print the URLs to point the suites at.
+#
+# These run on NON-DEFAULT host ports on purpose. The suites default to
+# localhost:6379 / 5432 / 9092, and a dev box or a shared CI runner very often
+# already has something else on those -- another project's Postgres, a stray
+# Redis. Reusing whatever happens to answer is worse than not running at all:
+# the suites probe their service at load time and `describe.skipIf` themselves
+# when it is unusable, so a foreign service on the right port produces a green
+# run that silently tested nothing. Dedicated ports make that impossible.
+#
+# Usage:
+#   ./scripts/ensure-services.sh            # start, wait, print the env
+#   ./scripts/ensure-services.sh --quiet    # only speak up on failure
+#   ./scripts/ensure-services.sh --env      # print only the export lines
+#   ./scripts/ensure-services.sh --down     # stop and remove the containers
+#
+# To use the URLs in a shell:
+#   eval "$(./scripts/ensure-services.sh --env)"
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+COMPOSE=("docker" "compose" "-f" "$REPO_ROOT/docker-compose.yml")
+
+# Keep in step with the published ports in docker-compose.yml.
+REDIS_PORT=6390
+PG_PORT=5433
+KAFKA_PORT=9192
+
+REDIS_URL="redis://localhost:${REDIS_PORT}"
+PG_URL="postgres://postgres@localhost:${PG_PORT}/postgres"
+KAFKA_BROKERS="localhost:${KAFKA_PORT}"
+
+print_env() {
+  echo "export REDIS_URL='${REDIS_URL}'"
+  echo "export PG_URL='${PG_URL}'"
+  echo "export KAFKA_BROKERS='${KAFKA_BROKERS}'"
+}
+
+QUIET=false
+case "${1:-}" in
+  --quiet) QUIET=true ;;
+  --env) print_env; exit 0 ;;
+  --down) "${COMPOSE[@]}" down --remove-orphans; exit 0 ;;
+  "") ;;
+  *) echo "unknown argument: $1" >&2; exit 2 ;;
+esac
+
+log() { [[ "$QUIET" == true ]] || echo "$@"; }
+err() { echo "$@" >&2; }
+
+# Probe each service the way its suite does -- a real protocol round trip, not a
+# TCP connect. `docker compose --wait` already gates on the healthchecks, but
+# these run from the host, so they also prove the published port is actually
+# wired through, which on macOS can lag the container becoming healthy.
+probe_redis() { "${COMPOSE[@]}" exec -T redis redis-cli ping 2>/dev/null | grep -q PONG; }
+probe_postgres() { "${COMPOSE[@]}" exec -T postgres pg_isready -U postgres -q 2>/dev/null; }
+probe_kafka() { "${COMPOSE[@]}" exec -T kafka /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1; }
+
+all_healthy() { probe_redis && probe_postgres && probe_kafka; }
+
+if all_healthy; then
+  log "[ok] redis, postgres and kafka are already up"
+  [[ "$QUIET" == true ]] || print_env
+  exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  err "[error] docker is not installed. Install Docker Desktop or colima and retry."
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  err "[error] docker is installed but the daemon is not responding."
+  err "        Start Docker Desktop (or colima) and retry."
+  exit 1
+fi
+
+log "[..] starting services"
+"${COMPOSE[@]}" up -d --wait --wait-timeout 180
+
+deadline=$(( SECONDS + 90 ))
+until all_healthy; do
+  if (( SECONDS >= deadline )); then
+    err "[error] services started but did not become usable:"
+    probe_redis    || err "        redis (${REDIS_PORT})"
+    probe_postgres || err "        postgres (${PG_PORT})"
+    probe_kafka    || err "        kafka (${KAFKA_PORT})"
+    err ""
+    "${COMPOSE[@]}" ps >&2 || true
+    exit 1
+  fi
+  sleep 2
+done
+
+log "[ok] redis, postgres and kafka are up"
+[[ "$QUIET" == true ]] || print_env

--- a/scripts/setup-ci-runner.sh
+++ b/scripts/setup-ci-runner.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Install a GitHub Actions self-hosted runner for this repo on the Mac mini.
+#
+# Run it from a machine that can reach the mini over SSH and has `gh` logged in
+# with admin rights on the repo (the registration token is minted here and piped
+# over, so the mini needs neither `gh` nor a GitHub login):
+#
+#   ./scripts/setup-ci-runner.sh
+#
+# Or run it directly ON the mini, having minted a token yourself:
+#
+#   RUNNER_TOKEN=xxxx LOCAL=1 ./scripts/setup-ci-runner.sh
+#
+# Idempotent. Re-running reconfigures the existing runner in place (`--replace`)
+# rather than stacking up duplicates, so it is the right way to recover a runner
+# that has gone offline or had its token expire.
+#
+# The mini already hosts a runner for another repo. Runners register to exactly
+# one repo, so this installs a SECOND, independent one in its own directory with
+# its own launchd service. It does not touch the existing one.
+
+set -euo pipefail
+
+REPO="${REPO:-dave-hillier-co/thresh}"
+REMOTE_HOST="${REMOTE_HOST:-daves-mac-mini.local}"
+REMOTE_USER="${REMOTE_USER:-davehillier}"
+RUNNER_VERSION="${RUNNER_VERSION:-2.336.0}"
+RUNNER_DIR="${RUNNER_DIR:-\$HOME/actions-runner-thresh}"
+RUNNER_NAME="${RUNNER_NAME:-mac-mini-thresh}"
+RUNNER_LABELS="${RUNNER_LABELS:-self-hosted,macOS,ARM64,thresh}"
+
+# The body that actually runs on the mini. Kept in one place so the local and
+# over-SSH paths cannot drift apart.
+remote_script() {
+  cat <<REMOTE
+set -euo pipefail
+export PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+
+RUNNER_DIR="${RUNNER_DIR}"
+VERSION="${RUNNER_VERSION}"
+TARBALL="actions-runner-osx-arm64-\${VERSION}.tar.gz"
+
+if [ "\$(uname -m)" != "arm64" ]; then
+  echo "expected an Apple-silicon mac; got \$(uname -m). Set RUNNER_VERSION/arch by hand." >&2
+  exit 1
+fi
+
+mkdir -p "\$RUNNER_DIR"
+cd "\$RUNNER_DIR"
+
+# Stop an existing service before reconfiguring, or config.sh refuses.
+# No sudo: the macOS runner installs as a per-user launchd agent, and a sudo
+# password prompt over a non-interactive SSH session would hang forever.
+if [ -f ./svc.sh ]; then
+  echo "-- existing runner found, stopping its service"
+  ./svc.sh stop >/dev/null 2>&1 || true
+fi
+
+if [ ! -f ./config.sh ]; then
+  echo "-- downloading runner \$VERSION"
+  curl -fsSL -o "\$TARBALL" \
+    "https://github.com/actions/runner/releases/download/v\${VERSION}/\${TARBALL}"
+  tar xzf "\$TARBALL"
+  rm -f "\$TARBALL"
+else
+  echo "-- runner already downloaded"
+fi
+
+echo "-- configuring for ${REPO} as ${RUNNER_NAME}"
+./config.sh \
+  --url "https://github.com/${REPO}" \
+  --token "\$RUNNER_TOKEN" \
+  --name "${RUNNER_NAME}" \
+  --labels "${RUNNER_LABELS}" \
+  --work _work \
+  --unattended \
+  --replace
+
+echo "-- installing and starting the launchd service"
+./svc.sh install
+./svc.sh start
+./svc.sh status || true
+
+echo "-- toolchain check (the workflow needs these on PATH)"
+for t in node pnpm docker git; do
+  if command -v "\$t" >/dev/null 2>&1; then
+    echo "   ok   \$t -> \$(command -v \$t)"
+  else
+    echo "   MISSING \$t -- install it on the mini or CI will fail at preflight"
+  fi
+done
+REMOTE
+}
+
+if [ "${LOCAL:-0}" = "1" ]; then
+  : "${RUNNER_TOKEN:?set RUNNER_TOKEN when running with LOCAL=1}"
+  export RUNNER_TOKEN
+  remote_script | bash
+  exit 0
+fi
+
+command -v gh >/dev/null || { echo "gh is required to mint the registration token" >&2; exit 1; }
+
+echo "=== Minting a registration token for ${REPO} ==="
+# Short-lived (about an hour) and single-use, which is why it is minted per run
+# rather than stored anywhere.
+TOKEN="$(gh api -X POST "repos/${REPO}/actions/runners/registration-token" --jq '.token')"
+[ -n "$TOKEN" ] || { echo "failed to mint a registration token" >&2; exit 1; }
+
+echo "=== Checking ${REMOTE_HOST} is reachable ==="
+if ! ssh -o ConnectTimeout=10 -o BatchMode=yes "${REMOTE_USER}@${REMOTE_HOST}" true 2>/dev/null; then
+  echo "cannot reach ${REMOTE_USER}@${REMOTE_HOST} over SSH." >&2
+  echo "Check the mini is awake and on the same network, or set REMOTE_HOST to its IP." >&2
+  exit 1
+fi
+
+echo "=== Installing the runner on ${REMOTE_HOST} ==="
+remote_script | ssh "${REMOTE_USER}@${REMOTE_HOST}" "RUNNER_TOKEN='${TOKEN}' bash -s"
+
+echo ""
+echo "=== Done ==="
+echo "Verify at: https://github.com/${REPO}/settings/actions/runners"


### PR DESCRIPTION
Adds GitHub Actions CI modelled on the `darkvelocity-pos` setup — self-hosted runner, bare-launchd `PATH`, PR-only concurrency cancellation, fast typecheck/lint job gating the slower test job.

Closes the coverage gap flagged in #42: "there is no CI, and 12 unit files are environment-gated on Redis/Postgres/Kafka and did not run."

## The point of it

The Redis, Postgres and Kafka suites probe their service at load time and `describe.skipIf` themselves when it is unreachable. A serviceless run therefore reports green while **12 unit files never execute**. With the services up:

| | files skipped | tests skipped |
|---|---|---|
| without services | 12 | 56 |
| with services | **1** | **4** |

52 previously-dark tests now run, and they pass. CI brings the services up and then **fails the build if more than one unit file skips** — otherwise a service that quietly stops starting degrades into reduced coverage rather than a red build, which is the exact failure this is meant to prevent.

## Non-default ports, deliberately

Services listen on **6390 / 5433 / 9192**, not 6379 / 5432 / 9092.

This was observed, not theorised. The first version of `ensure-services.sh` checked only whether the port was open — the same reuse logic the reference project uses. It reported all three services healthy on this machine, and the skip count did not move at all: another project's Postgres and Redis already hold the default ports, they answer a TCP connect, they are not usable by these suites, so the suites skipped themselves and the run stayed green having tested nothing. Dedicated ports make that impossible. The probes are now protocol round trips (`redis-cli ping`, `pg_isready`, `kafka-broker-api-versions`), not port checks.

## Kafka broker

`apache/kafka` in KRaft mode. Redpanda was tried first for its much faster start, but the pulling-stream and queue suites hang against it. Three consecutive full unit runs against `apache/kafka` are byte-identical (902 passed, 1 file skipped), so the intermittent Kafka failures seen during development were the broker, not flaky tests.

## Runner install

`scripts/setup-ci-runner.sh` installs the runner on the Mac mini over SSH. It mints a short-lived registration token locally via `gh`, so the mini needs no GitHub credentials. Idempotent — re-running reconfigures in place with `--replace`, which is also how to recover a runner that has gone offline. It installs a **second, independent** runner beside the existing darkvelocity one, since a runner registers to exactly one repo.

**This has not been run yet** — the mini was not reachable from this network while the work was done (`daves-mac-mini.local` does not resolve; only an orangepi answers on this subnet). Everything else here is verified locally. Minting a token was confirmed working, so reachability is the only outstanding step.

## Correction to #42

That PR said "95 parity files are environment-gated on Redis/Postgres/Kafka". That was wrong: **zero** parity files touch a backing service. Their 95 skips are deliberate `orleansTest.excluded` backlog entries — that count is the parity metric itself, and it should move when the backlog moves, never because of CI. Only the 12 unit files were service-gated.

## Verification

`pnpm typecheck` and `pnpm lint` clean (the new YAML passes the repo's own prettier check). Three consecutive full unit runs with services up: 902 passed / 1 file skipped, identical each time. Parity: 709 passed / 98 skipped, matching the baseline exactly across three runs.

One caveat worth recording: a parity run *did* fail once, while three unit suites were still running concurrently on the same machine. It passes cleanly whenever run alone. That is contention, not a flaky test — and it is the argument for the workflow keeping its jobs serialized on the single runner rather than fanning out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)