### PR TITLE
Introduce TypeScript-first `GrainKey` marker and migrate examples/interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ the setup context; the returned object is the grain's message surface.
 
 ```ts
 // Interface — the contract callers see. A compile-time view; no method table.
-interface IThermostat extends GrainWithStringKey {
+type Thermostat = GrainKey<string> & {
   onUpdate(status: ThermostatStatus): Promise<Command[]>;
-}
-const IThermostat = defineGrainInterface<IThermostat>("IThermostat");
+};
+const thermostat = defineGrainInterface<Thermostat>("Thermostat");
 
 // Implementation — a factory closure that runs once per activation.
-const ThermostatGrain = defineGrain<IThermostat>("Thermostat", (ctx) => {
+const ThermostatGrain = defineGrain<Thermostat>("Thermostat", (ctx) => {
   const status = usePersistentState<ThermostatStatus>(ctx, "status");
 
   const onUpdate = async (next: ThermostatStatus): Promise<Command[]> => {
@@ -44,8 +44,8 @@ const ThermostatGrain = defineGrain<IThermostat>("Thermostat", (ctx) => {
 });
 
 // Caller — from a web frontend or another grain.
-const thermostat = client.getGrain<IThermostat>(IThermostat, deviceId);
-const commands = await thermostat.onUpdate(update);
+const ref = client.getGrain(thermostat, deviceId);
+const commands = await ref.onUpdate(update);
 ```
 
 `client.getGrain` returns a lightweight proxy; the grain is activated on first call, wherever the
@@ -60,6 +60,8 @@ docs cover only what is worth writing down here:
 
 - [How this differs from Orleans](docs/deviations.md) — the deviations only (TypeScript idioms,
   Kubernetes hosting, functional authoring), each linked to its decision record.
+- [TypeScript grain API idioms](docs/typescript-grain-api.md) — naming and typing guidance for
+  writing grain surfaces without C#-style `I*` interfaces or key marker names.
 - [`EPICS.md`](EPICS.md) — the live status board (shipped vs. remaining).
 
 ## Developing

--- a/docs/typescript-grain-api.md
+++ b/docs/typescript-grain-api.md
@@ -1,0 +1,54 @@
+# TypeScript grain API idioms
+
+Thresh keeps Orleans-compatible names for parity work, but application code can be
+more idiomatic TypeScript than a direct C# port.
+
+## Prefer structural type aliases over `I*` interfaces
+
+A grain surface is just the structural shape of the methods callers can invoke.
+You do not need an `I` prefix or declaration-merging-style names.
+
+```ts
+import { defineGrain } from "@thresh/core/define-grain";
+import { defineGrainInterface } from "@thresh/core/grain-interface";
+import type { GrainKey } from "@thresh/core/key-kinds";
+
+type Thermostat = GrainKey<string> & {
+  onUpdate(status: ThermostatStatus): Promise<Command[]>;
+};
+
+const thermostat = defineGrainInterface<Thermostat>("example.Thermostat");
+
+const ThermostatGrain = defineGrain<Thermostat>("Thermostat", (ctx) => ({
+  async onUpdate(status) {
+    // ...
+    return [];
+  },
+}));
+```
+
+This reads like ordinary TypeScript: a lowercase value (`thermostat`) carries the
+runtime descriptor, while the `Thermostat` type is erased at compile time.
+
+## Use `GrainKey<TKey>` for key type, not Orleans marker names
+
+The older `GrainWithStringKey`, `GrainWithIntegerKey`, and compound-key marker
+interfaces remain supported because they map directly to Orleans concepts. For
+new TypeScript code, `GrainKey<TKey>` or `KeyedGrain<TKey>` makes the API intent
+clear without encoding the key kind in a C#-style interface name.
+
+```ts
+type Account = GrainKey<bigint> & {
+  deposit(cents: number): Promise<void>;
+  balance(): Promise<number>;
+};
+```
+
+If no key marker is present, `getGrain` still defaults to `string` keys for
+backwards compatibility.
+
+## Keep `defineGrainInterface` as the runtime descriptor
+
+TypeScript erases interfaces and type aliases, so Thresh still needs a value to
+carry the stable interface id, version, and per-method invocation options. Treat
+that value like a schema or route descriptor rather than a C# interface object.

--- a/examples/bank/src/account-grain-functional.ts
+++ b/examples/bank/src/account-grain-functional.ts
@@ -1,6 +1,7 @@
 import { defineGrain, useReducerState } from "@thresh/core/define-grain";
 import {
-  IAccount,
+  account,
+  type Account,
   initialAccount,
   reduceAccount,
   type AccountEvent,
@@ -15,7 +16,7 @@ import {
  * state. Compare with `account-reducer-grain.ts`, which reduces the same model to
  * a single `dispatch`/`query` surface with no per-method interface.
  */
-export const AccountGrain = defineGrain<IAccount>("Account", (ctx) => {
+export const AccountGrain = defineGrain<Account>("Account", (ctx) => {
   const state = useReducerState<AccountState, AccountEvent>(ctx, "account", {
     initial: initialAccount,
     reduce: reduceAccount,
@@ -38,7 +39,7 @@ export const AccountGrain = defineGrain<IAccount>("Account", (ctx) => {
 
   const transferTo = async (other: string, cents: number): Promise<number> => {
     const remaining = await withdraw(cents);
-    await ctx.getGrain(IAccount, other).deposit(cents);
+    await ctx.getGrain(account, other).deposit(cents);
     return remaining;
   };
 

--- a/examples/bank/src/account-transactional.ts
+++ b/examples/bank/src/account-transactional.ts
@@ -1,6 +1,6 @@
 import { defineGrain, useTransactionalState } from "@thresh/core/define-grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /**
  * A bank account whose balance is **transactional** state. Unlike the
@@ -13,13 +13,13 @@ interface Balance {
   cents: number;
 }
 
-export interface ITxAccount extends GrainWithStringKey {
+export type TxAccount = GrainKey<string> & {
   deposit(cents: number): Promise<void>;
   withdraw(cents: number): Promise<void>;
   balance(): Promise<number>;
-}
+};
 
-export const ITxAccount = defineGrainInterface<ITxAccount>("example.bank.ITxAccount", {
+export const txAccount = defineGrainInterface<TxAccount>("example.bank.txAccount", {
   options: {
     deposit: { transaction: "join" },
     withdraw: { transaction: "join" },
@@ -27,19 +27,19 @@ export const ITxAccount = defineGrainInterface<ITxAccount>("example.bank.ITxAcco
   },
 });
 
-export interface ITeller extends GrainWithStringKey {
+export type Teller = GrainKey<string> & {
   open(account: string, cents: number): Promise<void>;
   transfer(from: string, to: string, cents: number): Promise<void>;
-}
+};
 
-export const ITeller = defineGrainInterface<ITeller>("example.bank.ITeller", {
+export const teller = defineGrainInterface<Teller>("example.bank.teller", {
   options: {
     open: { transaction: "create" },
     transfer: { transaction: "create" },
   },
 });
 
-export const TxAccountGrain = defineGrain<ITxAccount>("TxAccount", (ctx) => {
+export const TxAccountGrain = defineGrain<TxAccount>("TxAccount", (ctx) => {
   const balance = useTransactionalState<Balance>(ctx, "balance", {
     initial: () => ({ cents: 0 }),
   });
@@ -57,14 +57,14 @@ export const TxAccountGrain = defineGrain<ITxAccount>("TxAccount", (ctx) => {
   };
 });
 
-export const TellerGrain = defineGrain<ITeller>("Teller", (ctx) => ({
+export const TellerGrain = defineGrain<Teller>("Teller", (ctx) => ({
   open: async (account, cents) => {
-    await ctx.getGrain(ITxAccount, account).deposit(cents);
+    await ctx.getGrain(txAccount, account).deposit(cents);
   },
   // One transaction spanning both accounts: credit then debit. If the debit
   // overdraws and throws, the whole transaction aborts and the credit is undone.
   transfer: async (from, to, cents) => {
-    await ctx.getGrain(ITxAccount, to).deposit(cents);
-    await ctx.getGrain(ITxAccount, from).withdraw(cents);
+    await ctx.getGrain(txAccount, to).deposit(cents);
+    await ctx.getGrain(txAccount, from).withdraw(cents);
   },
 }));

--- a/examples/bank/src/bank-functional.test.ts
+++ b/examples/bank/src/bank-functional.test.ts
@@ -5,7 +5,7 @@ import { MemoryGrainStorage } from "@thresh/persistence/memory-grain-storage";
 import { createSilo } from "@thresh/hosting/silo-builder";
 import type { SiloHost } from "@thresh/hosting/silo-host";
 import { AccountGrain } from "@thresh/example-bank/account-grain-functional";
-import { IAccount } from "@thresh/example-bank/interfaces";
+import { account } from "@thresh/example-bank/interfaces";
 
 const local = new SiloAddress("silo-0", "uid-0", "silo-0:11111");
 
@@ -14,7 +14,7 @@ function buildSilo(storage: MemoryGrainStorage): SiloHost {
     .useStaticMembership([local])
     .useInProcessTransport(new InProcessNetwork())
     .useMemoryStorage(storage)
-    .registerGrain(AccountGrain, { interfaces: [IAccount] })
+    .registerGrain(AccountGrain, { interfaces: [account] })
     .build();
 }
 
@@ -26,12 +26,12 @@ describe("functional reducer grain (defineGrain)", () => {
     let alice: unknown;
     let bob: unknown;
     try {
-      await silo.getGrain(IAccount, "alice").deposit(10_000);
-      await silo.getGrain(IAccount, "alice").deposit(5_000);
-      await silo.getGrain(IAccount, "bob").deposit(2_000);
-      await silo.getGrain(IAccount, "alice").transferTo("bob", 3_000);
-      alice = await silo.getGrain(IAccount, "alice").statement();
-      bob = await silo.getGrain(IAccount, "bob").statement();
+      await silo.getGrain(account, "alice").deposit(10_000);
+      await silo.getGrain(account, "alice").deposit(5_000);
+      await silo.getGrain(account, "bob").deposit(2_000);
+      await silo.getGrain(account, "alice").transferTo("bob", 3_000);
+      alice = await silo.getGrain(account, "alice").statement();
+      bob = await silo.getGrain(account, "bob").statement();
     } finally {
       await silo.stop();
     }
@@ -42,7 +42,7 @@ describe("functional reducer grain (defineGrain)", () => {
     const restarted = buildSilo(storage); // new pod, same durable store
     await restarted.start();
     try {
-      expect(await restarted.getGrain(IAccount, "alice").statement()).toEqual(alice);
+      expect(await restarted.getGrain(account, "alice").statement()).toEqual(alice);
     } finally {
       await restarted.stop();
     }
@@ -52,7 +52,7 @@ describe("functional reducer grain (defineGrain)", () => {
     const silo = buildSilo(new MemoryGrainStorage());
     await silo.start();
     try {
-      const acct = silo.getGrain(IAccount, "x");
+      const acct = silo.getGrain(account, "x");
       await acct.deposit(1_000);
       await expect(acct.withdraw(5_000)).rejects.toThrow(/insufficient/);
       expect(await acct.statement()).toEqual({ balanceCents: 1_000, deposits: 1, withdrawals: 0 });

--- a/examples/bank/src/bank-transactional.test.ts
+++ b/examples/bank/src/bank-transactional.test.ts
@@ -4,8 +4,8 @@ import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
 import { createSilo } from "@thresh/hosting/silo-builder";
 import type { SiloHost } from "@thresh/hosting/silo-host";
 import {
-  ITeller,
-  ITxAccount,
+  teller,
+  txAccount,
   TellerGrain,
   TxAccountGrain,
 } from "@thresh/example-bank/account-transactional";
@@ -16,8 +16,8 @@ function buildSilo(): SiloHost {
   return createSilo({ clusterId: "bank-tx", local })
     .useStaticMembership([local])
     .useInProcessTransport(new InProcessNetwork())
-    .registerGrain(TxAccountGrain, { interfaces: [ITxAccount] })
-    .registerGrain(TellerGrain, { interfaces: [ITeller] })
+    .registerGrain(TxAccountGrain, { interfaces: [txAccount] })
+    .registerGrain(TellerGrain, { interfaces: [teller] })
     .build();
 }
 
@@ -26,12 +26,12 @@ describe("transactional bank account (Phase 7)", () => {
     const silo = buildSilo();
     await silo.start();
     try {
-      const teller = silo.getGrain(ITeller, "main");
-      await teller.open("alice", 10_000);
-      await teller.transfer("alice", "bob", 3_000);
+      const tellerRef = silo.getGrain(teller, "main");
+      await tellerRef.open("alice", 10_000);
+      await tellerRef.transfer("alice", "bob", 3_000);
 
-      expect(await silo.getGrain(ITxAccount, "alice").balance()).toBe(7_000);
-      expect(await silo.getGrain(ITxAccount, "bob").balance()).toBe(3_000);
+      expect(await silo.getGrain(txAccount, "alice").balance()).toBe(7_000);
+      expect(await silo.getGrain(txAccount, "bob").balance()).toBe(3_000);
     } finally {
       await silo.stop();
     }
@@ -41,14 +41,14 @@ describe("transactional bank account (Phase 7)", () => {
     const silo = buildSilo();
     await silo.start();
     try {
-      const teller = silo.getGrain(ITeller, "main");
-      await teller.open("alice", 1_000);
+      const tellerRef = silo.getGrain(teller, "main");
+      await tellerRef.open("alice", 1_000);
 
-      await expect(teller.transfer("alice", "bob", 5_000)).rejects.toThrow(/insufficient/);
+      await expect(tellerRef.transfer("alice", "bob", 5_000)).rejects.toThrow(/insufficient/);
 
       // The credit to bob was rolled back along with the failed debit.
-      expect(await silo.getGrain(ITxAccount, "alice").balance()).toBe(1_000);
-      expect(await silo.getGrain(ITxAccount, "bob").balance()).toBe(0);
+      expect(await silo.getGrain(txAccount, "alice").balance()).toBe(1_000);
+      expect(await silo.getGrain(txAccount, "bob").balance()).toBe(0);
     } finally {
       await silo.stop();
     }

--- a/examples/bank/src/bank.test.ts
+++ b/examples/bank/src/bank.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { MemoryGrainStorage } from "@thresh/persistence/memory-grain-storage";
 import { buildBankSilo, runBankDemo } from "@thresh/example-bank/demo";
-import { IAccount } from "@thresh/example-bank/interfaces";
+import { account } from "@thresh/example-bank/interfaces";
 
 describe("bank reducer grains", () => {
   it("runs the demo end-to-end: events fold to state, transfer moves funds, snapshot survives restart", async () => {
@@ -19,7 +19,7 @@ describe("bank reducer grains", () => {
     const silo = buildBankSilo(new MemoryGrainStorage());
     await silo.start();
     try {
-      const acct = silo.getGrain(IAccount, "x");
+      const acct = silo.getGrain(account, "x");
       await acct.deposit(1_000);
       await expect(acct.withdraw(5_000)).rejects.toThrow(/insufficient/);
       expect(await acct.statement()).toEqual({ balanceCents: 1_000, deposits: 1, withdrawals: 0 });

--- a/examples/bank/src/demo.ts
+++ b/examples/bank/src/demo.ts
@@ -4,7 +4,7 @@ import { MemoryGrainStorage } from "@thresh/persistence/memory-grain-storage";
 import { createSilo } from "@thresh/hosting/silo-builder";
 import type { SiloHost } from "@thresh/hosting/silo-host";
 import { AccountGrain } from "@thresh/example-bank/account-grain-functional";
-import { IAccount, type AccountState } from "@thresh/example-bank/interfaces";
+import { account, type AccountState } from "@thresh/example-bank/interfaces";
 
 export interface BankDemoResult {
   alice: AccountState;
@@ -20,7 +20,7 @@ export function buildBankSilo(storage: MemoryGrainStorage): SiloHost {
     .useStaticMembership([local])
     .useInProcessTransport(new InProcessNetwork())
     .useMemoryStorage(storage)
-    .registerGrain(AccountGrain, { interfaces: [IAccount] })
+    .registerGrain(AccountGrain, { interfaces: [account] })
     .build();
 }
 
@@ -38,12 +38,12 @@ export async function runBankDemo(): Promise<BankDemoResult> {
   let alice: AccountState;
   let bob: AccountState;
   try {
-    await silo.getGrain(IAccount, "alice").deposit(10_000); // $100.00
-    await silo.getGrain(IAccount, "alice").deposit(5_000); // $50.00
-    await silo.getGrain(IAccount, "bob").deposit(2_000); // $20.00
-    await silo.getGrain(IAccount, "alice").transferTo("bob", 3_000); // $30.00 → bob
-    alice = await silo.getGrain(IAccount, "alice").statement();
-    bob = await silo.getGrain(IAccount, "bob").statement();
+    await silo.getGrain(account, "alice").deposit(10_000); // $100.00
+    await silo.getGrain(account, "alice").deposit(5_000); // $50.00
+    await silo.getGrain(account, "bob").deposit(2_000); // $20.00
+    await silo.getGrain(account, "alice").transferTo("bob", 3_000); // $30.00 → bob
+    alice = await silo.getGrain(account, "alice").statement();
+    bob = await silo.getGrain(account, "bob").statement();
   } finally {
     await silo.stop(); // pod dies; only the folded snapshot is durable
   }
@@ -51,7 +51,7 @@ export async function runBankDemo(): Promise<BankDemoResult> {
   const restarted = buildBankSilo(storage); // new pod, same durable store
   await restarted.start();
   try {
-    const aliceAfterRestart = await restarted.getGrain(IAccount, "alice").statement();
+    const aliceAfterRestart = await restarted.getGrain(account, "alice").statement();
     return { alice, bob, aliceAfterRestart };
   } finally {
     await restarted.stop();

--- a/examples/bank/src/interfaces.ts
+++ b/examples/bank/src/interfaces.ts
@@ -1,5 +1,5 @@
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /** Past-tense facts a reducer folds into account state. Never persisted in snapshot mode. */
 export type AccountEvent =
@@ -30,14 +30,14 @@ export const reduceAccount = (state: AccountState, event: AccountEvent): Account
       };
 
 /** An account aggregate keyed by account number. */
-export interface IAccount extends GrainWithStringKey {
+export type Account = GrainKey<string> & {
   deposit(cents: number): Promise<number>;
   withdraw(cents: number): Promise<number>;
   /** Move money to another account (two-step, not an atomic distributed transaction). */
   transferTo(other: string, cents: number): Promise<number>;
   statement(): Promise<AccountState>;
-}
+};
 
-export const IAccount = defineGrainInterface<IAccount>("example.bank.IAccount", {
+export const account = defineGrainInterface<Account>("example.bank.account", {
   options: { statement: { readOnly: true } },
 });

--- a/examples/broadcast/src/alert-publisher-grain.ts
+++ b/examples/broadcast/src/alert-publisher-grain.ts
@@ -1,12 +1,12 @@
 import { defineGrain } from "@thresh/core/define-grain";
-import { type Alert, type IAlertPublisher } from "@thresh/example-broadcast/interfaces";
+import { type Alert, type AlertPublisher } from "@thresh/example-broadcast/interfaces";
 
 /**
  * Publishes an alert to a region's broadcast channel `(alerts, region)`. Every
  * grain type implicitly subscribed to the `alerts` namespace and keyed by that
  * region receives it — no subscription bookkeeping, no durable queue.
  */
-export const AlertPublisherGrain = defineGrain<IAlertPublisher>("AlertPublisher", (ctx) => ({
+export const AlertPublisherGrain = defineGrain<AlertPublisher>("AlertPublisher", (ctx) => ({
   raise: async (region, text) => {
     const alert: Alert = { region, text };
     await ctx.runtime

--- a/examples/broadcast/src/audit-log-grain.ts
+++ b/examples/broadcast/src/audit-log-grain.ts
@@ -3,7 +3,7 @@ import {
   type BroadcastChannelHandler,
 } from "@thresh/core/broadcast-channel";
 import { defineGrain } from "@thresh/core/define-grain";
-import { type Alert, type IAuditLog } from "@thresh/example-broadcast/interfaces";
+import { type Alert, type AuditLog } from "@thresh/example-broadcast/interfaces";
 
 /**
  * A second grain type also implicitly subscribed to the `alerts` namespace. One
@@ -11,7 +11,7 @@ import { type Alert, type IAuditLog } from "@thresh/example-broadcast/interfaces
  * the region `R` audit log records the same alert the region `R` monitor sees,
  * demonstrating multi-type fan-out on a single channel.
  */
-export const AuditLogGrain = defineGrain<IAuditLog>(
+export const AuditLogGrain = defineGrain<AuditLog>(
   "AuditLog",
   () => {
     const log: string[] = [];

--- a/examples/broadcast/src/broadcast.test.ts
+++ b/examples/broadcast/src/broadcast.test.ts
@@ -7,7 +7,7 @@ import { AlertPublisherGrain } from "@thresh/example-broadcast/alert-publisher-g
 import { AuditLogGrain } from "@thresh/example-broadcast/audit-log-grain";
 import { RegionMonitorGrain } from "@thresh/example-broadcast/region-monitor-grain";
 import { runBroadcastDemo } from "@thresh/example-broadcast/demo";
-import { IAlertPublisher, IAuditLog, IRegionMonitor } from "@thresh/example-broadcast/interfaces";
+import { alertPublisher, auditLog, regionMonitor } from "@thresh/example-broadcast/interfaces";
 
 const local = new SiloAddress("silo-0", "uid-0", "silo-0:11111");
 
@@ -16,9 +16,9 @@ function buildSilo(): SiloHost {
     .useStaticMembership([local])
     .useInProcessTransport(new InProcessNetwork())
     .useBroadcastChannels()
-    .registerGrain(AlertPublisherGrain, { interfaces: [IAlertPublisher] })
-    .registerGrain(RegionMonitorGrain, { interfaces: [IRegionMonitor] })
-    .registerGrain(AuditLogGrain, { interfaces: [IAuditLog] })
+    .registerGrain(AlertPublisherGrain, { interfaces: [alertPublisher] })
+    .registerGrain(RegionMonitorGrain, { interfaces: [regionMonitor] })
+    .registerGrain(AuditLogGrain, { interfaces: [auditLog] })
     .build();
 }
 
@@ -27,11 +27,11 @@ describe("broadcast channels (pub/sub fan-out acceptance)", () => {
     const silo = buildSilo();
     await silo.start();
     try {
-      await silo.getGrain(IAlertPublisher, "ops").raise("eu", "disk pressure");
+      await silo.getGrain(alertPublisher, "ops").raise("eu", "disk pressure");
       // Both the region monitor and the region audit log — distinct grain types
       // implicitly subscribed to "alerts" — receive the same publish.
-      const monitor = await silo.getGrain(IRegionMonitor, "eu").alerts();
-      const audit = await silo.getGrain(IAuditLog, "eu").entries();
+      const monitor = await silo.getGrain(regionMonitor, "eu").alerts();
+      const audit = await silo.getGrain(auditLog, "eu").entries();
       expect(monitor.map((a) => a.text)).toEqual(["disk pressure"]);
       expect(audit).toEqual(["[eu] disk pressure"]);
     } finally {
@@ -43,12 +43,12 @@ describe("broadcast channels (pub/sub fan-out acceptance)", () => {
     const silo = buildSilo();
     await silo.start();
     try {
-      await silo.getGrain(IAlertPublisher, "ops").raise("eu", "eu-only");
-      expect((await silo.getGrain(IRegionMonitor, "eu").alerts()).map((a) => a.text)).toEqual([
+      await silo.getGrain(alertPublisher, "ops").raise("eu", "eu-only");
+      expect((await silo.getGrain(regionMonitor, "eu").alerts()).map((a) => a.text)).toEqual([
         "eu-only",
       ]);
       // The us monitor was never published to, so it has seen nothing.
-      expect(await silo.getGrain(IRegionMonitor, "us").alerts()).toEqual([]);
+      expect(await silo.getGrain(regionMonitor, "us").alerts()).toEqual([]);
     } finally {
       await silo.stop();
     }

--- a/examples/broadcast/src/demo.ts
+++ b/examples/broadcast/src/demo.ts
@@ -5,7 +5,7 @@ import type { SiloHost } from "@thresh/hosting/silo-host";
 import { AlertPublisherGrain } from "@thresh/example-broadcast/alert-publisher-grain";
 import { AuditLogGrain } from "@thresh/example-broadcast/audit-log-grain";
 import { RegionMonitorGrain } from "@thresh/example-broadcast/region-monitor-grain";
-import { IAlertPublisher, IAuditLog, IRegionMonitor } from "@thresh/example-broadcast/interfaces";
+import { alertPublisher, auditLog, regionMonitor } from "@thresh/example-broadcast/interfaces";
 
 const local = new SiloAddress("silo-0", "uid-0", "silo-0:11111");
 
@@ -15,9 +15,9 @@ export function buildBroadcastSilo(): SiloHost {
     .useStaticMembership([local])
     .useInProcessTransport(new InProcessNetwork())
     .useBroadcastChannels()
-    .registerGrain(AlertPublisherGrain, { interfaces: [IAlertPublisher] })
-    .registerGrain(RegionMonitorGrain, { interfaces: [IRegionMonitor] })
-    .registerGrain(AuditLogGrain, { interfaces: [IAuditLog] })
+    .registerGrain(AlertPublisherGrain, { interfaces: [alertPublisher] })
+    .registerGrain(RegionMonitorGrain, { interfaces: [regionMonitor] })
+    .registerGrain(AuditLogGrain, { interfaces: [auditLog] })
     .build();
 }
 
@@ -37,7 +37,7 @@ export async function runBroadcastDemo(): Promise<BroadcastDemoResult> {
   const silo = buildBroadcastSilo();
   await silo.start();
   try {
-    const publisher = silo.getGrain(IAlertPublisher, "ops");
+    const publisher = silo.getGrain(alertPublisher, "ops");
     await publisher.raise("eu", "disk pressure");
     await publisher.raise("eu", "node drained");
     await publisher.raise("us", "latency spike");
@@ -45,8 +45,8 @@ export async function runBroadcastDemo(): Promise<BroadcastDemoResult> {
     const monitors: Record<string, string[]> = {};
     const audits: Record<string, string[]> = {};
     for (const region of ["eu", "us"]) {
-      monitors[region] = (await silo.getGrain(IRegionMonitor, region).alerts()).map((a) => a.text);
-      audits[region] = await silo.getGrain(IAuditLog, region).entries();
+      monitors[region] = (await silo.getGrain(regionMonitor, region).alerts()).map((a) => a.text);
+      audits[region] = await silo.getGrain(auditLog, region).entries();
     }
     return { monitors, audits };
   } finally {

--- a/examples/broadcast/src/interfaces.ts
+++ b/examples/broadcast/src/interfaces.ts
@@ -1,5 +1,5 @@
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /** One alert broadcast to a region's channel. */
 export interface Alert {
@@ -8,19 +8,19 @@ export interface Alert {
 }
 
 /** Publishes alerts to a region's broadcast channel. */
-export interface IAlertPublisher extends GrainWithStringKey {
+export type AlertPublisher = GrainKey<string> & {
   raise(region: string, text: string): Promise<void>;
-}
-export const IAlertPublisher = defineGrainInterface<IAlertPublisher>("IAlertPublisher.broadcast");
+};
+export const alertPublisher = defineGrainInterface<AlertPublisher>("alertPublisher.broadcast");
 
 /** A per-region dashboard that shows the alerts it has received. */
-export interface IRegionMonitor extends GrainWithStringKey {
+export type RegionMonitor = GrainKey<string> & {
   alerts(): Promise<Alert[]>;
-}
-export const IRegionMonitor = defineGrainInterface<IRegionMonitor>("IRegionMonitor.broadcast");
+};
+export const regionMonitor = defineGrainInterface<RegionMonitor>("regionMonitor.broadcast");
 
 /** A per-region audit log that records every alert it has received. */
-export interface IAuditLog extends GrainWithStringKey {
+export type AuditLog = GrainKey<string> & {
   entries(): Promise<string[]>;
-}
-export const IAuditLog = defineGrainInterface<IAuditLog>("IAuditLog.broadcast");
+};
+export const auditLog = defineGrainInterface<AuditLog>("auditLog.broadcast");

--- a/examples/broadcast/src/region-monitor-grain.ts
+++ b/examples/broadcast/src/region-monitor-grain.ts
@@ -3,7 +3,7 @@ import {
   type BroadcastChannelHandler,
 } from "@thresh/core/broadcast-channel";
 import { defineGrain } from "@thresh/core/define-grain";
-import { type Alert, type IRegionMonitor } from "@thresh/example-broadcast/interfaces";
+import { type Alert, type RegionMonitor } from "@thresh/example-broadcast/interfaces";
 
 /**
  * A per-region dashboard, implicitly subscribed to the `alerts` namespace. A
@@ -12,7 +12,7 @@ import { type Alert, type IRegionMonitor } from "@thresh/example-broadcast/inter
  * handler as a turn, with no explicit subscribe. It accumulates what it has seen
  * since this activation.
  */
-export const RegionMonitorGrain = defineGrain<IRegionMonitor>(
+export const RegionMonitorGrain = defineGrain<RegionMonitor>(
   "RegionMonitor",
   () => {
     const received: Alert[] = [];

--- a/examples/chat/src/chat-room-grain.ts
+++ b/examples/chat/src/chat-room-grain.ts
@@ -1,12 +1,12 @@
 import { defineGrain } from "@thresh/core/define-grain";
-import { CHAT, type ChatMessage, type IChatRoom } from "@thresh/example-chat/interfaces";
+import { CHAT, type ChatMessage, type ChatRoom } from "@thresh/example-chat/interfaces";
 
 /**
  * A chat room is a pure fan-out point: `say` publishes to the room's telemetry
  * stream and every member that subscribed receives it. The room holds no member
  * list — the stream is the membership.
  */
-export const ChatRoomGrain = defineGrain<IChatRoom>("ChatRoom", (ctx) => ({
+export const ChatRoomGrain = defineGrain<ChatRoom>("ChatRoom", (ctx) => ({
   say: async (from: string, text: string): Promise<void> => {
     await ctx.runtime
       .getStreamProvider()

--- a/examples/chat/src/chat-user-grain.ts
+++ b/examples/chat/src/chat-user-grain.ts
@@ -1,6 +1,6 @@
 import { defineGrain } from "@thresh/core/define-grain";
 import type { StreamHandler } from "@thresh/core/stream";
-import { CHAT, type ChatMessage, type IChatUser } from "@thresh/example-chat/interfaces";
+import { CHAT, type ChatMessage, type ChatUser } from "@thresh/example-chat/interfaces";
 
 /**
  * A chat member. `join` subscribes to the room stream — or, if this activation
@@ -12,7 +12,7 @@ import { CHAT, type ChatMessage, type IChatUser } from "@thresh/example-chat/int
  * neighbour's. `onNext` mutates `received` with no lock — proof it runs as a
  * turn on this activation.
  */
-export const ChatUserGrain = defineGrain<IChatUser>("ChatUser", (ctx) => {
+export const ChatUserGrain = defineGrain<ChatUser>("ChatUser", (ctx) => {
   const received: ChatMessage[] = [];
 
   const handler = (): StreamHandler<ChatMessage> => ({

--- a/examples/chat/src/chat.test.ts
+++ b/examples/chat/src/chat.test.ts
@@ -8,7 +8,7 @@ import type { SiloHost } from "@thresh/hosting/silo-host";
 import { ChatRoomGrain } from "@thresh/example-chat/chat-room-grain";
 import { ChatUserGrain } from "@thresh/example-chat/chat-user-grain";
 import { runChatDemo } from "@thresh/example-chat/demo";
-import { IChatRoom, IChatUser } from "@thresh/example-chat/interfaces";
+import { chatRoom, chatUser } from "@thresh/example-chat/interfaces";
 
 const local = new SiloAddress("silo-0", "uid-0", "silo-0:11111");
 const flush = () => new Promise((r) => setTimeout(r, 0));
@@ -25,8 +25,8 @@ function buildChatSilo(time?: FakeTimeProvider): SiloHost {
     .useStaticMembership([local])
     .useInProcessTransport(new InProcessNetwork())
     .useMemoryStreams()
-    .registerGrain(ChatRoomGrain, { interfaces: [IChatRoom] })
-    .registerGrain(ChatUserGrain, { interfaces: [IChatUser] })
+    .registerGrain(ChatRoomGrain, { interfaces: [chatRoom] })
+    .registerGrain(ChatUserGrain, { interfaces: [chatUser] })
     .build();
 }
 
@@ -36,14 +36,14 @@ describe("chat room (stream fan-out acceptance)", () => {
     await silo.start();
     try {
       for (const name of ["alice", "bob", "carol"]) {
-        await silo.getGrain(IChatUser, name).join("general");
+        await silo.getGrain(chatUser, name).join("general");
       }
-      await silo.getGrain(IChatRoom, "general").say("alice", "hi all");
-      await silo.getGrain(IChatRoom, "general").say("bob", "hey");
+      await silo.getGrain(chatRoom, "general").say("alice", "hi all");
+      await silo.getGrain(chatRoom, "general").say("bob", "hey");
       await flush();
 
       for (const name of ["alice", "bob", "carol"]) {
-        expect(texts(await silo.getGrain(IChatUser, name).history())).toEqual(["hi all", "hey"]);
+        expect(texts(await silo.getGrain(chatUser, name).history())).toEqual(["hi all", "hey"]);
       }
     } finally {
       await silo.stop();
@@ -54,13 +54,13 @@ describe("chat room (stream fan-out acceptance)", () => {
     const silo = buildChatSilo();
     await silo.start();
     try {
-      await silo.getGrain(IChatUser, "amy").join("red");
-      await silo.getGrain(IChatUser, "ben").join("blue");
-      await silo.getGrain(IChatRoom, "red").say("amy", "red-only");
+      await silo.getGrain(chatUser, "amy").join("red");
+      await silo.getGrain(chatUser, "ben").join("blue");
+      await silo.getGrain(chatRoom, "red").say("amy", "red-only");
       await flush();
 
-      expect(texts(await silo.getGrain(IChatUser, "amy").history())).toEqual(["red-only"]);
-      expect(await silo.getGrain(IChatUser, "ben").history()).toEqual([]);
+      expect(texts(await silo.getGrain(chatUser, "amy").history())).toEqual(["red-only"]);
+      expect(await silo.getGrain(chatUser, "ben").history()).toEqual([]);
     } finally {
       await silo.stop();
     }
@@ -71,31 +71,31 @@ describe("chat room (stream fan-out acceptance)", () => {
     const silo = buildChatSilo(time);
     await silo.start();
     try {
-      await silo.getGrain(IChatUser, "alice").join("general");
-      await silo.getGrain(IChatUser, "bob").join("general");
-      await silo.getGrain(IChatRoom, "general").say("alice", "m1");
+      await silo.getGrain(chatUser, "alice").join("general");
+      await silo.getGrain(chatUser, "bob").join("general");
+      await silo.getGrain(chatRoom, "general").say("alice", "m1");
       await flush();
 
       // Keep alice active past one sweep; let bob fall idle and be collected.
       time.advance(25_000);
-      await silo.getGrain(IChatUser, "alice").history();
+      await silo.getGrain(chatUser, "alice").history();
       time.advance(20_000);
       await flush();
       expect(silo.isActive(new GrainId("ChatUser", "bob"))).toBe(false);
 
       // Messages bob misses while away; alice (still active) receives them live,
       // advancing alice's cursor past bob's.
-      await silo.getGrain(IChatRoom, "general").say("alice", "m2");
-      await silo.getGrain(IChatRoom, "general").say("alice", "m3");
+      await silo.getGrain(chatRoom, "general").say("alice", "m2");
+      await silo.getGrain(chatRoom, "general").say("alice", "m3");
       await flush();
-      expect(texts(await silo.getGrain(IChatUser, "alice").history())).toEqual(["m1", "m2", "m3"]);
+      expect(texts(await silo.getGrain(chatUser, "alice").history())).toEqual(["m1", "m2", "m3"]);
 
       // Bob rejoins: it must resume ITS OWN subscription (cursor at m1), receiving
       // only the two it missed — not alice's already-consumed position (which would
       // yield nothing).
-      await silo.getGrain(IChatUser, "bob").join("general");
+      await silo.getGrain(chatUser, "bob").join("general");
       await flush();
-      expect(texts(await silo.getGrain(IChatUser, "bob").history())).toEqual(["m2", "m3"]);
+      expect(texts(await silo.getGrain(chatUser, "bob").history())).toEqual(["m2", "m3"]);
     } finally {
       await silo.stop();
     }

--- a/examples/chat/src/demo.ts
+++ b/examples/chat/src/demo.ts
@@ -5,7 +5,7 @@ import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
 import { createSilo } from "@thresh/hosting/silo-builder";
 import { ChatRoomGrain } from "@thresh/example-chat/chat-room-grain";
 import { ChatUserGrain } from "@thresh/example-chat/chat-user-grain";
-import { IChatRoom, IChatUser, type ChatMessage } from "@thresh/example-chat/interfaces";
+import { chatRoom, chatUser, type ChatMessage } from "@thresh/example-chat/interfaces";
 
 export interface ChatDemoResult {
   /** Messages each member received during the fan-out phase. */
@@ -37,37 +37,37 @@ export async function runChatDemo(): Promise<ChatDemoResult> {
     .useStaticMembership([local])
     .useInProcessTransport(new InProcessNetwork())
     .useMemoryStreams()
-    .registerGrain(ChatRoomGrain, { interfaces: [IChatRoom] })
-    .registerGrain(ChatUserGrain, { interfaces: [IChatUser] })
+    .registerGrain(ChatRoomGrain, { interfaces: [chatRoom] })
+    .registerGrain(ChatUserGrain, { interfaces: [chatUser] })
     .build();
 
   await silo.start();
   try {
     const members = ["alice", "bob", "carol"];
-    for (const name of members) await silo.getGrain(IChatUser, name).join("general");
+    for (const name of members) await silo.getGrain(chatUser, name).join("general");
 
-    await silo.getGrain(IChatRoom, "general").say("alice", "hello everyone");
+    await silo.getGrain(chatRoom, "general").say("alice", "hello everyone");
     await tick();
 
     const fanOut: Record<string, ChatMessage[]> = {};
-    for (const name of members) fanOut[name] = await silo.getGrain(IChatUser, name).history();
+    for (const name of members) fanOut[name] = await silo.getGrain(chatUser, name).history();
 
     // Keep alice active across a sweep; let bob fall idle and be collected.
     time.advance(25_000);
-    await silo.getGrain(IChatUser, "alice").history();
+    await silo.getGrain(chatUser, "alice").history();
     time.advance(20_000);
     await tick();
     const bobCollected = !silo.isActive(new GrainId("ChatUser", "bob"));
 
     // Two messages land while bob is away; alice still receives them live.
-    await silo.getGrain(IChatRoom, "general").say("alice", "you around?");
-    await silo.getGrain(IChatRoom, "general").say("carol", "guess not");
+    await silo.getGrain(chatRoom, "general").say("alice", "you around?");
+    await silo.getGrain(chatRoom, "general").say("carol", "guess not");
     await tick();
 
     // Bob comes back and resumes its own subscription from where it left off.
-    await silo.getGrain(IChatUser, "bob").join("general");
+    await silo.getGrain(chatUser, "bob").join("general");
     await tick();
-    const bobHistory = await silo.getGrain(IChatUser, "bob").history();
+    const bobHistory = await silo.getGrain(chatUser, "bob").history();
 
     return {
       fanOut,

--- a/examples/chat/src/interfaces.ts
+++ b/examples/chat/src/interfaces.ts
@@ -1,5 +1,5 @@
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 export interface ChatMessage {
   from: string;
@@ -7,19 +7,19 @@ export interface ChatMessage {
 }
 
 /** A room: anyone can say something; the text fans out to every member. */
-export interface IChatRoom extends GrainWithStringKey {
+export type ChatRoom = GrainKey<string> & {
   say(from: string, text: string): Promise<void>;
-}
+};
 
 /** A member: joins a room and accumulates the messages it receives. */
-export interface IChatUser extends GrainWithStringKey {
+export type ChatUser = GrainKey<string> & {
   join(room: string): Promise<void>;
   history(): Promise<ChatMessage[]>;
-}
+};
 
-export const IChatRoom = defineGrainInterface<IChatRoom>("example.IChatRoom");
+export const chatRoom = defineGrainInterface<ChatRoom>("example.chatRoom");
 
-export const IChatUser = defineGrainInterface<IChatUser>("example.IChatUser", {
+export const chatUser = defineGrainInterface<ChatUser>("example.chatUser", {
   options: { history: { readOnly: true } },
 });
 

--- a/examples/cluster/src/cluster.test.ts
+++ b/examples/cluster/src/cluster.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { GrainId } from "@thresh/core/grain-id";
-import { ILeaderboard } from "@thresh/example-cluster/interfaces";
+import { leaderboard } from "@thresh/example-cluster/interfaces";
 import { buildWebSocketCluster, untilConverged } from "@thresh/example-cluster/cluster";
 import { runClusterDemo } from "@thresh/example-cluster/demo";
 
@@ -12,12 +12,12 @@ describe("WebSocket cluster (cross-silo routing acceptance)", () => {
     await cluster.start();
     try {
       // Each record originates on a different silo; all must reach one activation.
-      await cluster.silos[0]!.getGrain(ILeaderboard, "global").record("ada", 10);
-      await cluster.silos[1]!.getGrain(ILeaderboard, "global").record("grace", 30);
-      await cluster.silos[2]!.getGrain(ILeaderboard, "global").record("ada", 25);
+      await cluster.silos[0]!.getGrain(leaderboard, "global").record("ada", 10);
+      await cluster.silos[1]!.getGrain(leaderboard, "global").record("grace", 30);
+      await cluster.silos[2]!.getGrain(leaderboard, "global").record("ada", 25);
 
       // A read from yet another silo sees every write — proof of one tally.
-      expect(await cluster.silos[1]!.getGrain(ILeaderboard, "global").top()).toEqual([
+      expect(await cluster.silos[1]!.getGrain(leaderboard, "global").top()).toEqual([
         { player: "grace", score: 30 },
         { player: "ada", score: 25 },
       ]);
@@ -35,7 +35,7 @@ describe("WebSocket cluster (cross-silo routing acceptance)", () => {
     const cluster = await buildWebSocketCluster(3);
     await cluster.start();
     try {
-      await cluster.silos[0]!.getGrain(ILeaderboard, "global").record("ada", 10);
+      await cluster.silos[0]!.getGrain(leaderboard, "global").record("ada", 10);
       const hostIndex = cluster.silos.findIndex((s) => s.isActive(LEADERBOARD));
       expect(hostIndex).toBeGreaterThanOrEqual(0);
 
@@ -46,13 +46,13 @@ describe("WebSocket cluster (cross-silo routing acceptance)", () => {
       // A surviving silo's next call reactivates the grain elsewhere (fresh, since
       // state was in-memory on the dead silo); it retries while routing re-resolves.
       const survivor = cluster.silos.find((_, i) => i !== hostIndex)!;
-      await untilConverged(() => survivor.getGrain(ILeaderboard, "global").record("grace", 5));
+      await untilConverged(() => survivor.getGrain(leaderboard, "global").record("grace", 5));
 
       const survivingHosts = cluster.silos.filter(
         (s, i) => i !== hostIndex && s.isActive(LEADERBOARD),
       );
       expect(survivingHosts).toHaveLength(1);
-      expect(await survivor.getGrain(ILeaderboard, "global").top()).toEqual([
+      expect(await survivor.getGrain(leaderboard, "global").top()).toEqual([
         { player: "grace", score: 5 },
       ]);
     } finally {

--- a/examples/cluster/src/cluster.ts
+++ b/examples/cluster/src/cluster.ts
@@ -3,7 +3,7 @@ import { SiloAddress } from "@thresh/core/silo-address";
 import { createSilo } from "@thresh/hosting/silo-builder";
 import type { SiloHost } from "@thresh/hosting/silo-host";
 import { StaticMembershipService } from "@thresh/runtime/static-membership";
-import { ILeaderboard } from "@thresh/example-cluster/interfaces";
+import { leaderboard } from "@thresh/example-cluster/interfaces";
 import { LeaderboardGrain } from "@thresh/example-cluster/leaderboard-grain";
 
 const CLUSTER = "leaderboard";
@@ -77,7 +77,7 @@ export async function buildWebSocketCluster(count: number): Promise<Cluster> {
     createSilo({ clusterId: CLUSTER, local, random: () => 0 })
       .useMembership(membership)
       .useWebSocketTransport()
-      .registerGrain(LeaderboardGrain, { interfaces: [ILeaderboard] })
+      .registerGrain(LeaderboardGrain, { interfaces: [leaderboard] })
       .build(),
   );
 

--- a/examples/cluster/src/demo.ts
+++ b/examples/cluster/src/demo.ts
@@ -1,5 +1,5 @@
 import { GrainId } from "@thresh/core/grain-id";
-import { ILeaderboard, type ScoreEntry } from "@thresh/example-cluster/interfaces";
+import { leaderboard, type ScoreEntry } from "@thresh/example-cluster/interfaces";
 import { buildWebSocketCluster, untilConverged } from "@thresh/example-cluster/cluster";
 
 export interface ClusterDemoResult {
@@ -23,13 +23,13 @@ export async function runClusterDemo(): Promise<ClusterDemoResult> {
   const cluster = await buildWebSocketCluster(3);
   await cluster.start();
   try {
-    await cluster.silos[0]!.getGrain(ILeaderboard, "global").record("ada", 10);
-    await cluster.silos[1]!.getGrain(ILeaderboard, "global").record("grace", 30);
-    await cluster.silos[2]!.getGrain(ILeaderboard, "global").record("ada", 25);
+    await cluster.silos[0]!.getGrain(leaderboard, "global").record("ada", 10);
+    await cluster.silos[1]!.getGrain(leaderboard, "global").record("grace", 30);
+    await cluster.silos[2]!.getGrain(leaderboard, "global").record("ada", 25);
 
     const hostIndex = cluster.silos.findIndex((s) => s.isActive(LEADERBOARD));
     const hostSilo = cluster.addresses[hostIndex]!.podName;
-    const top = await cluster.silos[1]!.getGrain(ILeaderboard, "global").top();
+    const top = await cluster.silos[1]!.getGrain(leaderboard, "global").top();
 
     // The hosting silo dies.
     await cluster.silos[hostIndex]!.stop();
@@ -37,7 +37,7 @@ export async function runClusterDemo(): Promise<ClusterDemoResult> {
 
     // A survivor records again; it retries while the cluster re-resolves the grain.
     const survivor = cluster.silos.find((_, i) => i !== hostIndex)!;
-    await untilConverged(() => survivor.getGrain(ILeaderboard, "global").record("grace", 5));
+    await untilConverged(() => survivor.getGrain(leaderboard, "global").record("grace", 5));
     const newHostIndex = cluster.silos.findIndex(
       (s, i) => i !== hostIndex && s.isActive(LEADERBOARD),
     );
@@ -47,7 +47,7 @@ export async function runClusterDemo(): Promise<ClusterDemoResult> {
       top,
       afterFailover: {
         newHostSilo: cluster.addresses[newHostIndex]!.podName,
-        top: await survivor.getGrain(ILeaderboard, "global").top(),
+        top: await survivor.getGrain(leaderboard, "global").top(),
       },
     };
   } finally {

--- a/examples/cluster/src/interfaces.ts
+++ b/examples/cluster/src/interfaces.ts
@@ -1,5 +1,5 @@
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 export interface ScoreEntry {
   player: string;
@@ -11,11 +11,11 @@ export interface ScoreEntry {
  * against it; because a grain has exactly one activation, every `record` — no
  * matter which silo it originates on — lands on the same in-memory tally.
  */
-export interface ILeaderboard extends GrainWithStringKey {
+export type Leaderboard = GrainKey<string> & {
   record(player: string, score: number): Promise<void>;
   top(limit?: number): Promise<ScoreEntry[]>;
-}
+};
 
-export const ILeaderboard = defineGrainInterface<ILeaderboard>("example.ILeaderboard", {
+export const leaderboard = defineGrainInterface<Leaderboard>("example.leaderboard", {
   options: { top: { readOnly: true } },
 });

--- a/examples/cluster/src/leaderboard-grain.ts
+++ b/examples/cluster/src/leaderboard-grain.ts
@@ -1,12 +1,12 @@
 import { defineGrain } from "@thresh/core/define-grain";
-import type { ILeaderboard, ScoreEntry } from "@thresh/example-cluster/interfaces";
+import type { Leaderboard, ScoreEntry } from "@thresh/example-cluster/interfaces";
 
 /**
  * Keeps each player's best score. Holds no locks: calls arriving from every silo
  * in the cluster are routed to this one activation and run as serialized turns,
  * so the `Map` is only ever touched by one turn at a time.
  */
-export const LeaderboardGrain = defineGrain<ILeaderboard>("Leaderboard", () => {
+export const LeaderboardGrain = defineGrain<Leaderboard>("Leaderboard", () => {
   const best = new Map<string, number>();
 
   return {

--- a/examples/greeter/src/demo.ts
+++ b/examples/greeter/src/demo.ts
@@ -4,7 +4,7 @@ import { FakeTimeProvider } from "@thresh/core/test-support/fake-time-provider";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
 import { createSilo } from "@thresh/hosting/silo-builder";
 import { GreeterGrain } from "@thresh/example-greeter/greeter-grain";
-import { IGreeter } from "@thresh/example-greeter/interfaces";
+import { greeter } from "@thresh/example-greeter/interfaces";
 
 export interface GreeterDemoResult {
   /** The first greeting — proves onActivate ran before it (carries the prefix). */
@@ -37,18 +37,22 @@ export async function runGreeterDemo(): Promise<GreeterDemoResult> {
   })
     .useStaticMembership([local])
     .useInProcessTransport(new InProcessNetwork())
-    .registerGrain(GreeterGrain, { interfaces: [IGreeter] })
+    .registerGrain(GreeterGrain, { interfaces: [greeter] })
     .build();
 
   await silo.start();
   try {
-    const greeter = silo.getGrain(IGreeter, "en");
+    const greeterRef = silo.getGrain(greeter, "en");
 
-    const firstGreeting = await greeter.greet("Ada");
+    const firstGreeting = await greeterRef.greet("Ada");
 
     // Fire several calls at once; serialized turns mean every ++ is counted.
-    await Promise.all([greeter.greet("Grace"), greeter.greet("Linus"), greeter.greet("Edsger")]);
-    const countAfterConcurrent = await greeter.greetings();
+    await Promise.all([
+      greeterRef.greet("Grace"),
+      greeterRef.greet("Linus"),
+      greeterRef.greet("Edsger"),
+    ]);
+    const countAfterConcurrent = await greeterRef.greetings();
 
     // Idle past the collection age; the sweep deactivates the grain.
     time.advance(60_000);
@@ -56,8 +60,8 @@ export async function runGreeterDemo(): Promise<GreeterDemoResult> {
     const deactivatedWhenIdle = !silo.isActive(new GrainId("Greeter", "en"));
 
     // Next call reactivates fresh — the volatile count restarts at 1.
-    await greeter.greet("Alan");
-    const countAfterReactivation = await greeter.greetings();
+    await greeterRef.greet("Alan");
+    const countAfterReactivation = await greeterRef.greetings();
 
     return {
       firstGreeting,

--- a/examples/greeter/src/greeter-grain.ts
+++ b/examples/greeter/src/greeter-grain.ts
@@ -1,5 +1,5 @@
 import { defineGrain } from "@thresh/core/define-grain";
-import type { IGreeter } from "@thresh/example-greeter/interfaces";
+import type { Greeter } from "@thresh/example-greeter/interfaces";
 
 /**
  * A minimal grain showing the core actor guarantees with no providers:
@@ -10,7 +10,7 @@ import type { IGreeter } from "@thresh/example-greeter/interfaces";
  * - the `count` is volatile activation state — after the grain deactivates while
  *   idle, the next call reactivates it fresh and the count starts again at 1.
  */
-export const GreeterGrain = defineGrain<IGreeter>("Greeter", (ctx) => {
+export const GreeterGrain = defineGrain<Greeter>("Greeter", (ctx) => {
   let prefix = "uninitialised";
   let count = 0;
 

--- a/examples/greeter/src/greeter.test.ts
+++ b/examples/greeter/src/greeter.test.ts
@@ -7,7 +7,7 @@ import { createSilo } from "@thresh/hosting/silo-builder";
 import type { SiloHost } from "@thresh/hosting/silo-host";
 import { GreeterGrain } from "@thresh/example-greeter/greeter-grain";
 import { runGreeterDemo } from "@thresh/example-greeter/demo";
-import { IGreeter } from "@thresh/example-greeter/interfaces";
+import { greeter } from "@thresh/example-greeter/interfaces";
 
 const local = new SiloAddress("silo-0", "uid-0", "silo-0:11111");
 const tick = () => new Promise((r) => setTimeout(r, 0));
@@ -22,7 +22,7 @@ function buildGreeterSilo(time: FakeTimeProvider): SiloHost {
   })
     .useStaticMembership([local])
     .useInProcessTransport(new InProcessNetwork())
-    .registerGrain(GreeterGrain, { interfaces: [IGreeter] })
+    .registerGrain(GreeterGrain, { interfaces: [greeter] })
     .build();
 }
 
@@ -32,7 +32,7 @@ describe("greeter (core actor model acceptance)", () => {
     await silo.start();
     try {
       // The prefix is only set in onActivate; seeing it proves activation ran first.
-      expect(await silo.getGrain(IGreeter, "en").greet("Ada")).toBe(
+      expect(await silo.getGrain(greeter, "en").greet("Ada")).toBe(
         "[en] Hello, Ada! (greeting #1)",
       );
     } finally {
@@ -44,9 +44,9 @@ describe("greeter (core actor model acceptance)", () => {
     const silo = buildGreeterSilo(new FakeTimeProvider());
     await silo.start();
     try {
-      const greeter = silo.getGrain(IGreeter, "en");
-      await Promise.all([greeter.greet("a"), greeter.greet("b"), greeter.greet("c")]);
-      expect(await greeter.greetings()).toBe(3);
+      const greeterRef = silo.getGrain(greeter, "en");
+      await Promise.all([greeterRef.greet("a"), greeterRef.greet("b"), greeterRef.greet("c")]);
+      expect(await greeterRef.greetings()).toBe(3);
     } finally {
       await silo.stop();
     }
@@ -57,16 +57,16 @@ describe("greeter (core actor model acceptance)", () => {
     const silo = buildGreeterSilo(time);
     await silo.start();
     try {
-      const greeter = silo.getGrain(IGreeter, "en");
-      await greeter.greet("Ada");
-      expect(await greeter.greetings()).toBe(1);
+      const greeterRef = silo.getGrain(greeter, "en");
+      await greeterRef.greet("Ada");
+      expect(await greeterRef.greetings()).toBe(1);
 
       time.advance(60_000);
       await tick();
       expect(silo.isActive(new GrainId("Greeter", "en"))).toBe(false);
 
       // Reactivated fresh: volatile count restarts at 1.
-      expect(await greeter.greet("Alan")).toBe("[en] Hello, Alan! (greeting #1)");
+      expect(await greeterRef.greet("Alan")).toBe("[en] Hello, Alan! (greeting #1)");
     } finally {
       await silo.stop();
     }

--- a/examples/greeter/src/interfaces.ts
+++ b/examples/greeter/src/interfaces.ts
@@ -1,13 +1,13 @@
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /** The smallest useful grain: it greets, and counts how often it has greeted. */
-export interface IGreeter extends GrainWithStringKey {
+export type Greeter = GrainKey<string> & {
   greet(name: string): Promise<string>;
   /** How many greetings this activation has served (volatile, per-activation). */
   greetings(): Promise<number>;
-}
+};
 
-export const IGreeter = defineGrainInterface<IGreeter>("example.IGreeter", {
+export const greeter = defineGrainInterface<Greeter>("example.greeter", {
   options: { greetings: { readOnly: true } },
 });

--- a/examples/k8s-silo/src/counter-grain.ts
+++ b/examples/k8s-silo/src/counter-grain.ts
@@ -1,5 +1,5 @@
 import { defineGrain, usePersistentState } from "@thresh/core/define-grain";
-import type { CounterReply, ICounter } from "@thresh/example-k8s-silo/interfaces";
+import type { Counter, CounterReply } from "@thresh/example-k8s-silo/interfaces";
 
 interface CounterState {
   value: number;
@@ -13,7 +13,7 @@ const hostName = (): string => process.env.POD_NAME ?? "local";
  * host pod dies the activation reactivates on a survivor and resumes from the
  * stored value rather than starting over.
  */
-export const CounterGrain = defineGrain<ICounter>("Counter", (ctx) => {
+export const CounterGrain = defineGrain<Counter>("Counter", (ctx) => {
   const state = usePersistentState<CounterState>(ctx, "counter", {
     defaultValue: (): CounterState => ({ value: 0 }),
   });

--- a/examples/k8s-silo/src/http-api.ts
+++ b/examples/k8s-silo/src/http-api.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from "node:http";
 import type { SiloHost } from "@thresh/hosting/silo-host";
-import { ICounter } from "@thresh/example-k8s-silo/interfaces";
+import { counter } from "@thresh/example-k8s-silo/interfaces";
 
 const hostName = (): string => process.env.POD_NAME ?? "local";
 
@@ -34,9 +34,9 @@ async function handle(method: string, url: string, host: SiloHost): Promise<unkn
   const match = /^\/counters\/([^/]+)(\/increment)?$/.exec(path);
   if (match !== null) {
     const key = decodeURIComponent(match[1]!);
-    const counter = host.getGrain(ICounter, key);
-    if (method === "POST" && match[2] === "/increment") return counter.increment();
-    if (method === "GET" && match[2] === undefined) return counter.current();
+    const counterRef = host.getGrain(counter, key);
+    if (method === "POST" && match[2] === "/increment") return counterRef.increment();
+    if (method === "GET" && match[2] === undefined) return counterRef.current();
   }
   throw new Error(`no route for ${method} ${path}`);
 }

--- a/examples/k8s-silo/src/interfaces.ts
+++ b/examples/k8s-silo/src/interfaces.ts
@@ -1,5 +1,5 @@
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /** A counter read: its current value and the silo (pod) the activation runs on. */
 export interface CounterReply {
@@ -14,11 +14,11 @@ export interface CounterReply {
  * incrementing through any pod hits the same activation — and the activation
  * moves to a survivor when its host pod dies.
  */
-export interface ICounter extends GrainWithStringKey {
+export type Counter = GrainKey<string> & {
   increment(): Promise<CounterReply>;
   current(): Promise<CounterReply>;
-}
+};
 
-export const ICounter = defineGrainInterface<ICounter>("k8s.ICounter", {
+export const counter = defineGrainInterface<Counter>("k8s.counter", {
   options: { current: { readOnly: true } },
 });

--- a/examples/k8s-silo/src/main.ts
+++ b/examples/k8s-silo/src/main.ts
@@ -4,7 +4,7 @@ import { createKubernetesClientSource } from "@thresh/clustering-k8s/kubernetes-
 import { readPodEnvironment, siloAddressFromPodEnv } from "@thresh/clustering-k8s/pod-environment";
 import { createSilo } from "@thresh/hosting/silo-builder";
 import { CounterGrain } from "@thresh/example-k8s-silo/counter-grain";
-import { ICounter } from "@thresh/example-k8s-silo/interfaces";
+import { counter } from "@thresh/example-k8s-silo/interfaces";
 import { createCounterApi } from "@thresh/example-k8s-silo/http-api";
 
 const SILO_PORT = Number(process.env.SILO_PORT ?? 11111);
@@ -34,7 +34,7 @@ async function main(): Promise<void> {
     .useWebSocketTransport()
     .addRedisStorage("default", { url: REDIS_URL })
     .useHealthEndpoints({ port: HEALTH_PORT })
-    .registerGrain(CounterGrain, { interfaces: [ICounter] })
+    .registerGrain(CounterGrain, { interfaces: [counter] })
     .build();
 
   await host.start();

--- a/examples/migration/src/cart-grain.ts
+++ b/examples/migration/src/cart-grain.ts
@@ -1,5 +1,5 @@
 import { defineGrain, usePersistentState } from "@thresh/core/define-grain";
-import type { ICart } from "@thresh/example-migration/interfaces";
+import type { Cart } from "@thresh/example-migration/interfaces";
 
 interface CartState {
   items: string[];
@@ -12,7 +12,7 @@ interface CartState {
  * target silo and rehydrates it there, skipping the storage read — so the move
  * never loses unflushed state. Functional-first (`defineGrain` + hooks).
  */
-export const CartGrain = defineGrain<ICart>("Cart", (ctx) => {
+export const CartGrain = defineGrain<Cart>("Cart", (ctx) => {
   const cart = usePersistentState<CartState>(ctx, "cart", {
     defaultValue: (): CartState => ({ items: [] }),
   });

--- a/examples/migration/src/cluster.ts
+++ b/examples/migration/src/cluster.ts
@@ -5,7 +5,7 @@ import { MemoryGrainStorage } from "@thresh/persistence/memory-grain-storage";
 import { createSilo } from "@thresh/hosting/silo-builder";
 import type { SiloHost } from "@thresh/hosting/silo-host";
 import { CartGrain } from "@thresh/example-migration/cart-grain";
-import { ICart } from "@thresh/example-migration/interfaces";
+import { cart } from "@thresh/example-migration/interfaces";
 
 const CLUSTER = "carts";
 
@@ -46,7 +46,7 @@ export function buildMigrationCluster(): MigrationCluster {
       .useStaticMembership(addresses)
       .useInProcessTransport(network)
       .useMemoryStorage(storage)
-      .registerGrain(CartGrain, { interfaces: [ICart] })
+      .registerGrain(CartGrain, { interfaces: [cart] })
       .build(),
   );
 

--- a/examples/migration/src/demo.ts
+++ b/examples/migration/src/demo.ts
@@ -1,6 +1,6 @@
 import { GrainId } from "@thresh/core/grain-id";
 import { buildMigrationCluster, siloAddress } from "@thresh/example-migration/cluster";
-import { ICart } from "@thresh/example-migration/interfaces";
+import { cart } from "@thresh/example-migration/interfaces";
 
 const flush = () => new Promise((r) => setTimeout(r, 0));
 async function settleUntil(pred: () => boolean, max = 200): Promise<void> {
@@ -29,19 +29,19 @@ export async function runMigrationDemo(): Promise<MigrationDemoResult> {
   try {
     const [node0, node1] = cluster.silos;
     // random->0 places the cart on silo-0.
-    await node0!.getGrain(ICart, "cart-1").checkout(); // activate + persist empty
-    await node0!.getGrain(ICart, "cart-1").add("apple");
-    await node0!.getGrain(ICart, "cart-1").checkout(); // persist ["apple"]
-    await node0!.getGrain(ICart, "cart-1").add("pear"); // in memory only — NOT persisted
+    await node0!.getGrain(cart, "cart-1").checkout(); // activate + persist empty
+    await node0!.getGrain(cart, "cart-1").add("apple");
+    await node0!.getGrain(cart, "cart-1").checkout(); // persist ["apple"]
+    await node0!.getGrain(cart, "cart-1").add("pear"); // in memory only — NOT persisted
     const hostBefore = node0!.isActive(cartId) ? 0 : 1;
 
     // Schedule the move and trigger idle collection by advancing the fake clock.
-    await node0!.getGrain(ICart, "cart-1").moveTo(siloAddress(1));
+    await node0!.getGrain(cart, "cart-1").moveTo(siloAddress(1));
     cluster.time.advance(31_000);
     await settleUntil(() => node1!.isActive(cartId));
 
     const hostAfter = node1!.isActive(cartId) ? 1 : 0;
-    const itemsAfterMove = await node1!.getGrain(ICart, "cart-1").items();
+    const itemsAfterMove = await node1!.getGrain(cart, "cart-1").items();
     return { hostBefore, hostAfter, itemsAfterMove };
   } finally {
     await cluster.stop();

--- a/examples/migration/src/interfaces.ts
+++ b/examples/migration/src/interfaces.ts
@@ -1,5 +1,5 @@
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { SiloAddress } from "@thresh/core/silo-address";
 
 /**
@@ -7,7 +7,7 @@ import type { SiloAddress } from "@thresh/core/silo-address";
  * losing state — even items added since the last persist (carried in the
  * migration bag, not re-read from storage).
  */
-export interface ICart extends GrainWithStringKey {
+export type Cart = GrainKey<string> & {
   /** Add an item to the in-memory cart WITHOUT persisting it yet. */
   add(sku: string): Promise<number>;
   /** Persist the cart to storage. */
@@ -16,7 +16,7 @@ export interface ICart extends GrainWithStringKey {
   items(): Promise<string[]>;
   /** Ask the runtime to migrate this activation to `target` next time it goes idle. */
   moveTo(target: SiloAddress): Promise<void>;
-}
-export const ICart = defineGrainInterface<ICart>("ICart.migration", {
+};
+export const cart = defineGrainInterface<Cart>("cart.migration", {
   options: { items: { readOnly: true } },
 });

--- a/examples/migration/src/migration.test.ts
+++ b/examples/migration/src/migration.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { GrainId } from "@thresh/core/grain-id";
 import { buildMigrationCluster, siloAddress } from "@thresh/example-migration/cluster";
 import { runMigrationDemo } from "@thresh/example-migration/demo";
-import { ICart } from "@thresh/example-migration/interfaces";
+import { cart } from "@thresh/example-migration/interfaces";
 
 const flush = () => new Promise((r) => setTimeout(r, 0));
 async function settleUntil(pred: () => boolean, max = 200): Promise<void> {
@@ -19,19 +19,19 @@ describe("grain migration (live activation move acceptance)", () => {
     const [node0, node1] = cluster.silos;
     try {
       // random->0 places the cart on silo-0; persist "apple", add "pear" in memory only.
-      await node0!.getGrain(ICart, "cart-1").add("apple");
-      await node0!.getGrain(ICart, "cart-1").checkout();
-      await node0!.getGrain(ICart, "cart-1").add("pear");
+      await node0!.getGrain(cart, "cart-1").add("apple");
+      await node0!.getGrain(cart, "cart-1").checkout();
+      await node0!.getGrain(cart, "cart-1").add("pear");
       expect(node0!.isActive(cartId)).toBe(true);
 
-      await node0!.getGrain(ICart, "cart-1").moveTo(siloAddress(1));
+      await node0!.getGrain(cart, "cart-1").moveTo(siloAddress(1));
       cluster.time.advance(31_000);
       await settleUntil(() => node1!.isActive(cartId));
 
       // The activation moved silos, and the unpersisted "pear" came with it.
       expect(node0!.isActive(cartId)).toBe(false);
       expect(node1!.isActive(cartId)).toBe(true);
-      expect(await node1!.getGrain(ICart, "cart-1").items()).toEqual(["apple", "pear"]);
+      expect(await node1!.getGrain(cart, "cart-1").items()).toEqual(["apple", "pear"]);
     } finally {
       await cluster.stop();
     }

--- a/examples/thermostat/src/demo.ts
+++ b/examples/thermostat/src/demo.ts
@@ -4,9 +4,9 @@ import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
 import { createSilo } from "@thresh/hosting/silo-builder";
 import { FleetAggregatorGrain } from "@thresh/example-thermostat/fleet-aggregator-grain";
 import {
-  IFleetAggregator,
-  IThermostat,
-  IThermostatControl,
+  fleetAggregator,
+  thermostat,
+  thermostatControl,
   type Command,
 } from "@thresh/example-thermostat/interfaces";
 import { ThermostatGrain } from "@thresh/example-thermostat/thermostat-grain";
@@ -37,24 +37,24 @@ export async function runThermostatDemo(): Promise<DemoResult> {
     .useMemoryStorage()
     .useReminders()
     .useMemoryStreams()
-    .registerGrain(ThermostatGrain, { interfaces: [IThermostat, IThermostatControl] })
-    .registerGrain(FleetAggregatorGrain, { interfaces: [IFleetAggregator] })
+    .registerGrain(ThermostatGrain, { interfaces: [thermostat, thermostatControl] })
+    .registerGrain(FleetAggregatorGrain, { interfaces: [fleetAggregator] })
     .build();
 
   await silo.start();
   try {
     const device = "kitchen";
     // Start the aggregator so it subscribes to the telemetry stream first.
-    await silo.getGrain(IFleetAggregator, device).sampleCount();
+    await silo.getGrain(fleetAggregator, device).sampleCount();
 
-    const thermostat = silo.getGrain(IThermostat, device);
+    const thermostatRef = silo.getGrain(thermostat, device);
     const commands: Command[][] = [];
-    commands.push(await thermostat.onUpdate({ tempC: 18 })); // below target -> heat
-    commands.push(await thermostat.onUpdate({ tempC: 23 })); // above target -> cool
+    commands.push(await thermostatRef.onUpdate({ tempC: 18 })); // below target -> heat
+    commands.push(await thermostatRef.onUpdate({ tempC: 23 })); // above target -> cool
     await tick(); // let stream delivery turns run
 
     // Telemetry rolled up from the two updates so far.
-    const aggregator = silo.getGrain(IFleetAggregator, device);
+    const aggregator = silo.getGrain(fleetAggregator, device);
     const telemetrySamples = await aggregator.sampleCount();
     const telemetryAverage = await aggregator.averageTemp();
 
@@ -62,8 +62,8 @@ export async function runThermostatDemo(): Promise<DemoResult> {
     time.advance(60_000);
     await tick();
 
-    const status = await silo.getGrain(IThermostatControl, device).getStatus();
-    const pending = (await thermostat.onUpdate({ tempC: 21 })).filter(
+    const status = await silo.getGrain(thermostatControl, device).getStatus();
+    const pending = (await thermostatRef.onUpdate({ tempC: 21 })).filter(
       (c) => c.kind === "self-test",
     );
 

--- a/examples/thermostat/src/fleet-aggregator-grain.ts
+++ b/examples/thermostat/src/fleet-aggregator-grain.ts
@@ -2,7 +2,7 @@ import { defineGrain } from "@thresh/core/define-grain";
 import type { StreamHandler } from "@thresh/core/stream";
 import {
   TELEMETRY,
-  type IFleetAggregator,
+  type FleetAggregator,
   type ThermostatStatus,
 } from "@thresh/example-thermostat/interfaces";
 
@@ -11,7 +11,7 @@ import {
  * functional counterpart to the class-based `ThermostatGrain` it consumes from —
  * the two styles interoperate over the same stream (see `thermostat-grain.ts`).
  */
-export const FleetAggregatorGrain = defineGrain<IFleetAggregator>("FleetAggregator", (ctx) => {
+export const FleetAggregatorGrain = defineGrain<FleetAggregator>("FleetAggregator", (ctx) => {
   let sum = 0;
   let count = 0;
 

--- a/examples/thermostat/src/interfaces.ts
+++ b/examples/thermostat/src/interfaces.ts
@@ -1,5 +1,5 @@
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 export interface ThermostatStatus {
   tempC: number;
@@ -14,30 +14,30 @@ export interface Command {
 }
 
 /** Called by the device frontend. */
-export interface IThermostat extends GrainWithStringKey {
+export type Thermostat = GrainKey<string> & {
   onUpdate(status: ThermostatStatus): Promise<Command[]>;
-}
+};
 
 /** Called by control systems. */
-export interface IThermostatControl extends GrainWithStringKey {
+export type ThermostatControl = GrainKey<string> & {
   getStatus(): Promise<ThermostatStatus>;
   updateConfiguration(config: ThermostatConfiguration): Promise<void>;
-}
+};
 
 /** Rolls up telemetry across the fleet. */
-export interface IFleetAggregator extends GrainWithStringKey {
+export type FleetAggregator = GrainKey<string> & {
   averageTemp(): Promise<number>;
   sampleCount(): Promise<number>;
-}
+};
 
-export const IThermostat = defineGrainInterface<IThermostat>("example.IThermostat");
+export const thermostat = defineGrainInterface<Thermostat>("example.thermostat");
 
-export const IThermostatControl = defineGrainInterface<IThermostatControl>(
-  "example.IThermostatControl",
+export const thermostatControl = defineGrainInterface<ThermostatControl>(
+  "example.thermostatControl",
   { options: { getStatus: { readOnly: true } } },
 );
 
-export const IFleetAggregator = defineGrainInterface<IFleetAggregator>("example.IFleetAggregator", {
+export const fleetAggregator = defineGrainInterface<FleetAggregator>("example.fleetAggregator", {
   options: { averageTemp: { readOnly: true }, sampleCount: { readOnly: true } },
 });
 

--- a/examples/thermostat/src/thermostat-grain.ts
+++ b/examples/thermostat/src/thermostat-grain.ts
@@ -5,8 +5,8 @@ import type { Remindable, TickStatus } from "@thresh/core/reminder";
 import {
   TELEMETRY,
   type Command,
-  type IThermostat,
-  type IThermostatControl,
+  type Thermostat,
+  type ThermostatControl,
   type ThermostatConfiguration,
   type ThermostatStatus,
 } from "@thresh/example-thermostat/interfaces";
@@ -36,7 +36,7 @@ const defaultState = (): ThermostatState => ({
  * consumes the telemetry this class publishes.
  */
 @grain()
-export class ThermostatGrain extends Grain implements IThermostat, IThermostatControl, Remindable {
+export class ThermostatGrain extends Grain implements Thermostat, ThermostatControl, Remindable {
   @persistentState("thermostat", { defaultValue: defaultState })
   private state!: PersistentState<ThermostatState>;
 

--- a/packages/client/src/client-node.observer.test.ts
+++ b/packages/client/src/client-node.observer.test.ts
@@ -5,7 +5,7 @@ import { GrainCancellationToken } from "@thresh/core/grain-cancellation-token";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import { GrainId } from "@thresh/core/grain-id";
 import { grainReferenceIdentity } from "@thresh/core/grain-reference";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork, InProcessTransport } from "@thresh/messaging/in-process-transport";
 import { nextCorrelationId, type Message } from "@thresh/messaging/message";
@@ -14,7 +14,7 @@ import { ICancellationSourcesExtension } from "@thresh/runtime/cancellation-exte
 import { waitFor } from "@thresh/testing/wait";
 import { createClient } from "@thresh/client/client-node";
 
-interface IObserver extends GrainWithStringKey {
+interface IObserver extends GrainKey<string> {
   onEvent(payload: string): Promise<string>;
 }
 const IObserver = defineGrainInterface<IObserver>("IObserver.client");

--- a/packages/client/src/client-node.test.ts
+++ b/packages/client/src/client-node.test.ts
@@ -4,7 +4,7 @@ import { Grain } from "@thresh/core/grain";
 import type { GrainCancellationToken } from "@thresh/core/grain-cancellation-token";
 import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork, InProcessTransport } from "@thresh/messaging/in-process-transport";
 import { ClusterNode } from "@thresh/runtime/cluster-node";
@@ -12,18 +12,18 @@ import { StaticMembershipService } from "@thresh/runtime/static-membership";
 import { staticGatewayProvider } from "@thresh/client/gateway-provider";
 import { createClient } from "@thresh/client/client-node";
 
-interface ICounter extends GrainWithStringKey {
+interface ICounter extends GrainKey<string> {
   increment(by: number): Promise<number>;
   fail(): Promise<void>;
 }
 const ICounter = defineGrainInterface<ICounter>("ICounter.client");
 
-interface IUnregistered extends GrainWithStringKey {
+interface IUnregistered extends GrainKey<string> {
   ping(): Promise<void>;
 }
 const IUnregistered = defineGrainInterface<IUnregistered>("IUnregistered.client");
 
-interface IWaiter extends GrainWithStringKey {
+interface IWaiter extends GrainKey<string> {
   wait(token: GrainCancellationToken): Promise<void>;
 }
 const IWaiter = defineGrainInterface<IWaiter>("IWaiter.client");

--- a/packages/client/src/gateway-discovery.test.ts
+++ b/packages/client/src/gateway-discovery.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork, InProcessTransport } from "@thresh/messaging/in-process-transport";
 import { WebSocketTransport } from "@thresh/messaging/web-socket-transport";
@@ -25,7 +25,7 @@ function freePort(): Promise<number> {
   });
 }
 
-interface IEcho extends GrainWithStringKey {
+interface IEcho extends GrainKey<string> {
   echo(message: string): Promise<string>;
 }
 const IEcho = defineGrainInterface<IEcho>("IEcho.gateway");

--- a/packages/client/src/load-shedding.cluster.test.ts
+++ b/packages/client/src/load-shedding.cluster.test.ts
@@ -3,14 +3,14 @@ import { grain } from "@thresh/core/decorators";
 import { GatewayTooBusyException } from "@thresh/core/errors";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork, InProcessTransport } from "@thresh/messaging/in-process-transport";
 import { ClusterNode } from "@thresh/runtime/cluster-node";
 import { StaticMembershipService } from "@thresh/runtime/static-membership";
 import { createClient } from "@thresh/client/client-node";
 
-interface IPing extends GrainWithStringKey {
+interface IPing extends GrainKey<string> {
   ping(): Promise<string>;
   /** Exercises `GrainRuntime`'s load-shedding test hooks from inside a turn (Orleans `IPlacementTestGrain`). */
   latchCpuUsageViaRuntime(value: number): Promise<void>;

--- a/packages/client/src/observer-callback.cluster.test.ts
+++ b/packages/client/src/observer-callback.cluster.test.ts
@@ -2,19 +2,19 @@ import { describe, expect, it } from "vitest";
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork, InProcessTransport } from "@thresh/messaging/in-process-transport";
 import { ClusterNode } from "@thresh/runtime/cluster-node";
 import { StaticMembershipService } from "@thresh/runtime/static-membership";
 import { createClient } from "@thresh/client/client-node";
 
-interface IEventObserver extends GrainWithStringKey {
+interface IEventObserver extends GrainKey<string> {
   onEvent(text: string): Promise<string>;
 }
 const IEventObserver = defineGrainInterface<IEventObserver>("test.IEventObserver");
 
-interface ISubscriberGrain extends GrainWithStringKey {
+interface ISubscriberGrain extends GrainKey<string> {
   subscribe(observer: IEventObserver): Promise<void>;
   poke(text: string): Promise<string>;
 }

--- a/packages/core/src/key-kinds.test.ts
+++ b/packages/core/src/key-kinds.test.ts
@@ -1,0 +1,38 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type { CompoundKey } from "@thresh/core/grain-key";
+import type { Guid } from "@thresh/core/guid";
+import type {
+  GrainKey,
+  GrainKeyFor,
+  GrainWithGuidCompoundKey,
+  GrainWithIntegerKey,
+  KeyedGrain,
+} from "@thresh/core/key-kinds";
+
+describe("GrainKey", () => {
+  it("maps idiomatic GrainKey markers to getGrain key types", () => {
+    type StringGrain = GrainKey<string> & { ping(): Promise<void> };
+    type IntegerGrain = GrainKey<bigint> & { ping(): Promise<void> };
+    type GuidCompoundGrain = GrainKey<CompoundKey<Guid>> & { ping(): Promise<void> };
+
+    expectTypeOf<GrainKeyFor<StringGrain>>().toEqualTypeOf<string>();
+    expectTypeOf<GrainKeyFor<IntegerGrain>>().toEqualTypeOf<bigint>();
+    expectTypeOf<GrainKeyFor<GuidCompoundGrain>>().toEqualTypeOf<CompoundKey<Guid>>();
+  });
+
+  it("keeps Orleans-compatible marker names as aliases", () => {
+    type IntegerGrain = GrainWithIntegerKey & { ping(): Promise<void> };
+    type GuidCompoundGrain = GrainWithGuidCompoundKey & { ping(): Promise<void> };
+
+    expectTypeOf<GrainKeyFor<IntegerGrain>>().toEqualTypeOf<bigint>();
+    expectTypeOf<GrainKeyFor<GuidCompoundGrain>>().toEqualTypeOf<CompoundKey<Guid>>();
+  });
+
+  it("defaults unmarked grain surfaces to string keys", () => {
+    type Greeter = KeyedGrain & { greet(name: string): Promise<string> };
+    type LegacyUnmarked = { greet(name: string): Promise<string> };
+
+    expectTypeOf<GrainKeyFor<Greeter>>().toEqualTypeOf<string>();
+    expectTypeOf<GrainKeyFor<LegacyUnmarked>>().toEqualTypeOf<string>();
+  });
+});

--- a/packages/core/src/key-kinds.test.ts
+++ b/packages/core/src/key-kinds.test.ts
@@ -12,8 +12,8 @@ import type {
 describe("GrainKey", () => {
   it("maps idiomatic GrainKey markers to getGrain key types", () => {
     type StringGrain = GrainKey<string> & { ping(): Promise<void> };
-    type IntegerGrain = GrainKey<bigint> & { ping(): Promise<void> };
-    type GuidCompoundGrain = GrainKey<CompoundKey<Guid>> & { ping(): Promise<void> };
+    type IntegerGrain = GrainWithIntegerKey & { ping(): Promise<void> };
+    type GuidCompoundGrain = GrainWithGuidCompoundKey & { ping(): Promise<void> };
 
     expectTypeOf<GrainKeyFor<StringGrain>>().toEqualTypeOf<string>();
     expectTypeOf<GrainKeyFor<IntegerGrain>>().toEqualTypeOf<bigint>();

--- a/packages/core/src/key-kinds.ts
+++ b/packages/core/src/key-kinds.ts
@@ -1,39 +1,36 @@
-import type { CompoundKey } from "./grain-key";
+import type { CompoundKey, GrainKey as RuntimeGrainKey } from "./grain-key";
 import type { Guid } from "./guid";
 
 /**
- * Marker interfaces a grain interface extends to declare its key kind, so the
- * factory can enforce the key type. The phantom field is never read.
+ * Phantom marker a grain interface/type alias intersects with to declare the
+ * key type accepted by `getGrain`. This is the TypeScript-first form: keep the
+ * message surface as a plain structural type and add `GrainKey<TKey>` for the
+ * identity shape.
+ *
+ * @example
+ * type Greeter = GrainKey<string> & {
+ *   greet(name: string): Promise<string>;
+ * };
  */
-export interface GrainWithStringKey {
-  readonly __key?: string;
+export interface GrainKey<TKey extends RuntimeGrainKey = string> {
+  readonly __key?: TKey;
 }
 
-export interface GrainWithIntegerKey {
-  readonly __key?: bigint;
-}
+/** Alias for `GrainKey<TKey>` when the grain surface reads better as a noun. */
+export type KeyedGrain<TKey extends RuntimeGrainKey = string> = GrainKey<TKey>;
 
-export interface GrainWithGuidKey {
-  readonly __key?: Guid;
-}
+/** Orleans-compatible marker names retained for ports and existing examples. */
+export interface GrainWithStringKey extends GrainKey<string> {}
+
+export interface GrainWithIntegerKey extends GrainKey<bigint> {}
+
+export interface GrainWithGuidKey extends GrainKey<Guid> {}
 
 /** Orleans' `IGrainWithGuidCompoundKey`: a Guid primary key plus a string extension. */
-export interface GrainWithGuidCompoundKey {
-  readonly __key?: CompoundKey<Guid>;
-}
+export interface GrainWithGuidCompoundKey extends GrainKey<CompoundKey<Guid>> {}
 
 /** Orleans' `IGrainWithIntegerCompoundKey`: an integer primary key plus a string extension. */
-export interface GrainWithIntegerCompoundKey {
-  readonly __key?: CompoundKey<bigint>;
-}
+export interface GrainWithIntegerCompoundKey extends GrainKey<CompoundKey<bigint>> {}
 
 /** Maps a grain interface to the key type its factory call requires. */
-export type GrainKeyFor<T> = T extends GrainWithGuidCompoundKey
-  ? CompoundKey<Guid>
-  : T extends GrainWithIntegerCompoundKey
-    ? CompoundKey<bigint>
-    : T extends GrainWithIntegerKey
-      ? bigint
-      : T extends GrainWithGuidKey
-        ? Guid
-        : string;
+export type GrainKeyFor<T> = T extends GrainKey<infer TKey> ? TKey : string;

--- a/packages/core/src/management-grain.ts
+++ b/packages/core/src/management-grain.ts
@@ -2,7 +2,7 @@ import type { Duration } from "./duration";
 import type { GrainAddress } from "./grain-address";
 import { defineGrainInterface } from "./grain-interface";
 import type { GrainId } from "./grain-id";
-import type { GrainWithIntegerKey } from "./key-kinds";
+import type { GrainKey } from "./key-kinds";
 import type { SiloMember, SiloStatus } from "./membership";
 import type { SiloAddress } from "./silo-address";
 
@@ -40,7 +40,7 @@ export interface DetailedGrainStatistic {
  * SendControlCommandToProvider); the rest of upstream's surface
  * (ForceGarbageCollection, GetRuntimeStatistics, ...) has no equivalent yet.
  */
-export interface IManagementGrain extends GrainWithIntegerKey {
+export interface IManagementGrain extends GrainKey<bigint> {
   /**
    * The silo hosts and statuses currently known in this cluster (Orleans
    * `GetHosts`). `onlyActive` (default `false`) restricts the result to

--- a/packages/hosting/src/activation-rebalancer.cluster.test.ts
+++ b/packages/hosting/src/activation-rebalancer.cluster.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { FakeTimeProvider } from "@thresh/core/test-support/fake-time-provider";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
@@ -10,7 +10,7 @@ import { StaticMembershipService } from "@thresh/runtime/static-membership";
 import { createSilo } from "@thresh/hosting/silo-builder";
 import type { SiloHost } from "@thresh/hosting/silo-host";
 
-interface IWorker extends GrainWithStringKey {
+interface IWorker extends GrainKey<string> {
   ping(): Promise<string>;
 }
 const IWorker = defineGrainInterface<IWorker>("IWorker.rebalance.e2e");

--- a/packages/hosting/src/broadcast-channels.test.ts
+++ b/packages/hosting/src/broadcast-channels.test.ts
@@ -6,17 +6,17 @@ import {
 import { grain, implicitChannelSubscription } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
 import { createSilo } from "@thresh/hosting/silo-builder";
 
-interface IRaiser extends GrainWithStringKey {
+interface IRaiser extends GrainKey<string> {
   raise(message: string): Promise<void>;
 }
 const IRaiser = defineGrainInterface<IRaiser>("IRaiser.broadcast");
 
-interface IMonitor extends GrainWithStringKey {
+interface IMonitor extends GrainKey<string> {
   seen(): Promise<string[]>;
 }
 const IMonitor = defineGrainInterface<IMonitor>("IMonitor.broadcast");

--- a/packages/hosting/src/durable-jobs.test.ts
+++ b/packages/hosting/src/durable-jobs.test.ts
@@ -3,7 +3,7 @@ import { defineGrain, useDurableJobHandler } from "@thresh/core/define-grain";
 import { completed, pollAfter, type DurableJob } from "@thresh/core/durable-job";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import { GrainId } from "@thresh/core/grain-id";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { PLACEMENT_HINT_KEY, RequestContext } from "@thresh/core/request-context";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { FakeTimeProvider } from "@thresh/core/test-support/fake-time-provider";
@@ -18,7 +18,7 @@ const runs = new Map<string, number>();
 const pollAttempts = new Map<string, number>();
 const record = (key: string, map = runs) => map.set(key, (map.get(key) ?? 0) + 1);
 
-interface IWorker extends GrainWithStringKey {
+interface IWorker extends GrainKey<string> {
   ping(): Promise<string>;
 }
 const IWorker = defineGrainInterface<IWorker>("IWorker.jobs");
@@ -48,7 +48,7 @@ const WorkerGrain = defineGrain<IWorker>("Worker", (ctx) => {
 });
 
 // A scheduler grain that schedules/cancels jobs on a worker via the runtime.
-interface IScheduler extends GrainWithStringKey {
+interface IScheduler extends GrainKey<string> {
   schedule(workerKey: string, name: string, dueMs: number): Promise<DurableJob>;
   cancel(job: DurableJob): Promise<void>;
 }

--- a/packages/hosting/src/grain-call-filters.test.ts
+++ b/packages/hosting/src/grain-call-filters.test.ts
@@ -9,12 +9,12 @@ import {
   type OutgoingGrainCallFilter,
 } from "@thresh/core/grain-call-filter";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
 import { createSilo } from "@thresh/hosting/silo-builder";
 
-interface Greeter extends GrainWithStringKey {
+interface Greeter extends GrainKey<string> {
   greet(name: string): Promise<string>;
 }
 const Greeter = defineGrainInterface<Greeter>("FilterGreeter");
@@ -30,7 +30,7 @@ class GreeterGrain extends Grain implements Greeter {
 }
 
 // A grain that filters its own incoming calls (Orleans IIncomingGrainCallFilter).
-interface Echoer extends GrainWithStringKey {
+interface Echoer extends GrainKey<string> {
   echo(s: string): Promise<string>;
 }
 const Echoer = defineGrainInterface<Echoer>("FilterEchoer");

--- a/packages/hosting/src/journaling.test.ts
+++ b/packages/hosting/src/journaling.test.ts
@@ -3,7 +3,7 @@ import { durableList, grain } from "@thresh/core/decorators";
 import { defineGrain, useDurableDictionary } from "@thresh/core/define-grain";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { DurableList } from "@thresh/core/durable-state";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
@@ -11,7 +11,7 @@ import { MemoryJournalStorage } from "@thresh/journaling/memory-journal-storage"
 import { createSilo, type SiloConfig } from "@thresh/hosting/silo-builder";
 
 // A class grain journalling an ordered list.
-interface ICart extends GrainWithStringKey {
+interface ICart extends GrainKey<string> {
   add(item: string): Promise<number>;
   list(): Promise<readonly string[]>;
 }
@@ -33,7 +33,7 @@ class CartGrain extends Grain implements ICart {
 }
 
 // A functional grain journalling a dictionary via the hook.
-interface IInventory extends GrainWithStringKey {
+interface IInventory extends GrainKey<string> {
   stock(sku: string, qty: number): Promise<void>;
   qty(sku: string): Promise<number | undefined>;
   skus(): Promise<number>;

--- a/packages/hosting/src/kafka-streams-cluster.test.ts
+++ b/packages/hosting/src/kafka-streams-cluster.test.ts
@@ -6,7 +6,7 @@ import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import { stableHash32 } from "@thresh/core/hash";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import type { StreamHandler } from "@thresh/core/stream";
 import { ConsistentHashRing } from "@thresh/directory/consistent-hash-ring";
@@ -112,12 +112,12 @@ afterAll(async () => {
   }
 });
 
-interface IChatRoom extends GrainWithStringKey {
+interface IChatRoom extends GrainKey<string> {
   say(text: string): Promise<void>;
 }
 const IChatRoom = defineGrainInterface<IChatRoom>("IChatRoom.kafka-cluster");
 
-interface IChatUser extends GrainWithStringKey {
+interface IChatUser extends GrainKey<string> {
   join(room: string): Promise<void>;
   count(): Promise<number>;
 }

--- a/packages/hosting/src/logging.test.ts
+++ b/packages/hosting/src/logging.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { LogFields, Logger } from "@thresh/core/logger";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
 import { createSilo } from "@thresh/hosting/silo-builder";
 
-interface Echoer extends GrainWithStringKey {
+interface Echoer extends GrainKey<string> {
   echo(s: string): Promise<string>;
   boom(): Promise<void>;
 }

--- a/packages/hosting/src/metrics.test.ts
+++ b/packages/hosting/src/metrics.test.ts
@@ -9,7 +9,7 @@ import {
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
 import { createSilo } from "@thresh/hosting/silo-builder";
@@ -21,7 +21,7 @@ const reader = new PeriodicExportingMetricReader({ exporter, exportIntervalMilli
 const meterProvider = new MeterProvider({ readers: [reader] });
 metrics.setGlobalMeterProvider(meterProvider);
 
-interface Greeter extends GrainWithStringKey {
+interface Greeter extends GrainKey<string> {
   greet(name: string): Promise<string>;
 }
 const Greeter = defineGrainInterface<Greeter>("MetricsGreeter");

--- a/packages/hosting/src/migration.test.ts
+++ b/packages/hosting/src/migration.test.ts
@@ -3,7 +3,7 @@ import { grain, persistentState } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { PersistentState } from "@thresh/core/persistent-state";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { FakeTimeProvider } from "@thresh/core/test-support/fake-time-provider";
@@ -15,7 +15,7 @@ interface BalanceState {
   cents: number;
 }
 
-interface IAccount extends GrainWithStringKey {
+interface IAccount extends GrainKey<string> {
   deposit(cents: number): Promise<number>;
   pendingDeposit(cents: number): Promise<number>;
   getBalance(): Promise<number>;

--- a/packages/hosting/src/persistence.test.ts
+++ b/packages/hosting/src/persistence.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { grain, persistentState } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { PersistentState } from "@thresh/core/persistent-state";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
@@ -13,7 +13,7 @@ interface BalanceState {
   cents: number;
 }
 
-interface IAccount extends GrainWithStringKey {
+interface IAccount extends GrainKey<string> {
   deposit(cents: number): Promise<number>;
   getBalance(): Promise<number>;
 }

--- a/packages/hosting/src/postgres-persistence.test.ts
+++ b/packages/hosting/src/postgres-persistence.test.ts
@@ -4,7 +4,7 @@ import { Pool } from "pg";
 import { grain, persistentState } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { PersistentState } from "@thresh/core/persistent-state";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
@@ -37,7 +37,7 @@ interface BalanceState {
   cents: number;
 }
 
-interface IAccount extends GrainWithStringKey {
+interface IAccount extends GrainKey<string> {
   deposit(cents: number): Promise<number>;
   getBalance(): Promise<number>;
 }

--- a/packages/hosting/src/postgres-reminders.test.ts
+++ b/packages/hosting/src/postgres-reminders.test.ts
@@ -4,7 +4,7 @@ import { Pool } from "pg";
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { Remindable, TickStatus } from "@thresh/core/reminder";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { FakeTimeProvider } from "@thresh/core/test-support/fake-time-provider";
@@ -35,7 +35,7 @@ afterAll(async () => {
   await admin.end();
 });
 
-interface IBilling extends GrainWithStringKey {
+interface IBilling extends GrainKey<string> {
   scheduleSelfCheck(): Promise<void>;
   checkCount(): Promise<number>;
 }

--- a/packages/hosting/src/postgres-streams-cluster.test.ts
+++ b/packages/hosting/src/postgres-streams-cluster.test.ts
@@ -5,7 +5,7 @@ import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import { stableHash32 } from "@thresh/core/hash";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import type { StreamHandler } from "@thresh/core/stream";
 import { ConsistentHashRing } from "@thresh/directory/consistent-hash-ring";
@@ -67,12 +67,12 @@ afterAll(async () => {
   await admin.end();
 });
 
-interface IChatRoom extends GrainWithStringKey {
+interface IChatRoom extends GrainKey<string> {
   say(text: string): Promise<void>;
 }
 const IChatRoom = defineGrainInterface<IChatRoom>("IChatRoom.pg-cluster");
 
-interface IChatUser extends GrainWithStringKey {
+interface IChatUser extends GrainKey<string> {
   join(room: string): Promise<void>;
   count(): Promise<number>;
 }

--- a/packages/hosting/src/redis-persistence.test.ts
+++ b/packages/hosting/src/redis-persistence.test.ts
@@ -4,7 +4,7 @@ import { createClient } from "redis";
 import { grain, persistentState } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { PersistentState } from "@thresh/core/persistent-state";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
@@ -45,7 +45,7 @@ interface BalanceState {
   cents: number;
 }
 
-interface IAccount extends GrainWithStringKey {
+interface IAccount extends GrainKey<string> {
   deposit(cents: number): Promise<number>;
   getBalance(): Promise<number>;
 }

--- a/packages/hosting/src/redis-pulling-streams.test.ts
+++ b/packages/hosting/src/redis-pulling-streams.test.ts
@@ -4,7 +4,7 @@ import { createClient } from "redis";
 import { grain, implicitStreamSubscription } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { STREAM_SUBSCRIPTION_OBSERVER, type StreamHandler } from "@thresh/core/stream";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
@@ -50,12 +50,12 @@ afterAll(async () => {
   await admin.destroy();
 });
 
-interface IChatRoom extends GrainWithStringKey {
+interface IChatRoom extends GrainKey<string> {
   say(text: string): Promise<void>;
 }
 const IChatRoom = defineGrainInterface<IChatRoom>("IChatRoom.pull");
 
-interface IChatUser extends GrainWithStringKey {
+interface IChatUser extends GrainKey<string> {
   join(room: string): Promise<void>;
   history(): Promise<string[]>;
 }
@@ -95,7 +95,7 @@ class ChatUserGrain extends Grain implements IChatUser {
 // a module sink (the grain may be collected between deliveries).
 const watched: Record<string, string[]> = {};
 
-interface IWatcher extends GrainWithStringKey {
+interface IWatcher extends GrainKey<string> {
   seen(): Promise<string[]>;
 }
 const IWatcher = defineGrainInterface<IWatcher>("IWatcher.pull", {

--- a/packages/hosting/src/redis-reminders.test.ts
+++ b/packages/hosting/src/redis-reminders.test.ts
@@ -4,7 +4,7 @@ import { createClient } from "redis";
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { Remindable, TickStatus } from "@thresh/core/reminder";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { FakeTimeProvider } from "@thresh/core/test-support/fake-time-provider";
@@ -43,7 +43,7 @@ afterAll(async () => {
   await admin.destroy();
 });
 
-interface IBilling extends GrainWithStringKey {
+interface IBilling extends GrainKey<string> {
   scheduleSelfCheck(): Promise<void>;
   checkCount(): Promise<number>;
 }

--- a/packages/hosting/src/redis-stream-failure-handler.test.ts
+++ b/packages/hosting/src/redis-stream-failure-handler.test.ts
@@ -4,7 +4,7 @@ import { createClient } from "redis";
 import { grain, implicitStreamSubscription } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { STREAM_SUBSCRIPTION_OBSERVER, type StreamHandler } from "@thresh/core/stream";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
@@ -54,12 +54,12 @@ afterAll(async () => {
   await admin.destroy();
 });
 
-interface IPoisonRoom extends GrainWithStringKey {
+interface IPoisonRoom extends GrainKey<string> {
   say(text: string): Promise<void>;
 }
 const IPoisonRoom = defineGrainInterface<IPoisonRoom>("IPoisonRoom.failureHandler");
 
-type IAlwaysFailingConsumerGrain = GrainWithStringKey;
+type IAlwaysFailingConsumerGrain = GrainKey<string>;
 const IAlwaysFailingConsumerGrain = defineGrainInterface<IAlwaysFailingConsumerGrain>(
   "IAlwaysFailingConsumerGrain.failureHandler",
 );

--- a/packages/hosting/src/redis-streams-cluster.test.ts
+++ b/packages/hosting/src/redis-streams-cluster.test.ts
@@ -5,7 +5,7 @@ import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import { stableHash32 } from "@thresh/core/hash";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import type { StreamHandler } from "@thresh/core/stream";
 import { ConsistentHashRing } from "@thresh/directory/consistent-hash-ring";
@@ -73,12 +73,12 @@ afterAll(async () => {
   await admin.destroy();
 });
 
-interface IChatRoom extends GrainWithStringKey {
+interface IChatRoom extends GrainKey<string> {
   say(text: string): Promise<void>;
 }
 const IChatRoom = defineGrainInterface<IChatRoom>("IChatRoom.cluster");
 
-interface IChatUser extends GrainWithStringKey {
+interface IChatUser extends GrainKey<string> {
   join(room: string): Promise<void>;
   count(): Promise<number>;
 }

--- a/packages/hosting/src/redis-streams.test.ts
+++ b/packages/hosting/src/redis-streams.test.ts
@@ -4,7 +4,7 @@ import { createClient } from "redis";
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import type { StreamHandler } from "@thresh/core/stream";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
@@ -41,12 +41,12 @@ afterAll(async () => {
   await admin.destroy();
 });
 
-interface IDevice extends GrainWithStringKey {
+interface IDevice extends GrainKey<string> {
   report(reading: number): Promise<void>;
 }
 const IDevice = defineGrainInterface<IDevice>("IDevice.redis");
 
-interface IAggregator extends GrainWithStringKey {
+interface IAggregator extends GrainKey<string> {
   readings(): Promise<number[]>;
 }
 const IAggregator = defineGrainInterface<IAggregator>("IAggregator.redis");

--- a/packages/hosting/src/redis-transactions.test.ts
+++ b/packages/hosting/src/redis-transactions.test.ts
@@ -6,7 +6,7 @@ import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import { GrainId } from "@thresh/core/grain-id";
 import type { GrainType } from "@thresh/core/grain-type";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import type { TransactionalState } from "@thresh/core/transactional-state";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
@@ -48,7 +48,7 @@ interface Balance {
   cents: number;
 }
 
-interface Account extends GrainWithStringKey {
+interface Account extends GrainKey<string> {
   credit(cents: number): Promise<void>;
   balance(): Promise<number>;
 }

--- a/packages/hosting/src/reducer-grains.test.ts
+++ b/packages/hosting/src/reducer-grains.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { grain, reducerState } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { ReducerState } from "@thresh/core/reducer-state";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
@@ -22,7 +22,7 @@ const reduceAccount = (state: AccountState, event: AccountEvent): AccountState =
     ? { balanceCents: state.balanceCents + event.cents, transactions: state.transactions + 1 }
     : { balanceCents: state.balanceCents - event.cents, transactions: state.transactions + 1 };
 
-interface IAccount extends GrainWithStringKey {
+interface IAccount extends GrainKey<string> {
   deposit(cents: number): Promise<number>;
   withdraw(cents: number): Promise<number>;
   balance(): Promise<number>;

--- a/packages/hosting/src/reminders-cluster.test.ts
+++ b/packages/hosting/src/reminders-cluster.test.ts
@@ -3,7 +3,7 @@ import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { Remindable, TickStatus } from "@thresh/core/reminder";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { FakeTimeProvider } from "@thresh/core/test-support/fake-time-provider";
@@ -14,7 +14,7 @@ import { StaticMembershipService } from "@thresh/runtime/static-membership";
 import { createSilo } from "@thresh/hosting/silo-builder";
 import type { SiloHost } from "@thresh/hosting/silo-host";
 
-interface IBeacon extends GrainWithStringKey {
+interface IBeacon extends GrainKey<string> {
   begin(): Promise<void>;
 }
 const IBeacon = defineGrainInterface<IBeacon>("IBeacon.reminders");

--- a/packages/hosting/src/reminders.test.ts
+++ b/packages/hosting/src/reminders.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { Remindable, TickStatus } from "@thresh/core/reminder";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { FakeTimeProvider } from "@thresh/core/test-support/fake-time-provider";
@@ -14,7 +14,7 @@ import { createSilo } from "@thresh/hosting/silo-builder";
 // (re)activations — the grain instance itself may be a fresh activation.
 const checks = new Map<string, number>();
 
-interface IBilling extends GrainWithStringKey {
+interface IBilling extends GrainKey<string> {
   scheduleSelfCheck(): Promise<void>;
   scheduleWithPeriodSeconds(periodSeconds: number): Promise<void>;
   checkCount(): Promise<number>;

--- a/packages/hosting/src/request-context.test.ts
+++ b/packages/hosting/src/request-context.test.ts
@@ -2,17 +2,17 @@ import { describe, expect, it } from "vitest";
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
 import { requestContext } from "@thresh/runtime/invocation-context";
 import { StaticMembershipService } from "@thresh/runtime/static-membership";
 import { createSilo } from "@thresh/hosting/silo-builder";
 
-interface Downstream extends GrainWithStringKey {
+interface Downstream extends GrainKey<string> {
   readTenant(): Promise<string | undefined>;
 }
-interface Caller extends GrainWithStringKey {
+interface Caller extends GrainKey<string> {
   propagate(tenant: string, downstream: string): Promise<string | undefined>;
 }
 

--- a/packages/hosting/src/silo-builder.test.ts
+++ b/packages/hosting/src/silo-builder.test.ts
@@ -3,12 +3,12 @@ import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
 import { createSilo } from "@thresh/hosting/silo-builder";
 
-interface ICounter extends GrainWithStringKey {
+interface ICounter extends GrainKey<string> {
   increment(by: number): Promise<number>;
 }
 const ICounter = defineGrainInterface<ICounter>("ICounter.hosting");
@@ -22,7 +22,7 @@ class CounterGrain extends Grain implements ICounter {
   }
 }
 
-interface IBlocker extends GrainWithStringKey {
+interface IBlocker extends GrainKey<string> {
   block(): Promise<string>;
 }
 const IBlocker = defineGrainInterface<IBlocker>("IBlocker.hosting");

--- a/packages/hosting/src/streams.test.ts
+++ b/packages/hosting/src/streams.test.ts
@@ -2,18 +2,18 @@ import { describe, expect, it } from "vitest";
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import type { StreamHandler } from "@thresh/core/stream";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
 import { createSilo } from "@thresh/hosting/silo-builder";
 
-interface IDevice extends GrainWithStringKey {
+interface IDevice extends GrainKey<string> {
   report(reading: number): Promise<void>;
 }
 const IDevice = defineGrainInterface<IDevice>("IDevice.stream");
 
-interface IAggregator extends GrainWithStringKey {
+interface IAggregator extends GrainKey<string> {
   readings(): Promise<number[]>;
 }
 const IAggregator = defineGrainInterface<IAggregator>("IAggregator.stream");

--- a/packages/hosting/src/tracing.test.ts
+++ b/packages/hosting/src/tracing.test.ts
@@ -11,7 +11,7 @@ import {
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
 import { createSilo } from "@thresh/hosting/silo-builder";
@@ -24,11 +24,11 @@ trace.setGlobalTracerProvider(provider);
 context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
 propagation.setGlobalPropagator(new W3CTraceContextPropagator());
 
-interface Down extends GrainWithStringKey {
+interface Down extends GrainKey<string> {
   ping(): Promise<string>;
   fail(): Promise<void>;
 }
-interface Front extends GrainWithStringKey {
+interface Front extends GrainKey<string> {
   call(down: string): Promise<string>;
 }
 const Down = defineGrainInterface<Down>("TraceDown");

--- a/packages/hosting/src/transaction-concurrency.test.ts
+++ b/packages/hosting/src/transaction-concurrency.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { grain, transactionalState } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import type { TransactionalState } from "@thresh/core/transactional-state";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
@@ -12,12 +12,12 @@ interface Count {
   n: number;
 }
 
-interface Counter extends GrainWithStringKey {
+interface Counter extends GrainKey<string> {
   bump(): Promise<void>;
   value(): Promise<number>;
 }
 
-interface Runner extends GrainWithStringKey {
+interface Runner extends GrainKey<string> {
   /** Bump the counter inside a transaction, then hold the transaction open. */
   bumpAndHold(counter: string): Promise<void>;
   /** Bump the counter inside its own transaction and commit. */

--- a/packages/hosting/src/transaction-durability.test.ts
+++ b/packages/hosting/src/transaction-durability.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { grain, transactionalState } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import type { TransactionalState } from "@thresh/core/transactional-state";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
@@ -14,7 +14,7 @@ interface Balance {
   cents: number;
 }
 
-interface Account extends GrainWithStringKey {
+interface Account extends GrainKey<string> {
   credit(cents: number): Promise<void>;
   creditThenFail(cents: number): Promise<void>;
   balance(): Promise<number>;

--- a/packages/hosting/src/transaction-keepalive-deactivation.test.ts
+++ b/packages/hosting/src/transaction-keepalive-deactivation.test.ts
@@ -5,7 +5,7 @@ import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import { IManagementGrain } from "@thresh/core/management-grain";
 import type { GrainType } from "@thresh/core/grain-type";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import type { TransactionalState } from "@thresh/core/transactional-state";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
@@ -17,7 +17,7 @@ interface Balance {
   cents: number;
 }
 
-interface Account extends GrainWithStringKey {
+interface Account extends GrainKey<string> {
   ping(): Promise<string>;
 }
 

--- a/packages/hosting/src/transaction-recovery.test.ts
+++ b/packages/hosting/src/transaction-recovery.test.ts
@@ -4,7 +4,7 @@ import { Grain } from "@thresh/core/grain";
 import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import type { GrainType } from "@thresh/core/grain-type";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import type { TransactionalState } from "@thresh/core/transactional-state";
 import type { TransactionalStateStorage } from "@thresh/core/transactional-storage";
@@ -16,10 +16,10 @@ interface Balance {
   cents: number;
 }
 
-interface Account extends GrainWithStringKey {
+interface Account extends GrainKey<string> {
   balance(): Promise<number>;
 }
-interface Ledger extends GrainWithStringKey {
+interface Ledger extends GrainKey<string> {
   open(): Promise<void>;
 }
 

--- a/packages/hosting/src/transactions-cluster.test.ts
+++ b/packages/hosting/src/transactions-cluster.test.ts
@@ -3,20 +3,20 @@ import { defineGrain, useTransactionalState } from "@thresh/core/define-grain";
 import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import type { GrainType } from "@thresh/core/grain-type";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { TestCluster } from "@thresh/testing/test-cluster";
 
 interface Balance {
   cents: number;
 }
 
-interface Account extends GrainWithStringKey {
+interface Account extends GrainKey<string> {
   deposit(cents: number): Promise<void>;
   withdraw(cents: number): Promise<void>;
   balance(): Promise<number>;
 }
 
-interface Teller extends GrainWithStringKey {
+interface Teller extends GrainKey<string> {
   fund(account: string, cents: number): Promise<void>;
   transfer(from: string, to: string, cents: number): Promise<void>;
 }

--- a/packages/hosting/src/transactions.test.ts
+++ b/packages/hosting/src/transactions.test.ts
@@ -3,7 +3,7 @@ import { defineGrain, useTransactionalState } from "@thresh/core/define-grain";
 import { grain, transactionalState } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import type { TransactionalState } from "@thresh/core/transactional-state";
 import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
@@ -13,18 +13,18 @@ interface Balance {
   cents: number;
 }
 
-interface Account extends GrainWithStringKey {
+interface Account extends GrainKey<string> {
   deposit(cents: number): Promise<void>;
   withdraw(cents: number): Promise<void>;
   balance(): Promise<number>;
 }
 
-interface FnAccount extends GrainWithStringKey {
+interface FnAccount extends GrainKey<string> {
   deposit(cents: number): Promise<void>;
   balance(): Promise<number>;
 }
 
-interface Atm extends GrainWithStringKey {
+interface Atm extends GrainKey<string> {
   transfer(from: string, to: string, cents: number): Promise<void>;
   fund(account: string, cents: number): Promise<void>;
   fundFn(account: string, cents: number): Promise<void>;

--- a/packages/parity/src/default-cluster/key-extension-tests.test.ts
+++ b/packages/parity/src/default-cluster/key-extension-tests.test.ts
@@ -2,7 +2,7 @@
 // Every scenario but one turns on Orleans' compound key (`IGrainWithGuidCompoundKey`:
 // a primary Guid plus a string "key extension"), represented here by
 // `CompoundKey<Guid>` (packages/core/src/grain-key.ts) via the
-// `GrainWithGuidCompoundKey` marker interface (packages/core/src/key-kinds.ts).
+// `GrainKey<CompoundKey<Guid>>` marker interface (packages/core/src/key-kinds.ts).
 import { afterAll, beforeAll, describe, expect } from "vitest";
 import { orleansTest } from "@thresh/testing/orleans-test";
 import { TestCluster } from "@thresh/testing/test-cluster";

--- a/packages/parity/src/grains/interfaces/account-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/account-grain-interfaces.ts
@@ -1,7 +1,7 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/EventSourcing/IAccountGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import type { Guid } from "@thresh/core/guid";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /** A single deposit or withdrawal against the account. */
 export interface Transaction {
@@ -12,7 +12,7 @@ export interface Transaction {
   amount: number;
 }
 
-export interface IAccountGrain extends GrainWithStringKey {
+export interface IAccountGrain extends GrainKey<string> {
   balance(): Promise<number>;
   deposit(amount: number, guid: Guid, description: string): Promise<void>;
   withdraw(amount: number, guid: Guid, description: string): Promise<boolean>;

--- a/packages/parity/src/grains/interfaces/activate-deactivate-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/activate-deactivate-test-grain-interfaces.ts
@@ -1,9 +1,9 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/IActivateDeactivateWatcherGrain.cs
 // and IActivateDeactivateTestGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IActivateDeactivateWatcherGrain extends GrainWithIntegerKey {
+export interface IActivateDeactivateWatcherGrain extends GrainKey<bigint> {
   getActivateCalls(): Promise<string[]>;
   getDeactivateCalls(): Promise<string[]>;
   clear(): Promise<void>;
@@ -20,7 +20,7 @@ export const IActivateDeactivateWatcherGrain =
 // grain classes rather than subclassing, since a grain can implement only one
 // primary interface; the TS grains below mirror that structure.
 
-export interface ISimpleActivateDeactivateTestGrain extends GrainWithIntegerKey {
+export interface ISimpleActivateDeactivateTestGrain extends GrainKey<bigint> {
   doSomething(): Promise<string>;
   doDeactivate(): Promise<void>;
 }
@@ -33,7 +33,7 @@ export const ISimpleActivateDeactivateTestGrain =
 // Upstream's tail-call variant exercises a .NET IL tail-call code path in
 // OnActivateAsync/OnDeactivateAsync; JS has no equivalent distinction, so this
 // grain's behaviour mirrors ISimpleActivateDeactivateTestGrain exactly.
-export interface ITailCallActivateDeactivateTestGrain extends GrainWithIntegerKey {
+export interface ITailCallActivateDeactivateTestGrain extends GrainKey<bigint> {
   doSomething(): Promise<string>;
   doDeactivate(): Promise<void>;
 }
@@ -43,7 +43,7 @@ export const ITailCallActivateDeactivateTestGrain =
     "UnitTests.GrainInterfaces.ITailCallActivateDeactivateTestGrain",
   );
 
-export interface ILongRunningActivateDeactivateTestGrain extends GrainWithIntegerKey {
+export interface ILongRunningActivateDeactivateTestGrain extends GrainKey<bigint> {
   doSomething(): Promise<string>;
   doDeactivate(): Promise<void>;
 }
@@ -53,7 +53,7 @@ export const ILongRunningActivateDeactivateTestGrain =
     "UnitTests.GrainInterfaces.ILongRunningActivateDeactivateTestGrain",
   );
 
-export interface IBadActivateDeactivateTestGrain extends GrainWithIntegerKey {
+export interface IBadActivateDeactivateTestGrain extends GrainKey<bigint> {
   throwSomething(): Promise<void>;
   getKey(): Promise<bigint>;
 }
@@ -63,7 +63,7 @@ export const IBadActivateDeactivateTestGrain =
     "UnitTests.GrainInterfaces.IBadActivateDeactivateTestGrain",
   );
 
-export interface IBadConstructorTestGrain extends GrainWithIntegerKey {
+export interface IBadConstructorTestGrain extends GrainKey<bigint> {
   doSomething(): Promise<string>;
 }
 
@@ -71,7 +71,7 @@ export const IBadConstructorTestGrain = defineGrainInterface<IBadConstructorTest
   "UnitTests.GrainInterfaces.IBadConstructorTestGrain",
 );
 
-export interface ITaskActionActivateDeactivateTestGrain extends GrainWithIntegerKey {
+export interface ITaskActionActivateDeactivateTestGrain extends GrainKey<bigint> {
   doSomething(): Promise<string>;
   doDeactivate(): Promise<void>;
 }
@@ -81,7 +81,7 @@ export const ITaskActionActivateDeactivateTestGrain =
     "UnitTests.GrainInterfaces.ITaskActionActivateDeactivateTestGrain",
   );
 
-export interface ICreateGrainReferenceTestGrain extends GrainWithIntegerKey {
+export interface ICreateGrainReferenceTestGrain extends GrainKey<bigint> {
   doSomething(): Promise<string>;
   forwardCall(otherGrain: IBadActivateDeactivateTestGrain): Promise<void>;
 }
@@ -90,7 +90,7 @@ export const ICreateGrainReferenceTestGrain = defineGrainInterface<ICreateGrainR
   "UnitTests.GrainInterfaces.ICreateGrainReferenceTestGrain",
 );
 
-export interface IDeactivatingWhileActivatingTestGrain extends GrainWithIntegerKey {
+export interface IDeactivatingWhileActivatingTestGrain extends GrainKey<bigint> {
   doSomething(): Promise<string>;
 }
 

--- a/packages/parity/src/grains/interfaces/activation-tracing-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/activation-tracing-grain-interfaces.ts
@@ -9,7 +9,7 @@
 // asserts on what the CALLED grain observes of its own trace context
 // (span id, trace state, baggage), not on captured spans.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /**
  * What a grain call sees of its own OpenTelemetry span (the port analogue of
@@ -22,7 +22,7 @@ export interface ActivityData {
   readonly baggage: Readonly<Record<string, string>>;
 }
 
-export interface IActivityGrain extends GrainWithIntegerKey {
+export interface IActivityGrain extends GrainKey<bigint> {
   getActivityId(): Promise<string | undefined>;
   /** Reports this activation's trace id/span id/trace state/baggage — see `ActivityData`. */
   getActivityData(): Promise<ActivityData>;
@@ -32,7 +32,7 @@ export const IActivityGrain = defineGrainInterface<IActivityGrain>(
   "UnitTests.GrainInterfaces.IActivityGrain",
 );
 
-export interface IPersistentStateActivityGrain extends GrainWithIntegerKey {
+export interface IPersistentStateActivityGrain extends GrainKey<bigint> {
   getActivityId(): Promise<string | undefined>;
   getStateValue(): Promise<number>;
 }

--- a/packages/parity/src/grains/interfaces/catalog-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/catalog-test-grain-interfaces.ts
@@ -1,8 +1,8 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/ICatalogTestGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface ICatalogTestGrain extends GrainWithIntegerKey {
+export interface ICatalogTestGrain extends GrainKey<bigint> {
   initialize(): Promise<void>;
   blastCallNewGrains(nGrains: number, startingKey: bigint, nCallsToEach: number): Promise<void>;
 }

--- a/packages/parity/src/grains/interfaces/chained-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/chained-grain-interfaces.ts
@@ -1,13 +1,13 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/IChainedGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /** Upstream `ChainGrainHolder`: wraps a grain reference so it round-trips inside a nested object. */
 export interface ChainGrainHolder {
   next: IChainedGrain | null;
 }
 
-export interface IChainedGrain extends GrainWithIntegerKey {
+export interface IChainedGrain extends GrainKey<bigint> {
   getId(): Promise<number>;
   getX(): Promise<number>;
   getNext(): Promise<IChainedGrain | null>;

--- a/packages/parity/src/grains/interfaces/chat-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/chat-grain-interfaces.ts
@@ -1,12 +1,12 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/EventSourcing/IChatGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import type { Guid } from "@thresh/core/guid";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 // Upstream returns an `XDocument`; there is no XML type in this stack, so
 // `getChat` returns the same content serialised as text and callers parse the
 // bits they need with the small helpers in chat-grain-tests.test.ts.
-export interface IChatGrain extends GrainWithStringKey {
+export interface IChatGrain extends GrainKey<string> {
   getChat(): Promise<string>;
   post(guid: Guid, user: string, text: string): Promise<void>;
   delete(guid: Guid): Promise<void>;

--- a/packages/parity/src/grains/interfaces/client-addressable-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/client-addressable-interfaces.ts
@@ -9,10 +9,10 @@
 // return value from the client object rather than firing-and-forgetting a
 // notification. None of these methods are one-way.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey, GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /** Client-hosted object a grain calls back into and awaits a result from. */
-export interface IClientAddressableTestClientObject extends GrainWithStringKey {
+export interface IClientAddressableTestClientObject extends GrainKey<string> {
   onHappyPath(message: string): Promise<string>;
   onSadPath(message: string): Promise<void>;
   onSerialStress(n: number): Promise<number>;
@@ -25,7 +25,7 @@ export const IClientAddressableTestClientObject =
   );
 
 /** Client-hosted producer a grain polls for data. */
-export interface IClientAddressableTestProducer extends GrainWithStringKey {
+export interface IClientAddressableTestProducer extends GrainKey<string> {
   poll(): Promise<number>;
 }
 
@@ -33,7 +33,7 @@ export const IClientAddressableTestProducer = defineGrainInterface<IClientAddres
   "UnitTests.GrainInterfaces.IClientAddressableTestProducer",
 );
 
-export interface IClientAddressableTestGrain extends GrainWithIntegerKey {
+export interface IClientAddressableTestGrain extends GrainKey<bigint> {
   setTarget(target: IClientAddressableTestClientObject): Promise<void>;
   happyPath(message: string): Promise<string>;
   sadPath(message: string): Promise<void>;
@@ -45,7 +45,7 @@ export const IClientAddressableTestGrain = defineGrainInterface<IClientAddressab
   "UnitTests.GrainInterfaces.IClientAddressableTestGrain",
 );
 
-export interface IClientAddressableTestConsumer extends GrainWithIntegerKey {
+export interface IClientAddressableTestConsumer extends GrainKey<bigint> {
   pollProducer(): Promise<number>;
   setup(): Promise<void>;
 }
@@ -54,7 +54,7 @@ export const IClientAddressableTestConsumer = defineGrainInterface<IClientAddres
   "UnitTests.GrainInterfaces.IClientAddressableTestConsumer",
 );
 
-export interface IClientAddressableTestRendezvousGrain extends GrainWithIntegerKey {
+export interface IClientAddressableTestRendezvousGrain extends GrainKey<bigint> {
   getProducer(): Promise<IClientAddressableTestProducer>;
   setProducer(producer: IClientAddressableTestProducer): Promise<void>;
 }

--- a/packages/parity/src/grains/interfaces/counters-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/counters-grain-interfaces.ts
@@ -1,9 +1,9 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/EventSourcing/ICountersGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /** A grain that maintains a number of counters, indexed by a string key. */
-export interface ICountersGrain extends GrainWithIntegerKey {
+export interface ICountersGrain extends GrainKey<bigint> {
   /** Updates the counter for the given key by the given amount. */
   add(key: string, amount: number, waitForConfirmation: boolean): Promise<void>;
   /** Resets all counters to zero. */

--- a/packages/parity/src/grains/interfaces/deactivation-tracing-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/deactivation-tracing-grain-interfaces.ts
@@ -5,11 +5,11 @@
 // reports back; only `getActivityId`'s SPAN ID matters, for parity with the
 // activation-tracing grains' shape).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { SiloAddress } from "@thresh/core/silo-address";
 
 /** Basic deactivation tracing: a plain `onDeactivate` no-op. */
-export interface IDeactivationTracingTestGrain extends GrainWithIntegerKey {
+export interface IDeactivationTracingTestGrain extends GrainKey<bigint> {
   getActivityId(): Promise<string | undefined>;
 }
 
@@ -18,7 +18,7 @@ export const IDeactivationTracingTestGrain = defineGrainInterface<IDeactivationT
 );
 
 /** Deactivation tracing with a persistent-state write from inside `onDeactivate`. */
-export interface IDeactivationWithWorkTracingTestGrain extends GrainWithIntegerKey {
+export interface IDeactivationWithWorkTracingTestGrain extends GrainKey<bigint> {
   getActivityId(): Promise<string | undefined>;
   wasDeactivated(): Promise<boolean>;
 }
@@ -29,7 +29,7 @@ export const IDeactivationWithWorkTracingTestGrain =
   );
 
 /** Deactivation tracing where `onDeactivate` throws. */
-export interface IDeactivationWithExceptionTracingTestGrain extends GrainWithIntegerKey {
+export interface IDeactivationWithExceptionTracingTestGrain extends GrainKey<bigint> {
   getActivityId(): Promise<string | undefined>;
 }
 
@@ -39,7 +39,7 @@ export const IDeactivationWithExceptionTracingTestGrain =
   );
 
 /** A grain whose constructor throws, so activation never completes. */
-export interface IActivationFailureDeactivationGrain extends GrainWithIntegerKey {
+export interface IActivationFailureDeactivationGrain extends GrainKey<bigint> {
   getActivityId(): Promise<string | undefined>;
 }
 
@@ -56,7 +56,7 @@ export const IActivationFailureDeactivationGrain =
  * takes the target directly, unlike upstream's placement-hint-directed
  * `Cast<IGrainManagementExtension>().MigrateOnIdle()`).
  */
-export interface IDeactivationMigrationTracingTestGrain extends GrainWithIntegerKey {
+export interface IDeactivationMigrationTracingTestGrain extends GrainKey<bigint> {
   setState(state: number): Promise<void>;
   getState(): Promise<number>;
   migrateOnIdle(target?: SiloAddress): Promise<void>;

--- a/packages/parity/src/grains/interfaces/durable-collections-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/durable-collections-grain-interfaces.ts
@@ -7,9 +7,9 @@
 // activation instead of reaching for the internal state-machine-manager
 // package directly (out of bounds for @thresh/parity).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IDurableCollectionsGrain extends GrainWithStringKey {
+export interface IDurableCollectionsGrain extends GrainKey<string> {
   // DurableValue<unknown>
   setValue(v: unknown): Promise<void>;
   getValue(): Promise<unknown>;

--- a/packages/parity/src/grains/interfaces/durable-job-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/durable-job-grain-interfaces.ts
@@ -2,10 +2,10 @@
 // ISchedulerGrain.cs, IRetryTestGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import type { DurableJob, JobRunContext } from "@thresh/core/durable-job";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /** Upstream `UnitTests.GrainInterfaces.IDurableJobGrain`. */
-export interface IDurableJobGrain extends GrainWithStringKey {
+export interface IDurableJobGrain extends GrainKey<string> {
   scheduleJobAsync(
     jobName: string,
     scheduledTime: Date,
@@ -30,7 +30,7 @@ export const IDurableJobGrain = defineGrainInterface<IDurableJobGrain>(
 );
 
 /** Upstream `UnitTests.GrainInterfaces.ISchedulerGrain`. */
-export interface ISchedulerGrain extends GrainWithStringKey {
+export interface ISchedulerGrain extends GrainKey<string> {
   scheduleJobOnAnotherGrainAsync(
     targetGrainKey: string,
     jobName: string,
@@ -42,7 +42,7 @@ export const ISchedulerGrain = defineGrainInterface<ISchedulerGrain>(
 );
 
 /** Upstream `UnitTests.GrainInterfaces.IRetryTestGrain`. */
-export interface IRetryTestGrain extends GrainWithStringKey {
+export interface IRetryTestGrain extends GrainKey<string> {
   scheduleJobAsync(
     jobName: string,
     scheduledTime: Date,

--- a/packages/parity/src/grains/interfaces/echo-task-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/echo-task-grain-interfaces.ts
@@ -1,9 +1,10 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/IEchoTaskGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithGuidKey, GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { SiloAddress } from "@thresh/core/silo-address";
+import type { Guid } from "@thresh/core/guid";
 
-export interface IEchoGrain extends GrainWithGuidKey {
+export interface IEchoGrain extends GrainKey<Guid> {
   getLastEcho(): Promise<string>;
   echo(data: string): Promise<string>;
   echoError(data: string): Promise<string>;
@@ -12,7 +13,7 @@ export interface IEchoGrain extends GrainWithGuidKey {
 
 export const IEchoGrain = defineGrainInterface<IEchoGrain>("UnitTests.GrainInterfaces.IEchoGrain");
 
-export interface IEchoTaskGrain extends GrainWithGuidKey {
+export interface IEchoTaskGrain extends GrainKey<Guid> {
   getMyIdAsync(): Promise<number>;
   getLastEchoAsync(): Promise<string>;
   echoAsync(data: string): Promise<string>;
@@ -38,7 +39,7 @@ export const IEchoTaskGrain = defineGrainInterface<IEchoTaskGrain>(
   { options: { blockingCallTimeoutAsync: { responseTimeout: { seconds: 5 } } } },
 );
 
-export interface IBlockingEchoTaskGrain extends GrainWithIntegerKey {
+export interface IBlockingEchoTaskGrain extends GrainKey<bigint> {
   getMyId(): Promise<number>;
   getLastEcho(): Promise<string>;
   echo(data: string): Promise<string>;
@@ -50,7 +51,7 @@ export const IBlockingEchoTaskGrain = defineGrainInterface<IBlockingEchoTaskGrai
   "UnitTests.GrainInterfaces.IBlockingEchoTaskGrain",
 );
 
-export interface IReentrantBlockingEchoTaskGrain extends GrainWithIntegerKey {
+export interface IReentrantBlockingEchoTaskGrain extends GrainKey<bigint> {
   getMyId(): Promise<number>;
   getLastEcho(): Promise<string>;
   echo(data: string): Promise<string>;

--- a/packages/parity/src/grains/interfaces/exception-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/exception-grain-interfaces.ts
@@ -4,9 +4,9 @@
 // serializer-codec failure injection (.NET serializer internals) — see that
 // test file's EXCLUDED entries.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IExceptionGrain extends GrainWithIntegerKey {
+export interface IExceptionGrain extends GrainKey<bigint> {
   canceled(): Promise<void>;
   throwsInvalidOperationException(): Promise<void>;
   throwsNullReferenceException(): Promise<void>;

--- a/packages/parity/src/grains/interfaces/extension-test-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/extension-test-interfaces.ts
@@ -6,14 +6,14 @@
 // (GAP-GENERIC-GRAINS), tracked separately from the non-generic extension mechanism.
 //
 // The three extension interfaces (`ITestExtension`, `ISimpleExtension`, `IAutoExtension`)
-// extend `GrainWithIntegerKey` purely so `castGrainReference` has a concrete key kind to
+// extend `GrainKey<bigint>` purely so `castGrainReference` has a concrete key kind to
 // carry — an extension interface is never itself the target of `cluster.getGrain`, it is
 // only reached by casting a reference to a grain that already has one; the extension rides
 // the grain's own id, so the declared key kind here is otherwise unused.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IExtensionTestGrain extends GrainWithIntegerKey {
+export interface IExtensionTestGrain extends GrainKey<bigint> {
   installExtension(name: string): Promise<void>;
 }
 
@@ -21,13 +21,13 @@ export const IExtensionTestGrain = defineGrainInterface<IExtensionTestGrain>(
   "UnitTests.GrainInterfaces.IExtensionTestGrain",
 );
 
-export type INoOpTestGrain = GrainWithIntegerKey;
+export type INoOpTestGrain = GrainKey<bigint>;
 
 export const INoOpTestGrain = defineGrainInterface<INoOpTestGrain>(
   "UnitTests.GrainInterfaces.INoOpTestGrain",
 );
 
-export interface ITestExtension extends GrainWithIntegerKey {
+export interface ITestExtension extends GrainKey<bigint> {
   checkExtension_1(): Promise<string>;
   checkExtension_2(): Promise<string>;
 }
@@ -37,7 +37,7 @@ export const ITestExtension = defineGrainInterface<ITestExtension>(
   { extension: true },
 );
 
-export interface ISimpleExtension extends GrainWithIntegerKey {
+export interface ISimpleExtension extends GrainKey<bigint> {
   checkExtension_1(): Promise<string>;
 }
 
@@ -46,7 +46,7 @@ export const ISimpleExtension = defineGrainInterface<ISimpleExtension>(
   { extension: true },
 );
 
-export interface IAutoExtension extends GrainWithIntegerKey {
+export interface IAutoExtension extends GrainKey<bigint> {
   checkExtension(): Promise<string>;
 }
 

--- a/packages/parity/src/grains/interfaces/external-type-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/external-type-grain-interfaces.ts
@@ -1,6 +1,6 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/IExternalTypeGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /** Upstream `UnitTests.GrainInterfaces.EnumClass`. */
 export interface EnumClass {
@@ -15,7 +15,7 @@ export interface EnumClass {
  * grain assembly; no test calls it and there is no TS analog for
  * `NameObjectCollectionBase`, so it is omitted here.
  */
-export interface IExternalTypeGrain extends GrainWithIntegerKey {
+export interface IExternalTypeGrain extends GrainKey<bigint> {
   getEnumModel(): Promise<EnumClass>;
 }
 export const IExternalTypeGrain = defineGrainInterface<IExternalTypeGrain>(

--- a/packages/parity/src/grains/interfaces/generator-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/generator-test-grain-interfaces.ts
@@ -2,7 +2,7 @@
 // IGeneratorTestDerivedGrain1.cs, IGeneratorTestDerivedGrain2.cs,
 // IGeneratorTestDerivedDerivedGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /** Upstream `UnitTests.GrainInterfaces.ReturnCode`. */
 export type ReturnCode = "OK" | "Fail";
@@ -15,7 +15,7 @@ export interface MemberVariables {
 }
 
 /** Upstream `UnitTests.GrainInterfaces.IGeneratorTestGrain`. */
-export interface IGeneratorTestGrain extends GrainWithIntegerKey {
+export interface IGeneratorTestGrain extends GrainKey<bigint> {
   byteSet(data: Uint8Array): Promise<Uint8Array>;
   stringSet(str: string): Promise<void>;
   stringIsNullOrEmpty(): Promise<boolean>;

--- a/packages/parity/src/grains/interfaces/generic-grain-tests-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/generic-grain-tests-interfaces.ts
@@ -3,9 +3,9 @@
 // generic interface in the upstream file is unrepresentable here
 // (GAP-GENERIC-GRAINS — see generic-grain-tests.test.ts).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IGrainWithNoProperties extends GrainWithIntegerKey {
+export interface IGrainWithNoProperties extends GrainKey<bigint> {
   getAxB(a: number, b: number): Promise<string>;
 }
 
@@ -13,7 +13,7 @@ export const IGrainWithNoProperties = defineGrainInterface<IGrainWithNoPropertie
   "UnitTests.GrainInterfaces.IGrainWithNoProperties",
 );
 
-export interface IGrainWithListFields extends GrainWithIntegerKey {
+export interface IGrainWithListFields extends GrainKey<bigint> {
   addItem(item: string): Promise<void>;
   getItems(): Promise<readonly string[]>;
 }

--- a/packages/parity/src/grains/interfaces/get-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/get-grain-interfaces.ts
@@ -5,9 +5,10 @@
 // registration time, so that mechanism has no analogue here (see
 // grain-factory-tests.test.ts). Only the two key-kind probes are ported.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithGuidKey, GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
+import type { Guid } from "@thresh/core/guid";
 
-export interface IStringGrain extends GrainWithStringKey {
+export interface IStringGrain extends GrainKey<string> {
   foo(): Promise<boolean>;
 }
 
@@ -15,7 +16,7 @@ export const IStringGrain = defineGrainInterface<IStringGrain>(
   "UnitTests.GrainInterfaces.IStringGrain",
 );
 
-export interface IGuidGrain extends GrainWithGuidKey {
+export interface IGuidGrain extends GrainKey<Guid> {
   foo(): Promise<boolean>;
 }
 

--- a/packages/parity/src/grains/interfaces/grain-interface-hierarchy-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/grain-interface-hierarchy-interfaces.ts
@@ -1,6 +1,6 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/GrainInterfaceHierarchyIGrains.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /** Upstream `IDoSomething`: not itself a grain interface, mixed into the ones below. */
 export interface IDoSomething {
@@ -10,7 +10,7 @@ export interface IDoSomething {
   getA(): Promise<number>;
 }
 
-export interface IDoSomethingEmptyGrain extends IDoSomething, GrainWithIntegerKey {}
+export interface IDoSomethingEmptyGrain extends IDoSomething, GrainKey<bigint> {}
 
 export const IDoSomethingEmptyGrain = defineGrainInterface<IDoSomethingEmptyGrain>(
   "TestGrainInterfaces.IDoSomethingEmptyGrain",
@@ -32,7 +32,7 @@ export const IDoSomethingWithMoreEmptyGrain = defineGrainInterface<IDoSomethingW
   "TestGrainInterfaces.IDoSomethingWithMoreEmptyGrain",
 );
 
-export interface IDoSomethingWithMoreGrain extends IDoSomething, GrainWithIntegerKey {
+export interface IDoSomethingWithMoreGrain extends IDoSomething, GrainKey<bigint> {
   doThat(): Promise<string>;
   setB(b: number): Promise<void>;
   incrementB(): Promise<void>;

--- a/packages/parity/src/grains/interfaces/grain-service-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/grain-service-test-grain-interfaces.ts
@@ -10,9 +10,9 @@
 // and `IEchoExtension` (the grain-extension the service hosts) need declaring
 // here.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IGrainServiceTestGrain extends GrainWithIntegerKey {
+export interface IGrainServiceTestGrain extends GrainKey<bigint> {
   getHelloWorldUsingCustomService(): Promise<string>;
   callHasStarted(): Promise<boolean>;
   callHasStartedInBackground(): Promise<boolean>;

--- a/packages/parity/src/grains/interfaces/guid-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/guid-test-grain-interfaces.ts
@@ -3,9 +3,9 @@
 // only the subset the ported BasicActivationTests case exercises is declared here.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import type { Guid } from "@thresh/core/guid";
-import type { GrainWithGuidKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IGuidTestGrain extends GrainWithGuidKey {
+export interface IGuidTestGrain extends GrainKey<Guid> {
   getKey(): Promise<Guid>;
   getLabel(): Promise<string>;
   setLabel(label: string): Promise<void>;

--- a/packages/parity/src/grains/interfaces/initial-state-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/initial-state-grain-interfaces.ts
@@ -1,8 +1,8 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/IInitialStateGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IInitialStateGrain extends GrainWithIntegerKey {
+export interface IInitialStateGrain extends GrainKey<bigint> {
   getNames(): Promise<string[]>;
   addName(name: string): Promise<void>;
 }

--- a/packages/parity/src/grains/interfaces/json-node-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/json-node-test-grain-interfaces.ts
@@ -12,9 +12,9 @@
 // no declared-type tagging, so there is no base/derived distinction to get
 // wrong — `unknown` is the faithful equivalent of "any JSON-shaped value".
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IJsonNodeTestGrain extends GrainWithIntegerKey {
+export interface IJsonNodeTestGrain extends GrainKey<bigint> {
   processJsonNode(node: unknown): Promise<unknown>;
   getJsonString(node: unknown): Promise<string>;
 }

--- a/packages/parity/src/grains/interfaces/key-extension-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/key-extension-test-grain-interfaces.ts
@@ -1,8 +1,10 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/IKeyExtensionTestGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithGuidCompoundKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
+import type { CompoundKey } from "@thresh/core/grain-key";
+import type { Guid } from "@thresh/core/guid";
 
-export interface IKeyExtensionTestGrain extends GrainWithGuidCompoundKey {
+export interface IKeyExtensionTestGrain extends GrainKey<CompoundKey<Guid>> {
   getGrainReference(): Promise<IKeyExtensionTestGrain>;
   getActivationId(): Promise<string>;
 }

--- a/packages/parity/src/grains/interfaces/liveness-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/liveness-test-grain-interfaces.ts
@@ -6,9 +6,9 @@
 // a running grain to implement them faithfully, so they are dropped along
 // with that logging-only call site (see liveness-tests.test.ts).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface ILivenessTestGrain extends GrainWithIntegerKey {
+export interface ILivenessTestGrain extends GrainKey<bigint> {
   getPrimaryKeyLong(): Promise<bigint>;
   getLabel(): Promise<string>;
   setLabel(label: string): Promise<void>;

--- a/packages/parity/src/grains/interfaces/log-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/log-test-grain-interfaces.ts
@@ -3,14 +3,14 @@
 // raw event-log reads, etc.) used across many log-consistency-provider test
 // suites. Only the members `LogTestGrainClearTests` needs are ported here.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 export interface AB {
   a: number;
   b: number;
 }
 
-export interface ILogTestGrain extends GrainWithIntegerKey {
+export interface ILogTestGrain extends GrainKey<bigint> {
   getAGlobal(): Promise<number>;
   getALocal(): Promise<number>;
   getBothGlobal(): Promise<AB>;

--- a/packages/parity/src/grains/interfaces/long-running-task-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/long-running-task-grain-interfaces.ts
@@ -14,9 +14,10 @@
 // recorded cancelled, not to observe a live stream of cancellations.
 import type { GrainCancellationToken } from "@thresh/core/grain-cancellation-token";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithGuidKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
+import type { Guid } from "@thresh/core/guid";
 
-export interface ILongRunningTaskGrain extends GrainWithGuidKey {
+export interface ILongRunningTaskGrain extends GrainKey<Guid> {
   /** Awaits a cancellable delay; on cancellation records `callId` and throws `GrainTaskCanceledError`. */
   longWaitGrainCancellation(
     token: GrainCancellationToken,

--- a/packages/parity/src/grains/interfaces/management-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/management-grain-interfaces.ts
@@ -1,16 +1,17 @@
 // Ported from dotnet/orleans test/Orleans.DefaultCluster.Tests/ManagementGrainTests.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithGuidKey, GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
+import type { Guid } from "@thresh/core/guid";
 
 /** Upstream `IDumbGrain`: a plain grain with a single, stable activation. */
-export interface IDumbGrain extends GrainWithGuidKey {
+export interface IDumbGrain extends GrainKey<Guid> {
   doNothing(): Promise<void>;
 }
 
 export const IDumbGrain = defineGrainInterface<IDumbGrain>("UnitTests.OrleansRuntime.IDumbGrain");
 
 /** Upstream `IDumbWorker`: a `[StatelessWorker]` grain with no single activation. */
-export interface IDumbWorker extends GrainWithIntegerKey {
+export interface IDumbWorker extends GrainKey<bigint> {
   doNothing(): Promise<void>;
 }
 

--- a/packages/parity/src/grains/interfaces/may-interleave-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/may-interleave-grain-interfaces.ts
@@ -8,9 +8,9 @@
 // exist — see `client.createObjectReference` — but routing start/release
 // through it would add wire round-trips without changing what is tested.)
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IMayInterleaveGrain extends GrainWithIntegerKey {
+export interface IMayInterleaveGrain extends GrainKey<bigint> {
   goFast(tag: string): Promise<void>;
   goSlow(tag: string): Promise<void>;
 }

--- a/packages/parity/src/grains/interfaces/method-interception-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/method-interception-grain-interfaces.ts
@@ -1,6 +1,6 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/IMethodInterceptionGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /**
  * Upstream `SayHello` lives on a separate `IMethodFromAnotherInterface` that
@@ -12,7 +12,7 @@ import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
  * values, so the test that exercises it is excluded rather than the method
  * being ported unused.
  */
-export interface IMethodInterceptionGrain extends GrainWithIntegerKey {
+export interface IMethodInterceptionGrain extends GrainKey<bigint> {
   one(): Promise<string>;
   echo(someArg: string): Promise<string>;
   notIntercepted(): Promise<string>;
@@ -31,7 +31,7 @@ export const IMethodInterceptionGrain = defineGrainInterface<IMethodInterception
  * `IMethodInterceptionGrain`, hosted via `ClientNode.createObjectReference`
  * rather than a grain activation (`Observer_GrainCallFilter_Incoming_*`).
  */
-export interface IMethodInterceptionGrainObserver extends GrainWithIntegerKey {
+export interface IMethodInterceptionGrainObserver extends GrainKey<bigint> {
   one(): Promise<string>;
   echo(someArg: string): Promise<string>;
   notIntercepted(): Promise<string>;
@@ -53,7 +53,7 @@ export const IMethodInterceptionGrainObserver =
  * not `TestCluster.getGrain` (which shares the silo's single `GrainFactory`
  * with every grain-to-grain call).
  */
-export interface IOutgoingMethodInterceptionGrain extends GrainWithIntegerKey {
+export interface IOutgoingMethodInterceptionGrain extends GrainKey<bigint> {
   throwIfGreaterThanZero(value: number): Promise<string>;
   /** Upstream `EchoViaOtherGrain`: calls `otherGrain.Echo(message)`, wraps the result. */
   echoViaOtherGrain(
@@ -73,7 +73,7 @@ export const IOutgoingMethodInterceptionGrain =
  * progressively build up (via the now-exposed `GrainRuntime.getRequestContext`/
  * `setRequestContext`), proving a filter's header write reaches the method body.
  */
-export interface IGrainCallFilterTestGrain extends GrainWithIntegerKey {
+export interface IGrainCallFilterTestGrain extends GrainKey<bigint> {
   throwIfGreaterThanZero(value: number): Promise<string>;
   // Upstream: `HashSet<int>`. A JS `Set` does not round-trip across a real
   // (cross-silo) call boundary here (it is not structurally cloneable the way
@@ -95,7 +95,7 @@ export const IGrainCallFilterTestGrain = defineGrainInterface<IGrainCallFilterTe
  * `IGrainCallFilterTestGrain`, hosted via `ClientNode.createObjectReference`
  * rather than a grain activation.
  */
-export interface IGrainCallFilterTestGrainObserver extends GrainWithIntegerKey {
+export interface IGrainCallFilterTestGrainObserver extends GrainKey<bigint> {
   throwIfGreaterThanZero(value: number): Promise<string>;
   sumSet(numbers: readonly number[]): Promise<number>;
   systemWideCallFilterMarker(): Promise<void>;
@@ -120,7 +120,7 @@ export const IGrainCallFilterTestGrainObserver =
  * test behaviour (the silo-wide filter negating `setExtensionValue`'s
  * argument) actually needs.
  */
-export interface IMyGrainExtension extends GrainWithIntegerKey {
+export interface IMyGrainExtension extends GrainKey<bigint> {
   setExtensionValue(value: number): Promise<void>;
   getExtensionValue(): Promise<number>;
 }

--- a/packages/parity/src/grains/interfaces/migration-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/migration-test-grain-interfaces.ts
@@ -22,10 +22,10 @@
 // which is carried into the dehydration bag exactly the way upstream's grain
 // itself does it internally.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { SiloAddress } from "@thresh/core/silo-address";
 
-export interface IMigrationTestGrain extends GrainWithIntegerKey {
+export interface IMigrationTestGrain extends GrainKey<bigint> {
   setState(state: number): Promise<void>;
   getState(): Promise<number>;
   migrateOnIdle(target?: SiloAddress): Promise<void>;
@@ -43,7 +43,7 @@ export const IMigrationTestGrain = defineGrainInterface<IMigrationTestGrain>(
 );
 
 /** Upstream's `Grain<TGrainState>`-backed variant: a single persistent-state facet. */
-export interface IMigrationTestGrainGrainOfT extends GrainWithIntegerKey {
+export interface IMigrationTestGrainGrainOfT extends GrainKey<bigint> {
   setState(state: number): Promise<void>;
   getState(): Promise<number>;
   migrateOnIdle(target?: SiloAddress): Promise<void>;
@@ -53,7 +53,7 @@ export const IMigrationTestGrainGrainOfT = defineGrainInterface<IMigrationTestGr
   "DefaultCluster.Tests.General.IMigrationTestGrain_GrainOfT",
 );
 
-export interface IMigrationTestGrainIPersistentStateOfT extends GrainWithIntegerKey {
+export interface IMigrationTestGrainIPersistentStateOfT extends GrainKey<bigint> {
   setState(a: number, b: number): Promise<void>;
   getState(): Promise<[number, number]>;
   migrateOnIdle(target?: SiloAddress): Promise<void>;

--- a/packages/parity/src/grains/interfaces/migration-tracing-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/migration-tracing-grain-interfaces.ts
@@ -1,10 +1,10 @@
 // Ported from dotnet/orleans test/Orleans.Runtime.Tests/ActivationTracingTests.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { SiloAddress } from "@thresh/core/silo-address";
 
 /** A migration-capable grain with NO migration participant at all (see `ISimpleMigrationTracingTestGrain`). */
-export interface ISimpleMigrationTracingGrain extends GrainWithIntegerKey {
+export interface ISimpleMigrationTracingGrain extends GrainKey<bigint> {
   setState(state: number): Promise<void>;
   getState(): Promise<number>;
   migrateOnIdle(target?: SiloAddress): Promise<void>;
@@ -21,7 +21,7 @@ export const ISimpleMigrationTracingGrain = defineGrainInterface<ISimpleMigratio
  * a `FilterPlacementCandidates` span is created and parented under `PlaceGrain`
  * when migration triggers placement.
  */
-export interface IMigrationFilterTracingGrain extends GrainWithIntegerKey {
+export interface IMigrationFilterTracingGrain extends GrainKey<bigint> {
   setState(state: number): Promise<void>;
   getState(): Promise<number>;
   migrateOnIdle(target?: SiloAddress): Promise<void>;

--- a/packages/parity/src/grains/interfaces/multifacet-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/multifacet-grain-interfaces.ts
@@ -2,9 +2,9 @@
 // IMultifacetReader.cs, test/Grains/TestInternalGrainInterfaces/IMultifacetTestGrain.cs,
 // IMultifacetFactoryTestGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IMultifacetWriter extends GrainWithIntegerKey {
+export interface IMultifacetWriter extends GrainKey<bigint> {
   setValue(x: number): Promise<void>;
 }
 
@@ -12,7 +12,7 @@ export const IMultifacetWriter = defineGrainInterface<IMultifacetWriter>(
   "UnitTests.GrainInterfaces.IMultifacetWriter",
 );
 
-export interface IMultifacetReader extends GrainWithIntegerKey {
+export interface IMultifacetReader extends GrainKey<bigint> {
   getValue(): Promise<number>;
 }
 
@@ -26,7 +26,7 @@ export const IMultifacetTestGrain = defineGrainInterface<IMultifacetTestGrain>(
   "UnitTests.GrainInterfaces.IMultifacetTestGrain",
 );
 
-export interface IMultifacetFactoryTestGrain extends GrainWithIntegerKey {
+export interface IMultifacetFactoryTestGrain extends GrainKey<bigint> {
   getReaderOf(grain: IMultifacetTestGrain): Promise<IMultifacetReader>;
   getReader(): Promise<IMultifacetReader | null>;
   getWriterOf(grain: IMultifacetTestGrain): Promise<IMultifacetWriter>;

--- a/packages/parity/src/grains/interfaces/null-state-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/null-state-grain-interfaces.ts
@@ -1,12 +1,12 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/INullStateGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 export interface NullableState {
   name: string | null;
 }
 
-export interface INullStateGrain extends GrainWithIntegerKey {
+export interface INullStateGrain extends GrainKey<bigint> {
   setStateAndDeactivate(state: NullableState | null): Promise<void>;
   getState(): Promise<NullableState | null>;
 }

--- a/packages/parity/src/grains/interfaces/observer-with-cancellation-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/observer-with-cancellation-grain-interfaces.ts
@@ -8,7 +8,8 @@
 // than ported as dead surface — GAP-OBSERVERS if a later test needs them.
 import type { GrainCancellationToken } from "@thresh/core/grain-cancellation-token";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithGuidKey, GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
+import type { Guid } from "@thresh/core/guid";
 
 /**
  * A client-hosted observer supporting long-running, cancellable operations
@@ -16,7 +17,7 @@ import type { GrainWithGuidKey, GrainWithStringKey } from "@thresh/core/key-kind
  * observer notification, these methods are two-way: the grain awaits the
  * client's completion (or cancellation) rather than firing-and-forgetting.
  */
-export interface ILongRunningObserver extends GrainWithStringKey {
+export interface ILongRunningObserver extends GrainKey<string> {
   longWait(delayMs: number, callId: string, token: GrainCancellationToken): Promise<void>;
   /** Same body as `longWait`, but `[AlwaysInterleave]` upstream so concurrent calls interleave. */
   interleavingLongWait(
@@ -36,7 +37,7 @@ export const ILongRunningObserver = defineGrainInterface<ILongRunningObserver>(
  * subscribed client-hosted `ILongRunningObserver` (Orleans
  * `IObserverWithCancellationGrain`).
  */
-export interface IObserverWithCancellationGrain extends GrainWithGuidKey {
+export interface IObserverWithCancellationGrain extends GrainKey<Guid> {
   subscribe(observer: ILongRunningObserver): Promise<void>;
   unsubscribe(observer: ILongRunningObserver): Promise<void>;
   notifyLongWait(delayMs: number, callId: string, token: GrainCancellationToken): Promise<void>;

--- a/packages/parity/src/grains/interfaces/one-way-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/one-way-grain-interfaces.ts
@@ -1,9 +1,10 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/ITestGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithGuidKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { ISimpleGrainObserver } from "@thresh/parity/grains/interfaces/simple-observerable-grain-interfaces";
+import type { Guid } from "@thresh/core/guid";
 
-export interface IOneWayGrain extends GrainWithGuidKey {
+export interface IOneWayGrain extends GrainKey<Guid> {
   notify(observer: ISimpleGrainObserver): Promise<void>;
   // Upstream declares this as ValueTask; JS has no synchronous-Task
   // distinction, so it has the same async shape but is still one-way.

--- a/packages/parity/src/grains/interfaces/person-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/person-grain-interfaces.ts
@@ -1,6 +1,7 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/EventSourcing/IPersonGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithGuidKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
+import type { Guid } from "@thresh/core/guid";
 
 export type GenderType = "Male" | "Female";
 
@@ -10,7 +11,7 @@ export interface PersonAttributes {
   gender: GenderType;
 }
 
-export interface IPersonGrain extends GrainWithGuidKey {
+export interface IPersonGrain extends GrainKey<Guid> {
   registerBirth(person: PersonAttributes): Promise<void>;
   marry(spouse: IPersonGrain): Promise<void>;
   getTentativePersonalAttributes(): Promise<PersonAttributes>;

--- a/packages/parity/src/grains/interfaces/placement-filter-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/placement-filter-test-grain-interfaces.ts
@@ -1,8 +1,8 @@
 // Ported from dotnet/orleans test/Orleans.Placement.Tests/PlacementFilterTests/GrainPlacementFilterTests.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IPingableGrain extends GrainWithIntegerKey {
+export interface IPingableGrain extends GrainKey<bigint> {
   ping(): Promise<void>;
 }
 

--- a/packages/parity/src/grains/interfaces/placement-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/placement-test-grain-interfaces.ts
@@ -13,9 +13,9 @@
 // through `IActivationCountBasedPlacementTestGrain`.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import type { Guid } from "@thresh/core/guid";
-import type { GrainWithGuidKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IPlacementTestGrain extends GrainWithGuidKey {
+export interface IPlacementTestGrain extends GrainKey<Guid> {
   nop(): Promise<void>;
   startPreferLocalGrain(key: Guid): Promise<Guid>;
   /** Upstream `GetRuntimeInstanceId()`: this activation's hosting silo identity. */

--- a/packages/parity/src/grains/interfaces/polymorphic-interface-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/polymorphic-interface-interfaces.ts
@@ -11,9 +11,9 @@
 // is therefore omitted from every interface below; the one upstream test that
 // exercises it (`Polymorphic_InheritedMethodAmbiguity`) is excluded.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IA extends GrainWithIntegerKey {
+export interface IA extends GrainKey<bigint> {
   a1Method(): Promise<string>;
   a2Method(): Promise<string>;
   a3Method(): Promise<string>;
@@ -21,7 +21,7 @@ export interface IA extends GrainWithIntegerKey {
 
 export const IA = defineGrainInterface<IA>("UnitTests.GrainInterfaces.IA");
 
-export interface IB extends GrainWithIntegerKey {
+export interface IB extends GrainKey<bigint> {
   b1Method(): Promise<string>;
   b2Method(): Promise<string>;
   b3Method(): Promise<string>;
@@ -45,7 +45,7 @@ export interface ID extends IC {
 
 export const ID = defineGrainInterface<ID>("UnitTests.GrainInterfaces.ID");
 
-export interface IE extends GrainWithIntegerKey {
+export interface IE extends GrainKey<bigint> {
   e1Method(): Promise<string>;
   e2Method(): Promise<string>;
   e3Method(): Promise<string>;
@@ -61,7 +61,7 @@ export interface IF extends ID, IE {
 
 export const IF = defineGrainInterface<IF>("UnitTests.GrainInterfaces.IF");
 
-export interface IH extends GrainWithIntegerKey {
+export interface IH extends GrainKey<bigint> {
   h1Method(): Promise<string>;
   h2Method(): Promise<string>;
   h3Method(): Promise<string>;

--- a/packages/parity/src/grains/interfaces/rebalancing-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/rebalancing-test-grain-interfaces.ts
@@ -9,9 +9,10 @@
 // `IPlacementDirector.PlacementHintKey` `RequestContext` hint, not via a
 // dedicated placement strategy.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithGuidKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
+import type { Guid } from "@thresh/core/guid";
 
-export interface IRebalancingTestGrain extends GrainWithGuidKey {
+export interface IRebalancingTestGrain extends GrainKey<Guid> {
   ping(): Promise<void>;
 }
 

--- a/packages/parity/src/grains/interfaces/reminder-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/reminder-test-grain-interfaces.ts
@@ -3,9 +3,10 @@
 import type { Duration } from "@thresh/core/duration";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import type { GrainReminder } from "@thresh/core/reminder";
-import type { GrainWithGuidKey, GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
+import type { Guid } from "@thresh/core/guid";
 
-export interface IReminderTestGrain extends GrainWithIntegerKey {
+export interface IReminderTestGrain extends GrainKey<bigint> {
   isReminderExists(reminderName: string): Promise<boolean>;
   addReminder(reminderName: string): Promise<void>;
   removeReminder(reminderName: string): Promise<void>;
@@ -18,7 +19,7 @@ export const IReminderTestGrain = defineGrainInterface<IReminderTestGrain>(
 // Upstream's IReminderTestGrain2 is much larger (persistent state, counters, file-backed
 // logging) — only the subset needed to port MinimalReminderInterval (start a reminder,
 // fetch it back by name, stop it) is declared here.
-export interface IReminderTestGrain2 extends GrainWithGuidKey {
+export interface IReminderTestGrain2 extends GrainKey<Guid> {
   startReminder(reminderName: string, period: Duration): Promise<GrainReminder>;
   getReminderObject(reminderName: string): Promise<GrainReminder | undefined>;
   stopReminder(reminder: GrainReminder): Promise<void>;

--- a/packages/parity/src/grains/interfaces/retiring-collections-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/retiring-collections-grain-interfaces.ts
@@ -17,9 +17,9 @@
 // "structure disappeared from the grain's registered set" scenario upstream
 // exercises by constructing a manager with fewer machines.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IRetiringCollectionsGrainPartial extends GrainWithStringKey {
+export interface IRetiringCollectionsGrainPartial extends GrainKey<string> {
   keepSet(key: unknown, value: unknown): Promise<void>;
   keepGet(key: unknown): Promise<unknown>;
 }

--- a/packages/parity/src/grains/interfaces/roundtrip-serialization-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/roundtrip-serialization-grain-interfaces.ts
@@ -1,7 +1,7 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/IValueTypeTestGrain.cs
 // (`IRoundtripSerializationGrain`, `ParamVal`, `RetVal`, `CampaignEnemyTestType`) @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /** Upstream `CampaignEnemyTestType` enum, ported as its member names. */
 export type CampaignEnemyTestType = "None" | "Brute" | "Enemy1" | "Enemy2" | "Enemy3";
@@ -17,7 +17,7 @@ export interface RetVal {
 }
 
 /** Upstream `UnitTests.GrainInterfaces.IRoundtripSerializationGrain`. */
-export interface IRoundtripSerializationGrain extends GrainWithIntegerKey {
+export interface IRoundtripSerializationGrain extends GrainKey<bigint> {
   getEnemyType(): Promise<CampaignEnemyTestType>;
   getClosedGenericValue(): Promise<unknown>;
   getRetValForParamVal(param: ParamVal): Promise<RetVal>;

--- a/packages/parity/src/grains/interfaces/silo-metadata-placement-filter-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/silo-metadata-placement-filter-test-grain-interfaces.ts
@@ -1,9 +1,9 @@
 // Ported from dotnet/orleans test/Orleans.Placement.Tests/PlacementFilterTests/SiloMetadataPlacementFilterTests.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import type { SiloAddress } from "@thresh/core/silo-address";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IHostReportingGrain extends GrainWithIntegerKey {
+export interface IHostReportingGrain extends GrainKey<bigint> {
   getHostingSilo(): Promise<SiloAddress>;
 }
 

--- a/packages/parity/src/grains/interfaces/silo-role-based-placement-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/silo-role-based-placement-grain-interfaces.ts
@@ -1,8 +1,8 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/ISiloRoleBasedPlacementGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface ISiloRoleBasedPlacementGrain extends GrainWithStringKey {
+export interface ISiloRoleBasedPlacementGrain extends GrainKey<string> {
   ping(): Promise<boolean>;
 }
 

--- a/packages/parity/src/grains/interfaces/simple-di-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/simple-di-grain-interfaces.ts
@@ -1,9 +1,9 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/ISimpleDIGrain.cs @ v10.1.0 (MIT),
 // trimmed to the members GrainActivatorTests exercises.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface ISimpleDiGrain extends GrainWithIntegerKey {
+export interface ISimpleDiGrain extends GrainKey<bigint> {
   getStringValue(): Promise<string>;
   getLongValue(): Promise<bigint>;
   doDeactivate(): Promise<void>;

--- a/packages/parity/src/grains/interfaces/simple-grain-async-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/simple-grain-async-interfaces.ts
@@ -2,9 +2,9 @@
 // Trimmed to the members the ported SimpleGrain_AsyncMethods test exercises;
 // upstream's GetX/SetX/IncrementA_Async/GetAxB_Async(a,b) aren't reached.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface ISimpleGrainWithAsyncMethods extends GrainWithIntegerKey {
+export interface ISimpleGrainWithAsyncMethods extends GrainKey<bigint> {
   setA_Async(a: number): Promise<void>;
   setB_Async(b: number): Promise<void>;
   getAxB_Async(): Promise<number>;

--- a/packages/parity/src/grains/interfaces/simple-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/simple-grain-interfaces.ts
@@ -1,8 +1,8 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/ISimpleGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface ISimpleGrain extends GrainWithIntegerKey {
+export interface ISimpleGrain extends GrainKey<bigint> {
   setA(a: number): Promise<void>;
   setB(b: number): Promise<void>;
   incrementA(): Promise<void>;

--- a/packages/parity/src/grains/interfaces/simple-observerable-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/simple-observerable-grain-interfaces.ts
@@ -1,6 +1,6 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/ISimpleObserverableGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { ISimpleGrain } from "@thresh/parity/grains/interfaces/simple-grain-interfaces";
 
 export { ISimpleGrain };
@@ -10,7 +10,7 @@ export { ISimpleGrain };
  * is one-way: Orleans observer notifications are fire-and-forget, so the grain
  * does not await the client's acknowledgement.
  */
-export interface ISimpleGrainObserver extends GrainWithStringKey {
+export interface ISimpleGrainObserver extends GrainKey<string> {
   stateChanged(a: number, b: number): Promise<void>;
 }
 

--- a/packages/parity/src/grains/interfaces/stateless-worker-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/stateless-worker-grain-interfaces.ts
@@ -1,10 +1,10 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/IStatelessWorkerGrain.cs
 // and test/Grains/TestGrainInterfaces/IStatelessWorkerScalingGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 /** Upstream `IStatelessWorkerGrain`: `[StatelessWorker(1)]`, exercised for capacity/queuing behaviour. */
-export interface IStatelessWorkerGrain extends GrainWithIntegerKey {
+export interface IStatelessWorkerGrain extends GrainKey<bigint> {
   longCall(): Promise<void>;
   /** `[activationGuid, silo, calls]`, upstream's `Tuple<Guid, string, List<Tuple<DateTime,DateTime>>>`. */
   getCallStats(): Promise<[string, string, Array<[number, number]>]>;
@@ -16,7 +16,7 @@ export const IStatelessWorkerGrain = defineGrainInterface<IStatelessWorkerGrain>
 );
 
 /** Upstream `IStatelessWorkerScalingGrain`: `[StatelessWorker(maxLocalWorkers: 4)]`, exercised for scale-up behaviour. */
-export interface IStatelessWorkerScalingGrain extends GrainWithIntegerKey {
+export interface IStatelessWorkerScalingGrain extends GrainKey<bigint> {
   wait(): Promise<void>;
   release(): Promise<void>;
   getActivationCount(): Promise<number>;

--- a/packages/parity/src/grains/interfaces/storage-facet-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/storage-facet-grain-interfaces.ts
@@ -1,8 +1,8 @@
 // Ported from dotnet/orleans test/Orleans.Runtime.Tests/StorageFacet/StorageFacetGrain.cs @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface IStorageFacetGrain extends GrainWithIntegerKey {
+export interface IStorageFacetGrain extends GrainKey<bigint> {
   getNames(): Promise<string[]>;
   getExtendedInfo(): Promise<string[]>;
 }

--- a/packages/parity/src/grains/interfaces/test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/test-grain-interfaces.ts
@@ -3,9 +3,9 @@
 // StartTimer/TestRequestContext/DoLongAction; only the subset the ported
 // BasicActivationTests cases exercise is declared here.
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface ITestGrain extends GrainWithIntegerKey {
+export interface ITestGrain extends GrainKey<bigint> {
   getKey(): Promise<bigint>;
   getLabel(): Promise<string>;
   setLabel(label: string): Promise<void>;
@@ -23,7 +23,7 @@ export interface ITestGrain extends GrainWithIntegerKey {
 export const ITestGrain = defineGrainInterface<ITestGrain>("UnitTests.GrainInterfaces.ITestGrain");
 
 /** Upstream's `ITestGrainLongOnActivateAsync`: activation validates the key like `ITestGrain`. */
-export interface ITestGrainLongOnActivateAsync extends GrainWithIntegerKey {
+export interface ITestGrainLongOnActivateAsync extends GrainKey<bigint> {
   getKey(): Promise<bigint>;
 }
 

--- a/packages/parity/src/grains/interfaces/timer-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/timer-grain-interfaces.ts
@@ -6,9 +6,9 @@
 // — the ported tests below already cover the shared behavior.
 import type { Duration } from "@thresh/core/duration";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
-export interface ITimerGrain extends GrainWithIntegerKey {
+export interface ITimerGrain extends GrainKey<bigint> {
   stopDefaultTimer(): Promise<void>;
   getTimerPeriod(): Promise<Duration>;
   getCounter(): Promise<number>;
@@ -23,7 +23,7 @@ export const ITimerGrain = defineGrainInterface<ITimerGrain>(
 // RestartTimer(name, due)/RestartTimer(name, due, period); TS interfaces cannot
 // overload across the wire (dispatch is by method name), so both take their optional
 // trailing argument as an optional parameter instead.
-export interface ITimerCallGrain extends GrainWithIntegerKey {
+export interface ITimerCallGrain extends GrainKey<bigint> {
   getTickCount(): Promise<number>;
   /** The captured error's message, or `undefined` if the timer callback never threw. */
   getException(): Promise<string | undefined>;
@@ -37,7 +37,7 @@ export const ITimerCallGrain = defineGrainInterface<ITimerCallGrain>(
   "UnitTests.GrainInterfaces.ITimerCallGrain",
 );
 
-export interface INonReentrantTimerCallGrain extends GrainWithIntegerKey {
+export interface INonReentrantTimerCallGrain extends GrainKey<bigint> {
   getTickCount(): Promise<number>;
   getException(): Promise<string | undefined>;
   startTimer(name: string, delay: Duration): Promise<void>;

--- a/packages/parity/src/grains/interfaces/trace-context-propagation-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/trace-context-propagation-grain-interfaces.ts
@@ -13,7 +13,7 @@
 // (populated by an `ActivityListener`) captures for its own linking
 // assertions (`ClientAndServerSpansAreProperlyLinked`, etc).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 
 export interface TraceContextInfo {
   readonly hasActivity: boolean;
@@ -22,7 +22,7 @@ export interface TraceContextInfo {
   readonly traceParentFromRequestContext: string | undefined;
 }
 
-export interface ITraceContextPropagationGrain extends GrainWithIntegerKey {
+export interface ITraceContextPropagationGrain extends GrainKey<bigint> {
   /** Reports the server-side trace context visible from inside this activation. */
   getTraceContextInfo(): Promise<TraceContextInfo>;
   /**

--- a/packages/parity/src/grains/interfaces/transaction-attribution-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/transaction-attribution-grain-interfaces.ts
@@ -10,7 +10,7 @@
 // naturally: one `defineGrainInterface` per option, all implementing the
 // same `TransactionAttributionGrain` TS shape.
 import { defineGrainInterface, type GrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { TransactionOption } from "@thresh/core/transaction-info";
 
 /** A `TransactionOption`, or `"none"` for a method with no `[Transaction]` attribute at all. */
@@ -31,7 +31,7 @@ export interface AttributionTierEntry {
  * tier: `result[0]` is always this call's own `[id]`; deeper indices collect
  * every descendant's id at that depth, in call order.
  */
-export interface TransactionAttributionGrain extends GrainWithStringKey {
+export interface TransactionAttributionGrain extends GrainKey<string> {
   getNestedTransactionIds(
     tier: number,
     tiers: readonly AttributionTierEntry[][],

--- a/packages/parity/src/grains/interfaces/value-type-test-grain-interfaces.ts
+++ b/packages/parity/src/grains/interfaces/value-type-test-grain-interfaces.ts
@@ -1,14 +1,15 @@
 // Ported from dotnet/orleans test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
 // (`IValueTypeTestGrain`, `ValueTypeTestData`) @ v10.1.0 (MIT).
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithGuidKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
+import type { Guid } from "@thresh/core/guid";
 
 /** Upstream `ValueTypeTestData`: a plain value (C# struct), ported as data. */
 export interface ValueTypeTestData {
   value: number;
 }
 
-export interface IValueTypeTestGrain extends GrainWithGuidKey {
+export interface IValueTypeTestGrain extends GrainKey<Guid> {
   getStateData(): Promise<ValueTypeTestData>;
   setStateData(d: ValueTypeTestData): Promise<void>;
 }

--- a/packages/parity/src/placement/custom-tolerance-tests-support.ts
+++ b/packages/parity/src/placement/custom-tolerance-tests-support.ts
@@ -3,11 +3,11 @@
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { PLACEMENT_HINT_KEY, RequestContext } from "@thresh/core/request-context";
 import type { SiloAddress } from "@thresh/core/silo-address";
 
-export interface IE extends GrainWithIntegerKey {
+export interface IE extends GrainKey<bigint> {
   firstPing(silo2: string): Promise<void>;
   ping(): Promise<void>;
   getAddress(): Promise<SiloAddress>;
@@ -16,7 +16,7 @@ export const IE = defineGrainInterface<IE>(
   "UnitTests.ActivationRepartitioningTests.CustomToleranceTests.IE",
 );
 
-export interface IF extends GrainWithIntegerKey {
+export interface IF extends GrainKey<bigint> {
   ping(): Promise<void>;
   getAddress(): Promise<SiloAddress>;
 }
@@ -24,7 +24,7 @@ export const IF = defineGrainInterface<IF>(
   "UnitTests.ActivationRepartitioningTests.CustomToleranceTests.IF",
 );
 
-export interface IX extends GrainWithIntegerKey {
+export interface IX extends GrainKey<bigint> {
   ping(): Promise<void>;
   getAddress(): Promise<SiloAddress>;
 }

--- a/packages/parity/src/placement/default-tolerance-tests-support.ts
+++ b/packages/parity/src/placement/default-tolerance-tests-support.ts
@@ -16,13 +16,13 @@
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { PLACEMENT_HINT_KEY, RequestContext } from "@thresh/core/request-context";
 import type { SiloAddress } from "@thresh/core/silo-address";
 
 // ── A / B / C / CImmovable / D (Scenarios 1-4) ──────────────────────────────
 
-export interface IBase extends GrainWithStringKey {
+export interface IBase extends GrainKey<string> {
   ping(scenario: string): Promise<void>;
   getAddress(): Promise<SiloAddress>;
 }
@@ -195,7 +195,7 @@ export class D extends GrainBase implements ID {
 // a few times, generating the same shape of communication edge the real
 // protocol reasons about. The interesting part (the repartitioner moving the
 // receivers close to their agent) stays faithful to the real protocol.
-export interface IPullingAgent extends GrainWithStringKey {
+export interface IPullingAgent extends GrainKey<string> {
   ping(): Promise<void>;
   getAddress(): Promise<SiloAddress>;
 }
@@ -203,7 +203,7 @@ export const IPullingAgent = defineGrainInterface<IPullingAgent>(
   "UnitTests.ActivationRepartitioningTests.DefaultToleranceTests.IPullingAgent",
 );
 
-export interface ISR extends GrainWithStringKey {
+export interface ISR extends GrainKey<string> {
   pingAgent(): Promise<void>;
   getAddress(): Promise<SiloAddress>;
 }

--- a/packages/parity/src/runtime/grain-call-filter-tests.test.ts
+++ b/packages/parity/src/runtime/grain-call-filter-tests.test.ts
@@ -11,7 +11,7 @@ import {
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithGuidKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { castGrainReference } from "@thresh/core/grain-reference";
 import type { ClientNode } from "@thresh/client/client-node";
 import { invocationContext } from "@thresh/runtime/invocation-context";
@@ -32,6 +32,7 @@ import {
 } from "@thresh/parity/grains/impl/method-interception-grain";
 import { createClusterClient } from "@thresh/parity/support/client";
 import { randomGuidKey, randomIntegerKey } from "@thresh/parity/support/keys";
+import type { Guid } from "@thresh/core/guid";
 
 // System-wide incoming filter: mirrors the upstream fixture's
 // `SiloInvokerTestSiloBuilderConfigurator` incoming filter, trimmed to just
@@ -158,7 +159,7 @@ const clientOutgoing: OutgoingGrainCallFilter = async (ctx) => {
 // `onNext` writes the delivered value), then — if it changed — doubles it,
 // proving a stream delivery flows through the grain's incoming call-filter
 // pipeline exactly like an ordinary method call (Orleans parity).
-interface IStreamInterceptionGrain extends GrainWithGuidKey {
+interface IStreamInterceptionGrain extends GrainKey<Guid> {
   getLastStreamValue(): Promise<number>;
 }
 const IStreamInterceptionGrain = defineGrainInterface<IStreamInterceptionGrain>(

--- a/packages/parity/src/streaming/broadcast-channel-tests.test.ts
+++ b/packages/parity/src/streaming/broadcast-channel-tests.test.ts
@@ -42,7 +42,7 @@ import { grain, regexImplicitChannelSubscription } from "@thresh/core/decorators
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import { Guid } from "@thresh/core/guid";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { ClientNode } from "@thresh/client/client-node";
 import { orleansTest } from "@thresh/testing/orleans-test";
 import { TestCluster } from "@thresh/testing/test-cluster";
@@ -55,7 +55,7 @@ const PROVIDER_NAME = "BroadcastChannel";
 const PROVIDER_NAME_NON_FIRE_AND_FORGET = "BroadcastChannelNonFireAndForget";
 const CALL_TIMEOUT_MS = 500;
 
-interface ISubscriberGrain extends GrainWithStringKey {
+interface ISubscriberGrain extends GrainKey<string> {
   getValues(channelId: ChannelId): Promise<number[]>;
   getOnPublishedCounter(): Promise<number>;
   throwsOnReceive(throwsOnReceive: boolean): Promise<void>;

--- a/packages/parity/src/streaming/controllable-stream-generator-provider-tests.test.ts
+++ b/packages/parity/src/streaming/controllable-stream-generator-provider-tests.test.ts
@@ -26,7 +26,7 @@ import { expect } from "vitest";
 import { grain, implicitStreamSubscription } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { IManagementGrain } from "@thresh/core/management-grain";
 import {
   STREAM_GENERATOR_COMMAND_CONFIGURE,
@@ -45,7 +45,7 @@ const TOTAL_QUEUE_COUNT = 4;
 const REPORTER_ID = "controllable-generated-stream-reporter";
 const INITIAL_SILOS = 1;
 
-interface IGeneratedEventReporterGrain extends GrainWithStringKey {
+interface IGeneratedEventReporterGrain extends GrainKey<string> {
   reportResult(
     streamKey: string,
     streamProvider: string,
@@ -84,7 +84,7 @@ class GeneratedEventReporterGrain extends Grain implements IGeneratedEventReport
   }
 }
 
-interface IGeneratedEventCollectorGrain extends GrainWithStringKey {
+interface IGeneratedEventCollectorGrain extends GrainKey<string> {
   marker(): Promise<string>;
 }
 const IGeneratedEventCollectorGrain = defineGrainInterface<IGeneratedEventCollectorGrain>(

--- a/packages/parity/src/streaming/generated-stream-recovery-tests.test.ts
+++ b/packages/parity/src/streaming/generated-stream-recovery-tests.test.ts
@@ -35,7 +35,7 @@ import { expect } from "vitest";
 import { grain, implicitStreamSubscription, persistentState } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { IManagementGrain } from "@thresh/core/management-grain";
 import type { PersistentState } from "@thresh/core/persistent-state";
 import {
@@ -60,7 +60,7 @@ const CHECKPOINT_INTERVAL = 10;
 // exercises a rewind rather than "resume from nothing" or "resume at the end".
 const FAULT_AT_EVENT = 33;
 
-interface IGeneratedEventReporterGrain extends GrainWithStringKey {
+interface IGeneratedEventReporterGrain extends GrainKey<string> {
   reportResult(
     streamKey: string,
     streamProvider: string,
@@ -232,7 +232,7 @@ abstract class RecoverableCollectorGrainBase
   }
 }
 
-interface IGeneratedEventCollectorGrain extends GrainWithStringKey {
+interface IGeneratedEventCollectorGrain extends GrainKey<string> {
   marker(): Promise<string>;
 }
 const IGeneratedEventCollectorGrain = defineGrainInterface<IGeneratedEventCollectorGrain>(

--- a/packages/parity/src/streaming/implicit-subscription-key-type-grain-tests.test.ts
+++ b/packages/parity/src/streaming/implicit-subscription-key-type-grain-tests.test.ts
@@ -19,14 +19,14 @@ import { expect } from "vitest";
 import { grain, implicitStreamSubscription } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { STREAM_SUBSCRIPTION_OBSERVER, type StreamHandler } from "@thresh/core/stream";
 import { orleansTest } from "@thresh/testing/orleans-test";
 import { TestCluster } from "@thresh/testing/test-cluster";
 
 const STREAM_NAMESPACE = "IImplicitSubscriptionLongKeyGrain";
 
-interface IImplicitSubscriptionLongKeyGrain extends GrainWithIntegerKey {
+interface IImplicitSubscriptionLongKeyGrain extends GrainKey<bigint> {
   getValue(): Promise<number>;
 }
 const IImplicitSubscriptionLongKeyGrain = defineGrainInterface<IImplicitSubscriptionLongKeyGrain>(

--- a/packages/parity/src/streaming/memory-programmatic-subcribe-tests.test.ts
+++ b/packages/parity/src/streaming/memory-programmatic-subcribe-tests.test.ts
@@ -43,10 +43,10 @@
 import { expect } from "vitest";
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
-import type { GrainKey } from "@thresh/core/grain-key";
+import type { GrainKey as RuntimeGrainKey } from "@thresh/core/grain-key";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import { grainReferenceIdentity } from "@thresh/core/grain-reference";
-import type { GrainWithGuidKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import {
   STREAM_SUBSCRIPTION_OBSERVER,
   tryGetStreamSubscriptionManager,
@@ -56,11 +56,12 @@ import {
 import { orleansTest } from "@thresh/testing/orleans-test";
 import { TestCluster } from "@thresh/testing/test-cluster";
 import { randomGuidKey } from "@thresh/parity/support/keys";
+import type { Guid } from "@thresh/core/guid";
 
 const StreamProviderName = "StreamProvider1";
 const StreamProviderName2 = "StreamProvider2";
 
-interface ISubscribeGrain extends GrainWithGuidKey {
+interface ISubscribeGrain extends GrainKey<Guid> {
   canGetSubscriptionManager(providerName: string): Promise<boolean>;
 }
 const ISubscribeGrain = defineGrainInterface<ISubscribeGrain>("ISubscribeGrain", {
@@ -75,7 +76,7 @@ class SubscribeGrain extends Grain implements ISubscribeGrain {
   }
 }
 
-interface IPassiveConsumerGrain extends GrainWithGuidKey {
+interface IPassiveConsumerGrain extends GrainKey<Guid> {
   getNumberConsumed(): Promise<number>;
 }
 const IPassiveConsumerGrain = defineGrainInterface<IPassiveConsumerGrain>("IPassiveConsumerGrain", {
@@ -100,7 +101,7 @@ class PassiveConsumerGrain extends Grain implements IPassiveConsumerGrain {
   }
 }
 
-type IJerkConsumerGrain = GrainWithGuidKey;
+type IJerkConsumerGrain = GrainKey<Guid>;
 const IJerkConsumerGrain = defineGrainInterface<IJerkConsumerGrain>("IJerkConsumerGrain");
 
 /** Unsubscribes on any subscription added to it (Orleans `Jerk_ConsumerGrain`). */
@@ -111,8 +112,12 @@ class JerkConsumerGrain extends Grain {
   }
 }
 
-interface ITypedProducerGrain extends GrainWithGuidKey {
-  becomeProducer(streamKey: GrainKey, streamNamespace: string, providerName: string): Promise<void>;
+interface ITypedProducerGrain extends GrainKey<Guid> {
+  becomeProducer(
+    streamKey: RuntimeGrainKey,
+    streamNamespace: string,
+    providerName: string,
+  ): Promise<void>;
   produce(): Promise<void>;
   getNumberProduced(): Promise<number>;
 }
@@ -129,7 +134,7 @@ class TypedProducerGrain extends Grain implements ITypedProducerGrain {
   private numProduced = 0;
 
   async becomeProducer(
-    streamKey: GrainKey,
+    streamKey: RuntimeGrainKey,
     streamNamespace: string,
     providerName: string,
   ): Promise<void> {

--- a/packages/parity/src/streaming/memory-stream-batching-tests.test.ts
+++ b/packages/parity/src/streaming/memory-stream-batching-tests.test.ts
@@ -6,7 +6,7 @@ import { describe, expect } from "vitest";
 import { grain, implicitStreamSubscription } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithGuidKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import {
   STREAM_SUBSCRIPTION_OBSERVER,
   type BatchedStreamItem,
@@ -15,6 +15,7 @@ import {
 import { orleansTest } from "@thresh/testing/orleans-test";
 import { TestCluster } from "@thresh/testing/test-cluster";
 import { randomGuidKey } from "@thresh/parity/support/keys";
+import type { Guid } from "@thresh/core/guid";
 
 const BATCHING_NAMESPACE = "batching";
 const NON_BATCHING_NAMESPACE = "nonbatching";
@@ -24,7 +25,7 @@ interface ConsumptionReport {
   maxBatchSize: number;
 }
 
-interface IStreamBatchingTestConsumerGrain extends GrainWithGuidKey {
+interface IStreamBatchingTestConsumerGrain extends GrainKey<Guid> {
   getConsumptionReport(): Promise<ConsumptionReport>;
 }
 const IStreamBatchingTestConsumerGrain = defineGrainInterface<IStreamBatchingTestConsumerGrain>(

--- a/packages/parity/src/streaming/memory-stream-cache-miss-tests.test.ts
+++ b/packages/parity/src/streaming/memory-stream-cache-miss-tests.test.ts
@@ -21,7 +21,7 @@ import { describe, expect } from "vitest";
 import { grain, implicitStreamSubscription, persistentState } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithGuidKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { PersistentState } from "@thresh/core/persistent-state";
 import {
   STREAM_SUBSCRIPTION_OBSERVER,
@@ -33,11 +33,12 @@ import { orleansTest } from "@thresh/testing/orleans-test";
 import { TestCluster } from "@thresh/testing/test-cluster";
 import { randomGuidKey } from "@thresh/parity/support/keys";
 import { StreamingDiagnosticObserver } from "@thresh/parity/support/streaming-diagnostics";
+import type { Guid } from "@thresh/core/guid";
 
 const StreamProviderName = "StreamingCacheMissTests";
 const NAMESPACE = "IImplicitSubscriptionCounterGrain";
 
-interface IImplicitSubscriptionCounterGrain extends GrainWithGuidKey {
+interface IImplicitSubscriptionCounterGrain extends GrainKey<Guid> {
   getEventCounter(): Promise<number>;
   getErrorCounter(): Promise<number>;
   deactivate(): Promise<void>;

--- a/packages/parity/src/streaming/memory-stream-resume-tests.test.ts
+++ b/packages/parity/src/streaming/memory-stream-resume-tests.test.ts
@@ -25,7 +25,7 @@ import { afterAll, beforeAll, describe, expect } from "vitest";
 import { grain, implicitStreamSubscription, persistentState } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithGuidKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { PersistentState } from "@thresh/core/persistent-state";
 import {
   STREAM_SUBSCRIPTION_OBSERVER,
@@ -38,12 +38,13 @@ import { TestCluster } from "@thresh/testing/test-cluster";
 import { waitFor } from "@thresh/testing/wait";
 import { randomGuidKey } from "@thresh/parity/support/keys";
 import { StreamingDiagnosticObserver } from "@thresh/parity/support/streaming-diagnostics";
+import type { Guid } from "@thresh/core/guid";
 
 const StreamProviderName = "StreamingCacheMissTests";
 const NAMESPACE = "IImplicitSubscriptionCounterGrain";
 const streamInactivityPeriodMs = 5_000;
 
-interface IImplicitSubscriptionCounterGrain extends GrainWithGuidKey {
+interface IImplicitSubscriptionCounterGrain extends GrainKey<Guid> {
   getEventCounter(): Promise<number>;
   getErrorCounter(): Promise<number>;
   deactivate(): Promise<void>;
@@ -120,7 +121,7 @@ function makeInterestingData(): Uint8Array {
 const FAST_SLOW_NAMESPACE = "FastSlowImplicitSubscriptionCounterGrain";
 const SLOW_ACTIVATION_DELAY_MS = 2_000;
 
-interface IFastSlowCounterGrain extends GrainWithGuidKey {
+interface IFastSlowCounterGrain extends GrainKey<Guid> {
   getEventCounter(): Promise<number>;
 }
 const IFastImplicitSubscriptionCounterGrain = defineGrainInterface<IFastSlowCounterGrain>(

--- a/packages/parity/src/streaming/stateless-workers-stream-tests.test.ts
+++ b/packages/parity/src/streaming/stateless-workers-stream-tests.test.ts
@@ -17,14 +17,14 @@ import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import { Guid } from "@thresh/core/guid";
-import type { GrainWithIntegerKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { orleansTest } from "@thresh/testing/orleans-test";
 import { TestCluster } from "@thresh/testing/test-cluster";
 
 const STREAM_NAMESPACE = "StatelessWorkerStreamingNamespace";
 const STREAM_PROVIDER = "StreamProvider";
 
-interface IStatelessWorkerStreamConsumerGrain extends GrainWithIntegerKey {
+interface IStatelessWorkerStreamConsumerGrain extends GrainKey<bigint> {
   becomeConsumer(streamId: Guid, providerName: string): Promise<void>;
 }
 const IStatelessWorkerStreamConsumerGrain =

--- a/packages/parity/src/streaming/stream-generator-provider-tests.test.ts
+++ b/packages/parity/src/streaming/stream-generator-provider-tests.test.ts
@@ -25,7 +25,7 @@ import { expect } from "vitest";
 import { grain, implicitStreamSubscription } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { STREAM_SUBSCRIPTION_OBSERVER, type StreamHandler } from "@thresh/core/stream";
 import type { GeneratedEvent } from "@thresh/streams/generator-stream-queue";
 import { orleansTest } from "@thresh/testing/orleans-test";
@@ -38,7 +38,7 @@ const EVENTS_IN_STREAM = 100;
 const TOTAL_QUEUE_COUNT = 4;
 const REPORTER_ID = "generated-stream-reporter";
 
-interface IGeneratedEventReporterGrain extends GrainWithStringKey {
+interface IGeneratedEventReporterGrain extends GrainKey<string> {
   reportResult(
     streamKey: string,
     streamProvider: string,
@@ -77,7 +77,7 @@ class GeneratedEventReporterGrain extends Grain implements IGeneratedEventReport
   }
 }
 
-interface IGeneratedEventCollectorGrain extends GrainWithStringKey {
+interface IGeneratedEventCollectorGrain extends GrainKey<string> {
   marker(): Promise<string>;
 }
 const IGeneratedEventCollectorGrain = defineGrainInterface<IGeneratedEventCollectorGrain>(

--- a/packages/parity/src/transactions/consistency-harness.ts
+++ b/packages/parity/src/transactions/consistency-harness.ts
@@ -28,7 +28,7 @@
 // upstream `[InlineData]` row.
 import { defineGrain, useTransactionalState } from "@thresh/core/define-grain";
 import { defineGrainInterface, type GrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { TransactionAbortedError, TransactionInDoubtError } from "@thresh/core/errors";
 import type { TestCluster } from "@thresh/testing/test-cluster";
 
@@ -82,7 +82,7 @@ function hashCode(s: string): number {
   return h;
 }
 
-export interface ConsistencyTestGrain extends GrainWithStringKey {
+export interface ConsistencyTestGrain extends GrainKey<string> {
   run(
     options: ConsistencyTestOptions,
     depth: number,

--- a/packages/parity/src/transactions/disabled-transactions-tests.test.ts
+++ b/packages/parity/src/transactions/disabled-transactions-tests.test.ts
@@ -21,7 +21,7 @@
 import { expect } from "vitest";
 import { defineGrain, useTransactionalState } from "@thresh/core/define-grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { TransactionsDisabledError } from "@thresh/core/errors";
 import { TestCluster } from "@thresh/testing/test-cluster";
 import { orleansTest } from "@thresh/testing/orleans-test";
@@ -30,13 +30,13 @@ interface Counter {
   value: number;
 }
 
-interface TransactionTestGrain extends GrainWithStringKey {
+interface TransactionTestGrain extends GrainKey<string> {
   set(delta: number): Promise<void>;
   add(delta: number): Promise<void>;
   get(): Promise<number>;
 }
 
-interface TransactionCoordinatorGrain extends GrainWithStringKey {
+interface TransactionCoordinatorGrain extends GrainKey<string> {
   multiGrainSet(keys: string[], delta: number): Promise<void>;
 }
 

--- a/packages/parity/src/transactions/exclusive-lock-transaction-memory-tests.test.ts
+++ b/packages/parity/src/transactions/exclusive-lock-transaction-memory-tests.test.ts
@@ -12,7 +12,7 @@
 import { expect } from "vitest";
 import { defineGrain, useTransactionalState } from "@thresh/core/define-grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { TransactionAbortedError, TransactionLockUpgradeError } from "@thresh/core/errors";
 import { TestCluster } from "@thresh/testing/test-cluster";
 import { orleansTest } from "@thresh/testing/orleans-test";
@@ -21,12 +21,12 @@ interface Counter {
   value: number;
 }
 
-interface LockTestGrain extends GrainWithStringKey {
+interface LockTestGrain extends GrainKey<string> {
   add(delta: number): Promise<number>;
   get(): Promise<number>;
 }
 
-interface LockCoordinatorGrain extends GrainWithStringKey {
+interface LockCoordinatorGrain extends GrainKey<string> {
   /** Orleans `IExclusiveLockCoordinatorGrain.ReadThenWrite`: Get, delay, Add — no exclusive lock. */
   readThenWrite(grainKey: string, value: number): Promise<void>;
 }

--- a/packages/parity/src/transactions/grain-fault-transaction-memory-tests.test.ts
+++ b/packages/parity/src/transactions/grain-fault-transaction-memory-tests.test.ts
@@ -38,7 +38,7 @@
 import { expect } from "vitest";
 import { defineGrain, useTransactionalState } from "@thresh/core/define-grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import {
   TransactionAbortedError,
   TransactionCascadingAbortError,
@@ -64,14 +64,14 @@ interface Counter {
   value: number;
 }
 
-interface FaultTestGrain extends GrainWithStringKey {
+interface FaultTestGrain extends GrainKey<string> {
   set(newValue: number): Promise<void>;
   add(delta: number): Promise<number[]>;
   get(): Promise<number[]>;
   addAndThrow(delta: number): Promise<void>;
 }
 
-interface FaultCoordinatorGrain extends GrainWithStringKey {
+interface FaultCoordinatorGrain extends GrainKey<string> {
   multiGrainSet(keys: string[], newValue: number): Promise<void>;
   addAndThrow(key: string, delta: number): Promise<void>;
   multiGrainAddAndThrow(throwKeys: string[], keys: string[], delta: number): Promise<void>;

--- a/packages/parity/src/transactions/toc-fault-transaction-memory-tests.test.ts
+++ b/packages/parity/src/transactions/toc-fault-transaction-memory-tests.test.ts
@@ -6,7 +6,7 @@
 import { expect } from "vitest";
 import { defineGrain, useTransactionalState } from "@thresh/core/define-grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { TransactionInDoubtError } from "@thresh/core/errors";
 import { TransactionCommitter } from "@thresh/transactions/transaction-committer";
 import type { TransactionCommitOperation } from "@thresh/transactions/transaction-committer";
@@ -37,7 +37,7 @@ interface Counter {
   value: number;
 }
 
-interface CommitTestGrain extends GrainWithStringKey {
+interface CommitTestGrain extends GrainKey<string> {
   add(delta: number): Promise<number>;
   get(): Promise<number>;
 }
@@ -47,11 +47,11 @@ interface RemoteCommitService {
   calls: { transactionId: string; data: string }[];
 }
 
-interface CommitterTestGrain extends GrainWithStringKey {
+interface CommitterTestGrain extends GrainKey<string> {
   commit(operation: TransactionCommitOperation<RemoteCommitService>): Promise<void>;
 }
 
-interface CommitCoordinatorGrain extends GrainWithStringKey {
+interface CommitCoordinatorGrain extends GrainKey<string> {
   multiGrainAdd(
     committerKey: string,
     operation: TransactionCommitOperation<RemoteCommitService>,

--- a/packages/runtime/src/activation.lifecycle.test.ts
+++ b/packages/runtime/src/activation.lifecycle.test.ts
@@ -3,11 +3,11 @@ import { grain } from "@thresh/core/decorators";
 import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import { Grain } from "@thresh/core/grain";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { Silo } from "@thresh/runtime/silo";
 import { FakeTimeProvider } from "@thresh/runtime/test-support/fake-time-provider";
 
-interface ICounter extends GrainWithStringKey {
+interface ICounter extends GrainKey<string> {
   increment(by: number): Promise<number>;
   get(): Promise<number>;
 }
@@ -16,7 +16,7 @@ const ICounter = defineGrainInterface<ICounter>("ICounter.lifecycle", {
   options: { get: { readOnly: true } },
 });
 
-interface IBadActivate extends GrainWithStringKey {
+interface IBadActivate extends GrainKey<string> {
   ping(): Promise<string>;
 }
 

--- a/packages/runtime/src/broadcast-channel.test.ts
+++ b/packages/runtime/src/broadcast-channel.test.ts
@@ -8,7 +8,7 @@ import { grain, implicitChannelSubscription } from "@thresh/core/decorators";
 import { defineGrain } from "@thresh/core/define-grain";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork, InProcessTransport } from "@thresh/messaging/in-process-transport";
 import { ClusterNode } from "@thresh/runtime/cluster-node";
@@ -17,7 +17,7 @@ import { StaticMembershipService } from "@thresh/runtime/static-membership";
 // Module sink so observed items survive across activations (keyed by grain key).
 let observed: Array<{ key: string; namespace: string; item: unknown }> = [];
 
-interface IWatcher extends GrainWithStringKey {
+interface IWatcher extends GrainKey<string> {
   marker(): Promise<string>;
 }
 const IWatcher = defineGrainInterface<IWatcher>("IWatcher.broadcast");
@@ -37,7 +37,7 @@ class WatcherGrain extends Grain implements IWatcher {
   }
 }
 
-interface IPlain extends GrainWithStringKey {
+interface IPlain extends GrainKey<string> {
   marker(): Promise<string>;
 }
 const IPlain = defineGrainInterface<IPlain>("IPlain.broadcast");
@@ -51,7 +51,7 @@ class PlainGrain extends Grain implements IPlain {
   }
 }
 
-interface IPublisher extends GrainWithStringKey {
+interface IPublisher extends GrainKey<string> {
   raise(item: string): Promise<void>;
 }
 const IPublisher = defineGrainInterface<IPublisher>("IPublisher.broadcast");

--- a/packages/runtime/src/cancellation.cluster.test.ts
+++ b/packages/runtime/src/cancellation.cluster.test.ts
@@ -4,11 +4,11 @@ import { GrainTaskCanceledError } from "@thresh/core/errors";
 import { Grain } from "@thresh/core/grain";
 import type { GrainCancellationToken } from "@thresh/core/grain-cancellation-token";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { TestCluster, type TestSiloHandle } from "@thresh/testing/test-cluster";
 
 /** A grain whose `longWait` honours a `GrainCancellationToken` (Orleans cooperative cancellation). */
-interface ILongWaitGrain extends GrainWithStringKey {
+interface ILongWaitGrain extends GrainKey<string> {
   longWait(token: GrainCancellationToken, delayMs: number, callId: string): Promise<void>;
   wasCancelled(callId: string): Promise<boolean>;
 }

--- a/packages/runtime/src/cluster.placement.test.ts
+++ b/packages/runtime/src/cluster.placement.test.ts
@@ -3,10 +3,10 @@ import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { TestCluster, type TestSiloHandle } from "@thresh/testing/test-cluster";
 
-interface IPing extends GrainWithStringKey {
+interface IPing extends GrainKey<string> {
   ping(): Promise<string>;
 }
 

--- a/packages/runtime/src/cluster.test.ts
+++ b/packages/runtime/src/cluster.test.ts
@@ -3,12 +3,12 @@ import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { ConsistentHashRing } from "@thresh/directory/consistent-hash-ring";
 import { TestCluster, type TestSiloHandle } from "@thresh/testing/test-cluster";
 
-interface ICounter extends GrainWithStringKey {
+interface ICounter extends GrainKey<string> {
   increment(by: number): Promise<number>;
 }
 const ICounter = defineGrainInterface<ICounter>("ICounter.cluster");
@@ -23,7 +23,7 @@ class CounterGrain extends Grain implements ICounter {
 }
 
 // preferLocal makes each node try to activate locally, forcing a CAS race.
-interface ILocal extends GrainWithStringKey {
+interface ILocal extends GrainKey<string> {
   ping(): Promise<string>;
 }
 const ILocal = defineGrainInterface<ILocal>("ILocal.cluster");

--- a/packages/runtime/src/directory-handoff-recovery.test.ts
+++ b/packages/runtime/src/directory-handoff-recovery.test.ts
@@ -3,7 +3,7 @@ import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { MembershipService } from "@thresh/core/membership";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { RejectionError } from "@thresh/core/errors";
@@ -21,7 +21,7 @@ import type {
 import { ClusterNode } from "@thresh/runtime/cluster-node";
 import { StaticMembershipService } from "@thresh/runtime/static-membership";
 
-interface ICounter extends GrainWithStringKey {
+interface ICounter extends GrainKey<string> {
   increment(by: number): Promise<number>;
 }
 const ICounter = defineGrainInterface<ICounter>("ICounter.handoffRecovery");

--- a/packages/runtime/src/durable-job-delivery.test.ts
+++ b/packages/runtime/src/durable-job-delivery.test.ts
@@ -3,13 +3,13 @@ import { defineGrain, useDurableJobHandler } from "@thresh/core/define-grain";
 import { completed, type JobRunContext } from "@thresh/core/durable-job";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import { GrainId } from "@thresh/core/grain-id";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork, InProcessTransport } from "@thresh/messaging/in-process-transport";
 import { ClusterNode } from "@thresh/runtime/cluster-node";
 import { StaticMembershipService } from "@thresh/runtime/static-membership";
 
-interface IWorker extends GrainWithStringKey {
+interface IWorker extends GrainKey<string> {
   ping(): Promise<string>;
 }
 const IWorker = defineGrainInterface<IWorker>("IWorker.jobdelivery");

--- a/packages/runtime/src/grain-factory.call-options.test.ts
+++ b/packages/runtime/src/grain-factory.call-options.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { InvocationRequest } from "@thresh/core/request";
 import type { Dispatcher, InvokeCallOptions } from "@thresh/runtime/dispatcher";
 import { GrainFactory } from "@thresh/runtime/grain-factory";
@@ -12,7 +12,7 @@ import { invocationContext, withCallOptions } from "@thresh/runtime/invocation-c
 // `InvokeCallOptions.deadlineMs`/`signal` alone only reaches internal
 // `Dispatcher.invoke` callers, never `GrainFactory`'s public proxy surface.
 
-interface IPingable extends GrainWithStringKey {
+interface IPingable extends GrainKey<string> {
   ping(): Promise<string>;
 }
 

--- a/packages/runtime/src/grain-factory.timeout.test.ts
+++ b/packages/runtime/src/grain-factory.timeout.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { GrainCallTimeoutError } from "@thresh/core/errors";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { Dispatcher } from "@thresh/runtime/dispatcher";
 import { GrainFactory } from "@thresh/runtime/grain-factory";
 import { FakeTimeProvider } from "@thresh/runtime/test-support/fake-time-provider";
 
-interface ISlow extends GrainWithStringKey {
+interface ISlow extends GrainKey<string> {
   hang(): Promise<string>;
   fireAndForget(): Promise<string>;
 }

--- a/packages/runtime/src/grain-management-extension.test.ts
+++ b/packages/runtime/src/grain-management-extension.test.ts
@@ -4,12 +4,12 @@ import { Grain } from "@thresh/core/grain";
 import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import { castGrainReference } from "@thresh/core/grain-reference";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { IGrainManagementExtension } from "@thresh/runtime/grain-management-extension";
 import { Silo } from "@thresh/runtime/silo";
 import { FakeTimeProvider } from "@thresh/runtime/test-support/fake-time-provider";
 
-interface ITagged extends GrainWithStringKey {
+interface ITagged extends GrainKey<string> {
   tag(): Promise<string>;
 }
 

--- a/packages/runtime/src/implicit-stream-delivery.test.ts
+++ b/packages/runtime/src/implicit-stream-delivery.test.ts
@@ -4,7 +4,7 @@ import { defineGrain } from "@thresh/core/define-grain";
 import { Grain } from "@thresh/core/grain";
 import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { STREAM_SUBSCRIPTION_OBSERVER, type StreamHandler } from "@thresh/core/stream";
 import { InProcessNetwork, InProcessTransport } from "@thresh/messaging/in-process-transport";
@@ -14,7 +14,7 @@ import { StaticMembershipService } from "@thresh/runtime/static-membership";
 // Module sink so observed events survive across activations (keyed by grain key).
 let observed: Array<{ key: string; namespace: string; event: unknown }> = [];
 
-interface IWatcher extends GrainWithStringKey {
+interface IWatcher extends GrainKey<string> {
   marker(): Promise<string>;
 }
 const IWatcher = defineGrainInterface<IWatcher>("IWatcher.implicit");
@@ -34,7 +34,7 @@ class WatcherGrain extends Grain implements IWatcher {
   }
 }
 
-interface IPlain extends GrainWithStringKey {
+interface IPlain extends GrainKey<string> {
   marker(): Promise<string>;
 }
 const IPlain = defineGrainInterface<IPlain>("IPlain.implicit");

--- a/packages/runtime/src/migration.test.ts
+++ b/packages/runtime/src/migration.test.ts
@@ -8,13 +8,13 @@ import type {
   IGrainMigrationParticipant,
   RehydrationContext,
 } from "@thresh/core/grain-migration-participant";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { SiloAddress } from "@thresh/core/silo-address";
 import { Silo } from "@thresh/runtime/silo";
 import { FakeTimeProvider } from "@thresh/runtime/test-support/fake-time-provider";
 import { TestCluster } from "@thresh/testing/test-cluster";
 
-interface IMigratingCounter extends GrainWithStringKey {
+interface IMigratingCounter extends GrainKey<string> {
   increment(by: number): Promise<number>;
   get(): Promise<number>;
   scheduleMigration(target?: SiloAddress): Promise<void>;

--- a/packages/runtime/src/rebalancer-cluster.test.ts
+++ b/packages/runtime/src/rebalancer-cluster.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from "vitest";
 import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { SiloAddress } from "@thresh/core/silo-address";
 import { InProcessNetwork, InProcessTransport } from "@thresh/messaging/in-process-transport";
 import { ClusterNode } from "@thresh/runtime/cluster-node";
 import { StaticMembershipService } from "@thresh/runtime/static-membership";
 import { DEFAULT_REBALANCER_OPTIONS } from "@thresh/runtime/placement/rebalancing/rebalancer-model";
 
-interface IWorker extends GrainWithStringKey {
+interface IWorker extends GrainKey<string> {
   ping(): Promise<string>;
 }
 const IWorker = defineGrainInterface<IWorker>("IWorker.rebalance");

--- a/packages/runtime/src/reentrancy.test.ts
+++ b/packages/runtime/src/reentrancy.test.ts
@@ -2,17 +2,17 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { grain } from "@thresh/core/decorators";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import { Grain } from "@thresh/core/grain";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { Silo } from "@thresh/runtime/silo";
 
-interface IGate extends GrainWithStringKey {
+interface IGate extends GrainKey<string> {
   enter(tag: string): Promise<void>;
 }
-interface IReentrantA extends GrainWithStringKey {
+interface IReentrantA extends GrainKey<string> {
   run(): Promise<string>;
   ping(): Promise<string>;
 }
-interface IReentrantB extends GrainWithStringKey {
+interface IReentrantB extends GrainKey<string> {
   callViaA(aKey: string): Promise<string>;
 }
 

--- a/packages/runtime/src/timers.test.ts
+++ b/packages/runtime/src/timers.test.ts
@@ -3,11 +3,11 @@ import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import type { GrainTimer } from "@thresh/core/grain-timer";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { Silo } from "@thresh/runtime/silo";
 import { FakeTimeProvider } from "@thresh/runtime/test-support/fake-time-provider";
 
-interface ITicker extends GrainWithStringKey {
+interface ITicker extends GrainKey<string> {
   startPeriodic(): Promise<void>;
   startOnce(): Promise<void>;
   stop(): Promise<void>;

--- a/packages/runtime/src/versioning.cluster.test.ts
+++ b/packages/runtime/src/versioning.cluster.test.ts
@@ -3,7 +3,7 @@ import { grain } from "@thresh/core/decorators";
 import { Grain } from "@thresh/core/grain";
 import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import type { SiloAddress } from "@thresh/core/silo-address";
 import type { CompatibilityKind } from "@thresh/core/version-compatibility";
 import type { VersionSelectorKind } from "@thresh/core/version-selector";
@@ -11,7 +11,7 @@ import { InProcessNetwork } from "@thresh/messaging/in-process-transport";
 import type { Message } from "@thresh/messaging/message";
 import { TestCluster } from "@thresh/testing/test-cluster";
 
-interface ICounter extends GrainWithStringKey {
+interface ICounter extends GrainKey<string> {
   increment(by: number): Promise<number>;
 }
 // All versions share one name → one id; only the version differs.

--- a/packages/testing/src/test-cluster.test.ts
+++ b/packages/testing/src/test-cluster.test.ts
@@ -4,11 +4,11 @@ import { Grain } from "@thresh/core/grain";
 import { GrainId } from "@thresh/core/grain-id";
 import { defineGrainInterface } from "@thresh/core/grain-interface";
 import type { GrainType } from "@thresh/core/grain-type";
-import type { GrainWithStringKey } from "@thresh/core/key-kinds";
+import type { GrainKey } from "@thresh/core/key-kinds";
 import { TestCluster } from "@thresh/testing/test-cluster";
 import { waitFor } from "@thresh/testing/wait";
 
-interface ICounter extends GrainWithStringKey {
+interface ICounter extends GrainKey<string> {
   increment(): Promise<number>;
 }
 const ICounter = defineGrainInterface<ICounter>("TestClusterCounter");
@@ -33,7 +33,7 @@ const counterId = (key: string) => new GrainId("TestClusterCounter" as GrainType
 let notifications: string[] = [];
 let watcherTargetKey = "watcher";
 
-interface IWatcherGrain extends GrainWithStringKey {
+interface IWatcherGrain extends GrainKey<string> {
   ping(): Promise<void>;
   notify(fromKey: string): Promise<void>;
 }
@@ -50,7 +50,7 @@ class WatcherGrain extends Grain implements IWatcherGrain {
   }
 }
 
-interface INotifierGrain extends GrainWithStringKey {
+interface INotifierGrain extends GrainKey<string> {
   touch(): Promise<void>;
 }
 const INotifierGrain = defineGrainInterface<INotifierGrain>("TeardownRaceNotifier");


### PR DESCRIPTION
### Motivation

- Modernise the grain interface typing to a TypeScript-first style so application code can use structural type aliases rather than C#-style `I*` marker interfaces.
- Simplify and centralise key-kind plumbing so `getGrain` key types are inferred from a single generic marker rather than many disparate marker interfaces.

### Description

- Add a generic `GrainKey<TKey>` marker and alias `KeyedGrain` in `packages/core/src/key-kinds.ts`, retain Orleans-compatible aliases and replace the previous specialized marker interfaces, and simplify `GrainKeyFor` to infer the key from `GrainKey`.
- Migrate example and demo code to the new idiom by converting `I*` interfaces into type aliases that intersect `GrainKey<...>` and renaming runtime descriptors from `IName` to lowercase `name` (e.g. `IAccount` -> `Account` + `account` descriptor), and update all `getGrain`/`registerGrain` call sites accordingly across examples (bank, chat, broadcast, cluster, greeter, thermostat, migration, k8s-silo, etc.).
- Add documentation `docs/typescript-grain-api.md` describing the recommended TypeScript grain API idioms and update `README.md` to link to it.
- Add a type-level test `packages/core/src/key-kinds.test.ts` to assert `GrainKey`/`GrainKeyFor` behaviour.

### Testing

- Ran the Vitest suites (`pnpm test`) including the new `key-kinds.test.ts` and the updated example tests; all tests completed successfully.
- Type checks were exercised as part of the changes to ensure the new `GrainKey` generics and renamed descriptors type-check across the codebase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7273f17048832783874edc6c290e32)