### PR TITLE
Compose grain lifecycle with useOnActivate/useOnDeactivate hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ pnpm --filter @thresh/example-bank start         # reducer grains: events fold t
 pnpm --filter @thresh/example-thermostat start   # durable state + a reminder + a telemetry stream
 ```
 
-- [`examples/greeter`](examples/greeter) — the smallest grain: `onActivate` runs before the first
-  call, concurrent calls are serialized turns, and volatile state resets when the grain reactivates
+- [`examples/greeter`](examples/greeter) — the smallest grain: a `useOnActivate` hook runs before the
+  first call, concurrent calls are serialized turns, and volatile state resets when the grain reactivates
   after going idle.
 - [`examples/chat`](examples/chat) — a room fans each message out to every member; a member that
   deactivated while idle resumes *its own* durable subscription and recovers exactly what it missed.

--- a/docs/guide/grains.md
+++ b/docs/guide/grains.md
@@ -8,10 +8,14 @@ returned definition is passed to `getGrain`; the returned proxy implements `T`.
 
 ## Functional lifecycle
 
-`defineGrain(name, setup)` runs `setup` once per activation. Its returned behavior may implement
-`onActivate`, `onDeactivate`, and `onSetupState`. The setup context exposes the grain identity,
-runtime access, timers, reminders, streams, and other activation services. Do not leak closure state
-outside the grain.
+`defineGrain(name, setup)` runs `setup` once per activation. What `setup` returns is the grain's
+message surface and nothing else — the interface methods, plus an optional self incoming-call filter
+under `INCOMING_CALL_FILTER`. Lifecycle is registered with hooks, like the state facets:
+`useOnActivate(ctx, handler)` and `useOnDeactivate(ctx, handler)`. Both compose — call them as often
+as you like, from `setup` or from helpers it calls. Activate hooks run in registration order;
+deactivate hooks unwind LIFO, so a hook always tears down before whatever it was set up on top of.
+The setup context exposes the grain identity, runtime access, timers, reminders, streams, and other
+activation services. Do not leak closure state outside the grain.
 
 Each normal method call is one serialized turn. `readOnly` interface options declare calls that do
 not mutate state and enable runtime optimizations; violating read-only state guards throws. Other

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -97,10 +97,14 @@ returned definition is passed to `getGrain`; the returned proxy implements `T`.
 
 ## Functional lifecycle
 
-`defineGrain(name, setup)` runs `setup` once per activation. Its returned behavior may implement
-`onActivate`, `onDeactivate`, and `onSetupState`. The setup context exposes the grain identity,
-runtime access, timers, reminders, streams, and other activation services. Do not leak closure state
-outside the grain.
+`defineGrain(name, setup)` runs `setup` once per activation. What `setup` returns is the grain's
+message surface and nothing else — the interface methods, plus an optional self incoming-call filter
+under `INCOMING_CALL_FILTER`. Lifecycle is registered with hooks, like the state facets:
+`useOnActivate(ctx, handler)` and `useOnDeactivate(ctx, handler)`. Both compose — call them as often
+as you like, from `setup` or from helpers it calls. Activate hooks run in registration order;
+deactivate hooks unwind LIFO, so a hook always tears down before whatever it was set up on top of.
+The setup context exposes the grain identity, runtime access, timers, reminders, streams, and other
+activation services. Do not leak closure state outside the grain.
 
 Each normal method call is one serialized turn. `readOnly` interface options declare calls that do
 not mutate state and enable runtime optimizations; violating read-only state guards throws. Other

--- a/examples/greeter/src/demo.ts
+++ b/examples/greeter/src/demo.ts
@@ -7,7 +7,7 @@ import { GreeterGrain } from "@thresh/example-greeter/greeter-grain";
 import { greeter } from "@thresh/example-greeter/interfaces";
 
 export interface GreeterDemoResult {
-  /** The first greeting — proves onActivate ran before it (carries the prefix). */
+  /** The first greeting — proves the activate hook ran before it (carries the prefix). */
   firstGreeting: string;
   /** Count after several concurrent greets — proves serialized turns (no lost ++). */
   countAfterConcurrent: number;

--- a/examples/greeter/src/greeter-grain.ts
+++ b/examples/greeter/src/greeter-grain.ts
@@ -1,11 +1,11 @@
-import { defineGrain } from "@thresh/core/define-grain";
+import { defineGrain, useOnActivate } from "@thresh/core/define-grain";
 import type { Greeter } from "@thresh/example-greeter/interfaces";
 
 /**
  * A minimal grain showing the core actor guarantees with no providers:
  *
- * - `onActivate` runs before the first message — the greeting prefix it sets is
- *   always present, so no call ever sees an un-initialised grain.
+ * - the `useOnActivate` hook runs before the first message — the greeting prefix
+ *   it sets is always present, so no call ever sees an un-initialised grain.
  * - calls run as serialized turns — `count++` needs no lock and never races.
  * - the `count` is volatile activation state — after the grain deactivates while
  *   idle, the next call reactivates it fresh and the count starts again at 1.
@@ -14,11 +14,11 @@ export const GreeterGrain = defineGrain<Greeter>("Greeter", (ctx) => {
   let prefix = "uninitialised";
   let count = 0;
 
-  return {
-    onActivate: async () => {
-      prefix = `[${String(ctx.id.key)}]`;
-    },
+  useOnActivate(ctx, () => {
+    prefix = `[${String(ctx.id.key)}]`;
+  });
 
+  return {
     greet: async (name: string): Promise<string> => {
       count++;
       return `${prefix} Hello, ${name}! (greeting #${count})`;

--- a/examples/greeter/src/greeter.test.ts
+++ b/examples/greeter/src/greeter.test.ts
@@ -27,11 +27,11 @@ function buildGreeterSilo(time: FakeTimeProvider): SiloHost {
 }
 
 describe("greeter (core actor model acceptance)", () => {
-  it("runs onActivate before the first message", async () => {
+  it("runs the activate hook before the first message", async () => {
     const silo = buildGreeterSilo(new FakeTimeProvider());
     await silo.start();
     try {
-      // The prefix is only set in onActivate; seeing it proves activation ran first.
+      // The prefix is only set in the activate hook; seeing it proves activation ran first.
       expect(await silo.getGrain(greeter, "en").greet("Ada")).toBe(
         "[en] Hello, Ada! (greeting #1)",
       );

--- a/examples/thermostat/src/fleet-aggregator-grain.ts
+++ b/examples/thermostat/src/fleet-aggregator-grain.ts
@@ -1,4 +1,4 @@
-import { defineGrain } from "@thresh/core/define-grain";
+import { defineGrain, useOnActivate } from "@thresh/core/define-grain";
 import type { StreamHandler } from "@thresh/core/stream";
 import {
   TELEMETRY,
@@ -22,16 +22,16 @@ export const FleetAggregatorGrain = defineGrain<FleetAggregator>("FleetAggregato
     },
   });
 
-  return {
-    onActivate: async () => {
-      const stream = ctx.runtime
-        .getStreamProvider()
-        .getStream<ThermostatStatus>(TELEMETRY, ctx.id.key);
-      const existing = await stream.getSubscriptions();
-      if (existing.length > 0) await existing[0]!.resume(handler());
-      else await stream.subscribe(handler());
-    },
+  useOnActivate(ctx, async () => {
+    const stream = ctx.runtime
+      .getStreamProvider()
+      .getStream<ThermostatStatus>(TELEMETRY, ctx.id.key);
+    const existing = await stream.getSubscriptions();
+    if (existing.length > 0) await existing[0]!.resume(handler());
+    else await stream.subscribe(handler());
+  });
 
+  return {
     averageTemp: async (): Promise<number> => (count === 0 ? 0 : sum / count),
 
     sampleCount: async (): Promise<number> => count,

--- a/packages/core/src/define-grain.ts
+++ b/packages/core/src/define-grain.ts
@@ -56,13 +56,13 @@ export type DeactivateHandler = (
 ) => void | Promise<void>;
 
 /**
- * What a grain factory returns: the message surface — the interface
- * implementation, plus an optional self incoming-call filter (under
+ * What a grain factory returns: the grain's behaviour towards messages — the
+ * interface implementation, plus an optional self incoming-call filter (under
  * `INCOMING_CALL_FILTER`), which is itself part of how messages are handled.
  * Lifecycle is *not* returned: register it with {@link useOnActivate} /
  * {@link useOnDeactivate}, like any other facet hook.
  */
-export type GrainSurface<T> = T & Partial<SelfFilteringGrain>;
+export type GrainBehaviour<T> = T & Partial<SelfFilteringGrain>;
 
 export interface DefineGrainOptions extends Omit<GrainOptions, "name"> {
   /** Mark every method reentrant (the functional equivalent of `@reentrant()`). */
@@ -157,7 +157,7 @@ export function useOnDeactivate(ctx: GrainSetup, handler: DeactivateHandler): vo
  */
 export function defineGrain<T extends object>(
   name: string,
-  factory: (ctx: GrainSetup) => GrainSurface<T>,
+  factory: (ctx: GrainSetup) => GrainBehaviour<T>,
   options: DefineGrainOptions = {},
 ): new () => Grain {
   class FunctionalGrain extends Grain {
@@ -166,12 +166,12 @@ export function defineGrain<T extends object>(
     // catalog's method dispatch finds them.
     override setContext(context: GrainContext): void {
       super.setContext(context);
-      const surface = factory(createSetup(this, context));
+      const behaviour = factory(createSetup(this, context));
       // String keys are the interface methods; symbol keys carry system hooks
       // (e.g. a self incoming-call filter under `INCOMING_CALL_FILTER`).
-      const keys = [...Object.keys(surface), ...Object.getOwnPropertySymbols(surface)];
+      const keys = [...Object.keys(behaviour), ...Object.getOwnPropertySymbols(behaviour)];
       for (const key of keys) {
-        const value = (surface as Record<PropertyKey, unknown>)[key];
+        const value = (behaviour as Record<PropertyKey, unknown>)[key];
         if (typeof value !== "function") continue;
         // A returned lifecycle hook would install as an own property and
         // silently shadow the composed runners below, dropping every hook the

--- a/packages/core/src/define-grain.ts
+++ b/packages/core/src/define-grain.ts
@@ -22,6 +22,7 @@ import type {
   DurableValue,
 } from "./durable-state";
 import { registerDurableField, type DurableKind } from "./durable-state-metadata";
+import { createFieldRegistry } from "./field-registry";
 import type { Reducer, ReducerState } from "./reducer-state";
 import { registerReducerField } from "./reducer-state-metadata";
 import type { TransactionalState } from "./transactional-state";
@@ -38,18 +39,30 @@ export interface GrainSetup extends GrainContext {
   getGrain<T>(def: GrainInterface<T>, key: GrainKeyFor<T>): T;
 }
 
-/** Lifecycle hooks a behaviour may return; both are optional and awaited by the runtime. */
-export interface GrainLifecycle {
-  onActivate(reason: ActivationReason): void | Promise<void>;
-  onDeactivate(reason: DeactivationReason, signal?: AbortSignal): void | Promise<void>;
-}
+/**
+ * A hook run when the activation comes up, before the first message. Registered
+ * with {@link useOnActivate}; the runtime awaits it.
+ */
+export type ActivateHandler = (reason: ActivationReason) => void | Promise<void>;
 
 /**
- * What a grain factory returns: the interface implementation plus optional
- * lifecycle hooks and an optional self incoming-call filter (under
- * `INCOMING_CALL_FILTER`).
+ * A hook run when the activation is torn down. Registered with
+ * {@link useOnDeactivate}; the runtime awaits it and may pass an advisory
+ * `signal` (see `Grain.onDeactivate`).
  */
-export type GrainBehaviour<T> = T & Partial<GrainLifecycle> & Partial<SelfFilteringGrain>;
+export type DeactivateHandler = (
+  reason: DeactivationReason,
+  signal?: AbortSignal,
+) => void | Promise<void>;
+
+/**
+ * What a grain factory returns: the message surface — the interface
+ * implementation, plus an optional self incoming-call filter (under
+ * `INCOMING_CALL_FILTER`), which is itself part of how messages are handled.
+ * Lifecycle is *not* returned: register it with {@link useOnActivate} /
+ * {@link useOnDeactivate}, like any other facet hook.
+ */
+export type GrainSurface<T> = T & Partial<SelfFilteringGrain>;
 
 export interface DefineGrainOptions extends Omit<GrainOptions, "name"> {
   /** Mark every method reentrant (the functional equivalent of `@reentrant()`). */
@@ -95,14 +108,48 @@ function instanceOf(ctx: GrainSetup): object {
   return instance;
 }
 
+// Lifecycle handlers are registered per activation instance, the same way the
+// state facets register their fields — the factory may call the hooks any
+// number of times, including from helpers it composes.
+const activateHandlers = createFieldRegistry<ActivateHandler>();
+const deactivateHandlers = createFieldRegistry<DeactivateHandler>();
+
+/**
+ * Register a hook to run when the activation comes up, before the first
+ * message — the functional counterpart of overriding `Grain.onActivate`.
+ *
+ * Hooks compose: each call adds one, and they run in registration order, so a
+ * helper that sets something up runs after the setup it depends on. Every hook
+ * is awaited in turn, and a hook that throws fails the activation (the
+ * remaining ones do not run), exactly as a throwing `onActivate` does.
+ */
+export function useOnActivate(ctx: GrainSetup, handler: ActivateHandler): void {
+  activateHandlers.register(instanceOf(ctx), handler);
+}
+
+/**
+ * Register a hook to run when the activation is torn down — the functional
+ * counterpart of overriding `Grain.onDeactivate`.
+ *
+ * Hooks compose LIFO: the last registered runs first, unwinding the activation
+ * in the reverse of the order it was built up, so a hook always tears down
+ * before whatever it was set up on top of. Every hook is awaited in turn, and
+ * one that throws does not strand the hooks under it — the unwind runs to the
+ * bottom and the first failure is then surfaced.
+ */
+export function useOnDeactivate(ctx: GrainSetup, handler: DeactivateHandler): void {
+  deactivateHandlers.register(instanceOf(ctx), handler);
+}
+
 /**
  * Register a grain implementation written as a factory closure rather than a
  * class — the functional counterpart of the `@grain()` decorator on a `Grain`
  * subclass. The factory runs once per activation, after the context is bound and
  * before any facet read or `onActivate`; it captures per-activation state in
  * closure variables (safe without locks under the single-turn model, exactly as
- * class fields are) and returns the interface methods plus optional lifecycle
- * hooks.
+ * class fields are) and returns the grain's message surface — nothing else.
+ * Lifecycle belongs to the hooks (`useOnActivate` / `useOnDeactivate`), not to
+ * the returned object.
  *
  * The returned constructor registers and activates through the same catalog,
  * scheduler and facet-binding machinery as a class grain, so the two styles
@@ -110,22 +157,31 @@ function instanceOf(ctx: GrainSetup): object {
  */
 export function defineGrain<T extends object>(
   name: string,
-  factory: (ctx: GrainSetup) => GrainBehaviour<T>,
+  factory: (ctx: GrainSetup) => GrainSurface<T>,
   options: DefineGrainOptions = {},
 ): new () => Grain {
   class FunctionalGrain extends Grain {
     // Run the factory once the runtime binds the context (before `preActivate`
-    // reads facets), then install the returned methods/hooks as own members so
-    // the catalog's method dispatch and lifecycle calls find them.
+    // reads facets), then install the returned methods as own members so the
+    // catalog's method dispatch finds them.
     override setContext(context: GrainContext): void {
       super.setContext(context);
-      const behaviour = factory(createSetup(this, context));
+      const surface = factory(createSetup(this, context));
       // String keys are the interface methods; symbol keys carry system hooks
       // (e.g. a self incoming-call filter under `INCOMING_CALL_FILTER`).
-      const keys = [...Object.keys(behaviour), ...Object.getOwnPropertySymbols(behaviour)];
+      const keys = [...Object.keys(surface), ...Object.getOwnPropertySymbols(surface)];
       for (const key of keys) {
-        const value = (behaviour as Record<PropertyKey, unknown>)[key];
+        const value = (surface as Record<PropertyKey, unknown>)[key];
         if (typeof value !== "function") continue;
+        // A returned lifecycle hook would install as an own property and
+        // silently shadow the composed runners below, dropping every hook the
+        // factory registered. The surface is messages only — say so loudly.
+        if (key === "onActivate" || key === "onDeactivate") {
+          throw new Error(
+            `grain "${name}" returned ${key} from its factory; lifecycle is registered with ` +
+              "useOnActivate / useOnDeactivate, not returned in the message surface",
+          );
+        }
         Object.defineProperty(this, key, {
           value,
           writable: true,
@@ -133,6 +189,33 @@ export function defineGrain<T extends object>(
           configurable: true,
         });
       }
+    }
+
+    // Registration order coming up: a hook that throws fails the activation
+    // and the ones after it never run, exactly as a throwing `onActivate` does.
+    override async onActivate(reason: ActivationReason): Promise<void> {
+      for (const handler of activateHandlers.getFields(this)) await handler(reason);
+    }
+
+    // The reverse of registration order going down, and — unlike activation —
+    // a hook that throws does not strand the ones registered under it: the
+    // stack unwinds to the bottom, then the first failure is surfaced to the
+    // runtime's usual `onDeactivate` error handling.
+    override async onDeactivate(reason: DeactivationReason, signal?: AbortSignal): Promise<void> {
+      const handlers = deactivateHandlers.getFields(this);
+      let failure: unknown;
+      let failed = false;
+      for (let i = handlers.length - 1; i >= 0; i--) {
+        try {
+          await handlers[i]!(reason, signal);
+        } catch (err) {
+          if (!failed) {
+            failure = err;
+            failed = true;
+          }
+        }
+      }
+      if (failed) throw failure;
     }
   }
 

--- a/packages/parity/src/runtime/lifecycle-tests.test.ts
+++ b/packages/parity/src/runtime/lifecycle-tests.test.ts
@@ -6,7 +6,7 @@
 // LifecycleSubject (packages/runtime/src/lifecycle-subject.ts), a standalone
 // primitive driven directly here, exactly as upstream — it is not wired into
 // grain/silo lifecycle, which stays a flat before/after hook pair (see
-// GrainLifecycle in packages/core/src/define-grain.ts).
+// useOnActivate / useOnDeactivate in packages/core/src/define-grain.ts).
 import { describe, expect } from "vitest";
 import { orleansTest } from "@thresh/testing/orleans-test";
 import { LifecycleSubject, type LifecycleObserver } from "@thresh/runtime/lifecycle-subject";

--- a/packages/runtime/src/define-grain.lifecycle.test.ts
+++ b/packages/runtime/src/define-grain.lifecycle.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { defineGrain, useOnActivate, useOnDeactivate } from "@thresh/core/define-grain";
+import { GrainId } from "@thresh/core/grain-id";
+import { defineGrainInterface } from "@thresh/core/grain-interface";
+import type { GrainKey } from "@thresh/core/key-kinds";
+import { Silo } from "@thresh/runtime/silo";
+import { FakeTimeProvider } from "@thresh/runtime/test-support/fake-time-provider";
+
+interface ILayered extends GrainKey<string> {
+  ping(): Promise<string>;
+}
+
+const ILayered = defineGrainInterface<ILayered>("ILayered.define-grain-lifecycle");
+const IBadActivate = defineGrainInterface<ILayered>("IBadActivate.define-grain-lifecycle");
+const IBadDeactivate = defineGrainInterface<ILayered>("IBadDeactivate.define-grain-lifecycle");
+
+// Module-scoped sink the grains write lifecycle events to.
+let events: string[] = [];
+
+// Two independent "layers" register their own hooks, as separate helpers would:
+// activation runs them in registration order, deactivation unwinds them LIFO.
+const LayeredGrain = defineGrain<ILayered>("Layered", (ctx) => {
+  useOnActivate(ctx, (reason) => {
+    events.push(`activate:outer:${reason}`);
+  });
+  useOnDeactivate(ctx, (reason) => {
+    events.push(`deactivate:outer:${reason.code}`);
+  });
+
+  useOnActivate(ctx, async (reason) => {
+    await Promise.resolve();
+    events.push(`activate:inner:${reason}`);
+  });
+  useOnDeactivate(ctx, async () => {
+    await Promise.resolve();
+    events.push("deactivate:inner");
+  });
+
+  return {
+    ping: async (): Promise<string> => {
+      events.push(`ping:${String(ctx.id.key)}`);
+      return "pong";
+    },
+  };
+});
+
+// An activate hook that throws fails the activation; a deactivate hook that
+// throws must still let the rest of the stack unwind.
+const BadActivateGrain = defineGrain<ILayered>("BadActivate", (ctx) => {
+  useOnActivate(ctx, () => {
+    events.push("activate:first");
+  });
+  useOnActivate(ctx, () => {
+    throw new Error("boom");
+  });
+  useOnActivate(ctx, () => {
+    events.push("activate:third");
+  });
+  return { ping: async (): Promise<string> => "pong" };
+});
+
+const BadDeactivateGrain = defineGrain<ILayered>("BadDeactivate", (ctx) => {
+  useOnDeactivate(ctx, () => {
+    events.push("deactivate:first-registered");
+  });
+  useOnDeactivate(ctx, () => {
+    throw new Error("teardown boom");
+  });
+  useOnDeactivate(ctx, () => {
+    events.push("deactivate:last-registered");
+  });
+  return { ping: async (): Promise<string> => "pong" };
+});
+
+const flush = (): Promise<unknown> => new Promise((r) => setTimeout(r, 0));
+const layeredId = (key: string): GrainId => new GrainId("Layered", key);
+
+describe("defineGrain lifecycle hooks (sociable)", () => {
+  let time: FakeTimeProvider;
+  let silo: Silo;
+
+  beforeEach(() => {
+    events = [];
+    time = new FakeTimeProvider();
+    silo = new Silo({ time, defaultCollectionAgeSeconds: 30, collectionIntervalSeconds: 10 });
+    silo.registerGrain(LayeredGrain, { interfaces: [ILayered] });
+    silo.registerGrain(BadActivateGrain, { interfaces: [IBadActivate] });
+    silo.registerGrain(BadDeactivateGrain, { interfaces: [IBadDeactivate] });
+    silo.start();
+  });
+
+  it("runs every registered activate hook, in registration order, before the first message", async () => {
+    const grain = silo.getGrain(ILayered, "a");
+    expect(await grain.ping()).toBe("pong");
+    expect(events).toEqual([
+      "activate:outer:incoming-call",
+      "activate:inner:incoming-call",
+      "ping:a",
+    ]);
+  });
+
+  it("unwinds deactivate hooks LIFO, after the activate hooks that set them up", async () => {
+    const grain = silo.getGrain(ILayered, "a");
+    await grain.ping();
+
+    // Move past the 30s collection age; the 10s collector sweep deactivates it.
+    time.advance(31_000);
+    await flush();
+
+    expect(silo.isActive(layeredId("a"))).toBe(false);
+    expect(events.slice(events.indexOf("ping:a") + 1)).toEqual([
+      "deactivate:inner",
+      "deactivate:outer:idle",
+    ]);
+  });
+
+  it("fails the activation when an activate hook throws, skipping the hooks after it", async () => {
+    await expect(silo.getGrain(IBadActivate, "a").ping()).rejects.toThrow("boom");
+    expect(events).toEqual(["activate:first"]);
+  });
+
+  it("keeps unwinding the remaining deactivate hooks when one throws", async () => {
+    const grain = silo.getGrain(IBadDeactivate, "a");
+    await grain.ping();
+    events = [];
+
+    time.advance(31_000);
+    await flush();
+
+    // LIFO: last-registered first, then the thrower, then the first-registered
+    // one — which must still run rather than being stranded by the throw.
+    expect(events).toEqual(["deactivate:last-registered", "deactivate:first-registered"]);
+  });
+
+  it("rejects a factory that still returns lifecycle hooks in its surface", () => {
+    const Legacy = defineGrain<ILayered>(
+      "LegacyLifecycle",
+      () =>
+        ({
+          ping: async (): Promise<string> => "pong",
+          onActivate: async (): Promise<void> => undefined,
+        }) as unknown as ILayered,
+    );
+
+    // The factory runs when the runtime binds the context, so the shadowing
+    // surface is caught there rather than silently replacing the composed hooks.
+    expect(() => new Legacy().setContext({ id: layeredId("a") } as never)).toThrow(/useOnActivate/);
+  });
+});


### PR DESCRIPTION
Replace the `GrainLifecycle` interface pattern (returning `onActivate`/`onDeactivate` from the grain factory) with composable hook functions `useOnActivate` and `useOnDeactivate`. This enables helpers and middleware to register their own lifecycle handlers without requiring the grain factory to coordinate them.

## Key Changes

- **New hook API**: Introduce `useOnActivate(ctx, handler)` and `useOnDeactivate(ctx, handler)` functions that register lifecycle handlers per activation instance, similar to how state facets register fields
- **Activation order**: Activate hooks run in registration order (setup dependencies run first); deactivate hooks unwind LIFO (teardown reverses setup)
- **Error handling**: Activation failures stop the sequence; deactivation failures in one hook do not strand the remaining ones — the stack unwinds to completion before surfacing the first error
- **Surface separation**: The grain factory now returns only the message surface (interface methods + optional `INCOMING_CALL_FILTER`), not lifecycle hooks. Returning `onActivate`/`onDeactivate` from the factory now throws with a clear error message
- **Implementation**: Use the existing `createFieldRegistry` pattern to track handlers per activation instance, with `FunctionalGrain` overriding `onActivate` and `onDeactivate` to invoke the registered handlers

## Testing

- Comprehensive test suite (`define-grain.lifecycle.test.ts`) covering:
  - Multiple hooks composing in registration order
  - LIFO deactivation unwinding
  - Activation failure behavior
  - Deactivation error resilience
  - Detection of lifecycle hooks in the returned surface

## Examples Updated

- `GreeterGrain` and `FleetAggregatorGrain` migrated from returning `onActivate` to using `useOnActivate` hook
- Documentation updated to reflect the new composable lifecycle pattern

https://claude.ai/code/session_01BHwf7it6a6hJ4VjHKMrnAX